### PR TITLE
Stabilize local runtime QC

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -54,6 +54,7 @@ class Settings:
     auth_trader_password: str
     database_url: str
     redis_url: str
+    cors_origins: list[str]
     broker_mode: str
     allow_live_trading: bool
     allow_controller_mock: bool
@@ -99,6 +100,14 @@ class Settings:
             auth_trader_password=os.getenv("AUTH_TRADER_PASSWORD", "trader123!").strip(),
             database_url=os.getenv("DATABASE_URL", default_db).strip(),
             redis_url=os.getenv("REDIS_URL", "redis://127.0.0.1:6379/0").strip(),
+            cors_origins=[
+                item.strip()
+                for item in os.getenv(
+                    "CORS_ORIGINS",
+                    "http://127.0.0.1:3000,http://localhost:3000,http://127.0.0.1:3010,http://localhost:3010",
+                ).split(",")
+                if item.strip()
+            ],
             broker_mode=os.getenv("BROKER_MODE", "paper").strip().lower(),
             allow_live_trading=_as_bool(os.getenv("ALLOW_LIVE_TRADING", "false")),
             allow_controller_mock=_as_bool(os.getenv("ALLOW_CONTROLLER_MOCK", "true"), True),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,7 +31,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="traders-cockpit", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/services/cockpit.py
+++ b/backend/app/services/cockpit.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from math import floor
 from random import uniform
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.adapters.broker import AlpacaBrokerAdapter, PaperBrokerAdapter
@@ -504,7 +504,16 @@ class CockpitService:
         return position
 
     def _next_order_id(self, db: Session) -> str:
-        return f"ORD-{len(db.scalars(select(OrderEntity)).all()) + 1:04d}"
+        persisted_max = db.scalar(select(func.max(OrderEntity.id))) or 0
+        pending_max = 0
+        for instance in db.new:
+            if isinstance(instance, OrderEntity) and instance.order_id.startswith("ORD-"):
+                try:
+                    pending_max = max(pending_max, int(instance.order_id.split("-", 1)[1]))
+                except ValueError:
+                    continue
+        next_seq = max(persisted_max, pending_max) + 1
+        return f"ORD-{next_seq:04d}"
 
     def _order_view(self, row: OrderEntity) -> OrderView:
         return OrderView(

--- a/docs/issues/2026-03-20-runtime-qc-and-cors.md
+++ b/docs/issues/2026-03-20-runtime-qc-and-cors.md
@@ -1,0 +1,32 @@
+# Runtime QC And CORS Stabilization
+
+## Problem
+
+The local cockpit rendered, but browser verification exposed two operational defects:
+
+- frontend browser requests could fail against the backend because credentialed CORS was too permissive to be valid
+- backend stop-order creation could generate duplicate `order_id` values inside the same transaction
+
+## Business value
+
+This work turns the scaffold into a verifiable local development slice that can be loaded in a real browser, exercised with Playwright, and trusted during staged integration.
+
+## Scope
+
+- tighten backend CORS configuration for known local frontend origins
+- fix in-transaction order id generation for multi-order stop plans
+- restore a passing backend test suite
+- rerun browser and local build/test checks
+
+## Acceptance criteria
+
+- [ ] `GET /health` returns healthy on the local backend
+- [ ] frontend loads successfully on the local dev port
+- [ ] Playwright can load setup data from the cockpit UI
+- [ ] backend `pytest` passes
+- [ ] frontend lint, tests, and build pass
+
+## Risks / constraints
+
+- local ports can already be occupied by unrelated services
+- the current workflow still depends on manual local process management until scripts are expanded further

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
       "@": path.resolve(__dirname)
     }
   },
+  esbuild: {
+    jsx: "automatic"
+  },
   test: {
     environment: "jsdom",
     setupFiles: ["./tests/setup.ts"]


### PR DESCRIPTION
## Summary
- tighten local CORS handling for credentialed frontend requests
- fix in-transaction order id generation for multi-stop creation
- stabilize frontend vitest runtime config
- document the runtime QC issue record

## Validation
- python -m pytest -q
- npm run lint
- npm run test
- npm run build
- Playwright browser smoke against http://127.0.0.1:3010
