### PR TITLE
Integrate validated release prep into integration-app

### DIFF
--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -8,7 +8,6 @@ Create Date: 2026-03-20
 from alembic import op
 import sqlalchemy as sa
 
-
 revision = "0001_initial"
 down_revision = None
 branch_labels = None

--- a/backend/app/adapters/broker.py
+++ b/backend/app/adapters/broker.py
@@ -33,7 +33,9 @@ class BrokerAdapter:
     def close_position(self, symbol: str) -> BrokerOrderResult:
         raise NotImplementedError
 
-    def wait_for_position(self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0) -> int:
+    def wait_for_position(
+        self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0
+    ) -> int:
         raise NotImplementedError
 
     def cancel_order(self, broker_order_id: str) -> None:
@@ -61,7 +63,9 @@ class PaperBrokerAdapter(BrokerAdapter):
     def close_position(self, symbol: str) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="FILLED")
 
-    def wait_for_position(self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0) -> int:
+    def wait_for_position(
+        self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0
+    ) -> int:
         return min_qty
 
     def cancel_order(self, broker_order_id: str) -> None:
@@ -138,22 +142,36 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return "after_hours"
         return "overnight"
 
-    def place_market_order(self, symbol: str, qty: int, side: str, time_in_force: str = "day") -> BrokerOrderResult:
+    def place_market_order(
+        self, symbol: str, qty: int, side: str, time_in_force: str = "day"
+    ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("FILLED", "Alpaca paper credentials are missing for broker execution")
-        payload = {"symbol": symbol, "qty": qty, "side": side, "type": "market", "time_in_force": time_in_force}
+            return self._fallback_or_raise(
+                "FILLED", "Alpaca paper credentials are missing for broker execution"
+            )
+        payload = {
+            "symbol": symbol,
+            "qty": qty,
+            "side": side,
+            "type": "market",
+            "time_in_force": time_in_force,
+        }
         try:
             with self._client() as client:
                 response = client.post("/v2/orders", json=payload)
                 response.raise_for_status()
                 data = response.json()
         except httpx.HTTPError as exc:
-            return self._fallback_or_raise("FILLED", self._extract_http_error_message("Alpaca market order failed", exc))
+            return self._fallback_or_raise(
+                "FILLED", self._extract_http_error_message("Alpaca market order failed", exc)
+            )
         return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper())
 
     def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("ACTIVE", "Alpaca paper credentials are missing for stop execution")
+            return self._fallback_or_raise(
+                "ACTIVE", "Alpaca paper credentials are missing for stop execution"
+            )
         payload = {
             "symbol": symbol,
             "qty": qty,
@@ -168,7 +186,9 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 response.raise_for_status()
                 data = response.json()
         except httpx.HTTPError as exc:
-            return self._fallback_or_raise("ACTIVE", self._extract_http_error_message("Alpaca stop order failed", exc))
+            return self._fallback_or_raise(
+                "ACTIVE", self._extract_http_error_message("Alpaca stop order failed", exc)
+            )
         return BrokerOrderResult(data.get("id"), str(data.get("status", "new")).upper())
 
     def place_limit_order(
@@ -181,7 +201,9 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         extended_hours: bool = False,
     ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("FILLED", "Alpaca paper credentials are missing for profit execution")
+            return self._fallback_or_raise(
+                "FILLED", "Alpaca paper credentials are missing for profit execution"
+            )
         payload = {
             "symbol": symbol,
             "qty": qty,
@@ -198,14 +220,18 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 response.raise_for_status()
                 data = response.json()
         except httpx.HTTPError as exc:
-            return self._fallback_or_raise("FILLED", self._extract_http_error_message("Alpaca limit order failed", exc))
+            return self._fallback_or_raise(
+                "FILLED", self._extract_http_error_message("Alpaca limit order failed", exc)
+            )
         return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper())
 
     def place_trailing_stop(
         self, symbol: str, qty: int, trail: float, trail_unit: str
     ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("ACTIVE", "Alpaca paper credentials are missing for runner execution")
+            return self._fallback_or_raise(
+                "ACTIVE", "Alpaca paper credentials are missing for runner execution"
+            )
         payload = {
             "symbol": symbol,
             "qty": qty,
@@ -223,22 +249,30 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 response.raise_for_status()
                 data = response.json()
         except httpx.HTTPError as exc:
-            return self._fallback_or_raise("ACTIVE", self._extract_http_error_message("Alpaca trailing stop failed", exc))
+            return self._fallback_or_raise(
+                "ACTIVE", self._extract_http_error_message("Alpaca trailing stop failed", exc)
+            )
         return BrokerOrderResult(data.get("id"), str(data.get("status", "new")).upper())
 
     def close_position(self, symbol: str) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("FILLED", "Alpaca paper credentials are missing for flatten execution")
+            return self._fallback_or_raise(
+                "FILLED", "Alpaca paper credentials are missing for flatten execution"
+            )
         try:
             with self._client() as client:
                 response = client.delete(f"/v2/positions/{symbol}")
                 response.raise_for_status()
                 data = response.json()
         except httpx.HTTPError as exc:
-            return self._fallback_or_raise("FILLED", self._extract_http_error_message("Alpaca close position failed", exc))
+            return self._fallback_or_raise(
+                "FILLED", self._extract_http_error_message("Alpaca close position failed", exc)
+            )
         return BrokerOrderResult(data.get("id"), "FILLED")
 
-    def wait_for_position(self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0) -> int:
+    def wait_for_position(
+        self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0
+    ) -> int:
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
                 return min_qty
@@ -281,7 +315,9 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
                 return
-            raise ValueError(self._extract_http_error_message("Alpaca order cancellation failed", exc)) from exc
+            raise ValueError(
+                self._extract_http_error_message("Alpaca order cancellation failed", exc)
+            ) from exc
 
     def get_session_state(self) -> str:
         if not self.settings.has_alpaca_credentials:
@@ -300,4 +336,6 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
                 return "regular_open"
-            raise ValueError(self._extract_http_error_message("Alpaca market clock lookup failed", exc)) from exc
+            raise ValueError(
+                self._extract_http_error_message("Alpaca market clock lookup failed", exc)
+            ) from exc

--- a/backend/app/adapters/broker.py
+++ b/backend/app/adapters/broker.py
@@ -13,11 +13,35 @@ from app.core.config import Settings
 class BrokerOrderResult:
     broker_order_id: str | None
     status: str
+    payload: dict | None = None
+
+
+@dataclass
+class BrokerEntryOrder:
+    symbol: str
+    qty: int
+    side: str
+    order_type: str
+    time_in_force: str
+    limit_price: float | None = None
+    stop_price: float | None = None
+    order_class: str = "simple"
+    extended_hours: bool = False
+    take_profit_limit_price: float | None = None
+    stop_loss_stop_price: float | None = None
+    stop_loss_limit_price: float | None = None
 
 
 class BrokerAdapter:
-    def place_market_order(self, symbol: str, qty: int, side: str) -> BrokerOrderResult:
+    def place_entry_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
         raise NotImplementedError
+
+    def place_market_order(self, symbol: str, qty: int, side: str) -> BrokerOrderResult:
+        return self.place_entry_order(
+            BrokerEntryOrder(
+                symbol=symbol, qty=qty, side=side, order_type="market", time_in_force="day"
+            )
+        )
 
     def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
         raise NotImplementedError
@@ -41,11 +65,38 @@ class BrokerAdapter:
     def cancel_order(self, broker_order_id: str) -> None:
         raise NotImplementedError
 
+    def list_recent_orders(self, limit: int = 50) -> list[dict]:
+        raise NotImplementedError
+
+    def get_order(self, broker_order_id: str) -> dict | None:
+        raise NotImplementedError
+
     def get_session_state(self) -> str:
+        raise NotImplementedError
+
+    def get_account_summary(self) -> dict[str, float] | None:
         raise NotImplementedError
 
 
 class PaperBrokerAdapter(BrokerAdapter):
+    def place_entry_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
+        return BrokerOrderResult(
+            broker_order_id=None,
+            status="ACTIVE" if order.order_class in {"bracket", "oco", "oto"} else "FILLED",
+            payload={
+                "symbol": order.symbol,
+                "qty": str(order.qty),
+                "side": order.side,
+                "type": order.order_type,
+                "time_in_force": order.time_in_force,
+                "order_class": order.order_class,
+                "limit_price": order.limit_price,
+                "stop_price": order.stop_price,
+                "extended_hours": order.extended_hours,
+                "status": "accepted",
+            },
+        )
+
     def place_market_order(self, symbol: str, qty: int, side: str) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="FILLED")
 
@@ -71,8 +122,17 @@ class PaperBrokerAdapter(BrokerAdapter):
     def cancel_order(self, broker_order_id: str) -> None:
         return None
 
+    def list_recent_orders(self, limit: int = 50) -> list[dict]:
+        return []
+
+    def get_order(self, broker_order_id: str) -> dict | None:
+        return None
+
     def get_session_state(self) -> str:
         return "regular_open"
+
+    def get_account_summary(self) -> dict[str, float] | None:
+        return None
 
 
 class AlpacaBrokerAdapter(BrokerAdapter):
@@ -84,6 +144,8 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             else settings.alpaca_api_base_url
         )
         self.market_tz = ZoneInfo("America/New_York")
+        self._account_summary_cache: tuple[float, dict[str, float]] | None = None
+        self._recent_orders_cache: tuple[float, int, list[dict]] | None = None
 
     def _client(self) -> httpx.Client:
         self._ensure_execution_allowed()
@@ -93,7 +155,7 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 "APCA-API-KEY-ID": self.settings.alpaca_api_key_id,
                 "APCA-API-SECRET-KEY": self.settings.alpaca_api_secret_key,
             },
-            timeout=10.0,
+            timeout=4.0,
         )
 
     def _ensure_execution_allowed(self) -> None:
@@ -142,20 +204,33 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return "after_hours"
         return "overnight"
 
-    def place_market_order(
-        self, symbol: str, qty: int, side: str, time_in_force: str = "day"
-    ) -> BrokerOrderResult:
+    def place_entry_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
                 "FILLED", "Alpaca paper credentials are missing for broker execution"
             )
-        payload = {
-            "symbol": symbol,
-            "qty": qty,
-            "side": side,
-            "type": "market",
-            "time_in_force": time_in_force,
+        payload: dict[str, object] = {
+            "symbol": order.symbol,
+            "qty": order.qty,
+            "side": order.side,
+            "type": order.order_type,
+            "time_in_force": order.time_in_force,
         }
+        if order.limit_price is not None:
+            payload["limit_price"] = order.limit_price
+        if order.stop_price is not None:
+            payload["stop_price"] = order.stop_price
+        if order.order_class != "simple":
+            payload["order_class"] = order.order_class
+        if order.extended_hours:
+            payload["extended_hours"] = True
+        if order.take_profit_limit_price is not None:
+            payload["take_profit"] = {"limit_price": order.take_profit_limit_price}
+        if order.stop_loss_stop_price is not None:
+            stop_loss: dict[str, float] = {"stop_price": order.stop_loss_stop_price}
+            if order.stop_loss_limit_price is not None:
+                stop_loss["limit_price"] = order.stop_loss_limit_price
+            payload["stop_loss"] = stop_loss
         try:
             with self._client() as client:
                 response = client.post("/v2/orders", json=payload)
@@ -165,31 +240,33 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return self._fallback_or_raise(
                 "FILLED", self._extract_http_error_message("Alpaca market order failed", exc)
             )
-        return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper())
+        return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper(), data)
+
+    def place_market_order(
+        self, symbol: str, qty: int, side: str, time_in_force: str = "day"
+    ) -> BrokerOrderResult:
+        return self.place_entry_order(
+            BrokerEntryOrder(
+                symbol=symbol, qty=qty, side=side, order_type="market", time_in_force=time_in_force
+            )
+        )
 
     def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
                 "ACTIVE", "Alpaca paper credentials are missing for stop execution"
             )
-        payload = {
-            "symbol": symbol,
-            "qty": qty,
-            "side": "sell",
-            "type": "stop",
-            "stop_price": stop_price,
-            "time_in_force": "gtc",
-        }
-        try:
-            with self._client() as client:
-                response = client.post("/v2/orders", json=payload)
-                response.raise_for_status()
-                data = response.json()
-        except httpx.HTTPError as exc:
-            return self._fallback_or_raise(
-                "ACTIVE", self._extract_http_error_message("Alpaca stop order failed", exc)
+        result = self.place_entry_order(
+            BrokerEntryOrder(
+                symbol=symbol,
+                qty=qty,
+                side="sell",
+                order_type="stop",
+                stop_price=stop_price,
+                time_in_force="gtc",
             )
-        return BrokerOrderResult(data.get("id"), str(data.get("status", "new")).upper())
+        )
+        return BrokerOrderResult(result.broker_order_id, result.status, result.payload)
 
     def place_limit_order(
         self,
@@ -204,26 +281,17 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return self._fallback_or_raise(
                 "FILLED", "Alpaca paper credentials are missing for profit execution"
             )
-        payload = {
-            "symbol": symbol,
-            "qty": qty,
-            "side": side,
-            "type": "limit",
-            "limit_price": limit_price,
-            "time_in_force": time_in_force,
-        }
-        if extended_hours:
-            payload["extended_hours"] = True
-        try:
-            with self._client() as client:
-                response = client.post("/v2/orders", json=payload)
-                response.raise_for_status()
-                data = response.json()
-        except httpx.HTTPError as exc:
-            return self._fallback_or_raise(
-                "FILLED", self._extract_http_error_message("Alpaca limit order failed", exc)
+        return self.place_entry_order(
+            BrokerEntryOrder(
+                symbol=symbol,
+                qty=qty,
+                side=side,
+                order_type="limit",
+                limit_price=limit_price,
+                time_in_force=time_in_force,
+                extended_hours=extended_hours,
             )
-        return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper())
+        )
 
     def place_trailing_stop(
         self, symbol: str, qty: int, trail: float, trail_unit: str
@@ -319,6 +387,57 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 self._extract_http_error_message("Alpaca order cancellation failed", exc)
             ) from exc
 
+    def list_recent_orders(self, limit: int = 50) -> list[dict]:
+        import time
+
+        cache_entry = self._recent_orders_cache
+        if cache_entry is not None:
+            cached_at, cached_limit, cached_payload = cache_entry
+            if cached_limit >= limit and time.monotonic() - cached_at < 2.0:
+                return [dict(order) for order in cached_payload[:limit]]
+        if not self.settings.has_alpaca_credentials:
+            if self.settings.allow_controller_mock:
+                return []
+            raise ValueError("Alpaca paper credentials are missing for broker order lookup")
+        try:
+            with self._client() as client:
+                response = client.get(
+                    "/v2/orders", params={"status": "all", "direction": "desc", "limit": limit}
+                )
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:
+            if self.settings.allow_controller_mock:
+                return []
+            raise ValueError(
+                self._extract_http_error_message("Alpaca recent orders lookup failed", exc)
+            ) from exc
+        rows = [dict(order) for order in payload] if isinstance(payload, list) else []
+        self._recent_orders_cache = (time.monotonic(), limit, rows)
+        return [dict(order) for order in rows]
+
+    def get_order(self, broker_order_id: str) -> dict | None:
+        if not broker_order_id:
+            return None
+        if not self.settings.has_alpaca_credentials:
+            if self.settings.allow_controller_mock:
+                return None
+            raise ValueError("Alpaca paper credentials are missing for broker order lookup")
+        try:
+            with self._client() as client:
+                response = client.get(f"/v2/orders/{broker_order_id}")
+                if response.status_code == 404:
+                    return None
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:
+            if self.settings.allow_controller_mock:
+                return None
+            raise ValueError(
+                self._extract_http_error_message("Alpaca order lookup failed", exc)
+            ) from exc
+        return payload if isinstance(payload, dict) else None
+
     def get_session_state(self) -> str:
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
@@ -339,3 +458,38 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             raise ValueError(
                 self._extract_http_error_message("Alpaca market clock lookup failed", exc)
             ) from exc
+
+    def get_account_summary(self) -> dict[str, float] | None:
+        import time
+
+        cache_entry = self._account_summary_cache
+        if cache_entry is not None:
+            cached_at, payload = cache_entry
+            if time.monotonic() - cached_at < 5.0:
+                return dict(payload)
+        if not self.settings.has_alpaca_credentials:
+            if self.settings.allow_controller_mock:
+                return None
+            raise ValueError("Alpaca paper credentials are missing for broker account lookup")
+        try:
+            with self._client() as client:
+                response = client.get("/v2/account")
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:
+            if self.settings.allow_controller_mock:
+                return None
+            raise ValueError(
+                self._extract_http_error_message("Alpaca account lookup failed", exc)
+            ) from exc
+        try:
+            equity = float(payload.get("equity") or 0.0)
+            buying_power = float(payload.get("buying_power") or 0.0)
+            cash = float(payload.get("cash") or 0.0)
+        except (TypeError, ValueError):
+            return None
+        if equity <= 0 or buying_power <= 0:
+            return None
+        summary = {"equity": equity, "buying_power": buying_power, "cash": cash}
+        self._account_summary_cache = (time.monotonic(), summary)
+        return dict(summary)

--- a/backend/app/adapters/market_data.py
+++ b/backend/app/adapters/market_data.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from concurrent.futures import ThreadPoolExecutor
 from zoneinfo import ZoneInfo
+import time
 
 import httpx
 
@@ -55,6 +57,7 @@ class SetupMarketData:
     quote_timestamp: datetime | None
     session_state: str
     quote_state: str
+    entry_basis: str
     bid: float
     ask: float
     last: float
@@ -85,6 +88,7 @@ class MockMarketDataAdapter:
             quote_timestamp=datetime.now(UTC),
             session_state="closed",
             quote_state="quote_unavailable",
+            entry_basis="bid_ask_midpoint",
             **payload,
         )
 
@@ -94,6 +98,7 @@ class AlpacaPolygonMarketDataAdapter:
         self.settings = settings
         self.fallback = MockMarketDataAdapter()
         self._market_tz = ZoneInfo("America/New_York")
+        self._setup_cache: dict[str, tuple[float, SetupMarketData]] = {}
 
     def _data_client(self) -> httpx.Client:
         return httpx.Client(
@@ -102,7 +107,7 @@ class AlpacaPolygonMarketDataAdapter:
                 "APCA-API-KEY-ID": self.settings.alpaca_api_key_id,
                 "APCA-API-SECRET-KEY": self.settings.alpaca_api_secret_key,
             },
-            timeout=10.0,
+            timeout=4.0,
         )
 
     def _trading_client(self) -> httpx.Client:
@@ -112,7 +117,7 @@ class AlpacaPolygonMarketDataAdapter:
                 "APCA-API-KEY-ID": self.settings.alpaca_api_key_id,
                 "APCA-API-SECRET-KEY": self.settings.alpaca_api_secret_key,
             },
-            timeout=10.0,
+            timeout=4.0,
         )
 
     def _fail_or_fallback(self, symbol: str, reason: str, message: str) -> SetupMarketData:
@@ -139,6 +144,12 @@ class AlpacaPolygonMarketDataAdapter:
         except (TypeError, ValueError):
             return False
         return bid > 0 and ask > 0
+
+    def _parse_float(self, value: object, fallback: float = 0.0) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return fallback
 
     def _session_state_from_clock(self, clock_payload: dict | None) -> str:
         if not clock_payload:
@@ -183,6 +194,16 @@ class AlpacaPolygonMarketDataAdapter:
             return None, None
         return quote, self._parse_quote_timestamp(str(quote.get("t") or ""))
 
+    def _snapshot_payload(self, client: httpx.Client, symbol: str) -> dict | None:
+        response = client.get(f"/v2/stocks/{symbol}/snapshot")
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else None
+
+    def _load_snapshot_payload(self, symbol: str) -> dict | None:
+        with self._data_client() as client:
+            return self._snapshot_payload(client, symbol)
+
     def _historical_quote(
         self, client: httpx.Client, symbol: str
     ) -> tuple[dict | None, datetime | None]:
@@ -199,6 +220,54 @@ class AlpacaPolygonMarketDataAdapter:
             return None, None
         return quote, self._parse_quote_timestamp(str(quote.get("t") or ""))
 
+    def _daily_bars(self, client: httpx.Client, symbol: str, *, limit: int = 60) -> list[dict]:
+        end = datetime.now(UTC)
+        start = end - timedelta(days=max(limit * 2, 45))
+        response = client.get(
+            f"/v2/stocks/{symbol}/bars",
+            params={
+                "timeframe": "1Day",
+                "start": start.isoformat().replace("+00:00", "Z"),
+                "end": end.isoformat().replace("+00:00", "Z"),
+                "limit": max(20, min(limit, 200)),
+                "feed": "iex",
+                "adjustment": "raw",
+            },
+        )
+        response.raise_for_status()
+        rows = response.json().get("bars")
+        if not isinstance(rows, list):
+            return []
+        return [row for row in rows if isinstance(row, dict)]
+
+    def _load_daily_bars(self, symbol: str, *, limit: int = 60) -> list[dict]:
+        with self._data_client() as client:
+            return self._daily_bars(client, symbol, limit=limit)
+
+    def _atr14(self, bars: list[dict]) -> float | None:
+        if len(bars) < 14:
+            return None
+        true_ranges: list[float] = []
+        prev_close: float | None = None
+        for bar in bars:
+            high = self._parse_float(bar.get("h"))
+            low = self._parse_float(bar.get("l"))
+            close = self._parse_float(bar.get("c"))
+            if min(high, low, close) <= 0:
+                continue
+            if prev_close is None:
+                tr = high - low
+            else:
+                tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+            true_ranges.append(tr)
+            prev_close = close
+        if len(true_ranges) < 14:
+            return None
+        atr = sum(true_ranges[:14]) / 14
+        for tr in true_ranges[14:]:
+            atr = ((atr * 13) + tr) / 14
+        return round(atr, 4)
+
     def _market_clock(self) -> dict | None:
         try:
             with self._trading_client() as client:
@@ -209,7 +278,27 @@ class AlpacaPolygonMarketDataAdapter:
         except httpx.HTTPError:
             return None
 
+    def _cache_ttl(self, session_state: str) -> float:
+        return 8.0 if session_state == "regular_open" else 45.0
+
+    def _get_cached_setup(self, symbol: str) -> SetupMarketData | None:
+        cache_entry = self._setup_cache.get(symbol.upper())
+        if cache_entry is None:
+            return None
+        cached_at, payload = cache_entry
+        if time.monotonic() - cached_at > self._cache_ttl(payload.session_state):
+            self._setup_cache.pop(symbol.upper(), None)
+            return None
+        return SetupMarketData(**payload.__dict__)
+
+    def _store_cached_setup(self, symbol: str, payload: SetupMarketData) -> SetupMarketData:
+        self._setup_cache[symbol.upper()] = (time.monotonic(), payload)
+        return SetupMarketData(**payload.__dict__)
+
     def get_setup_data(self, symbol: str) -> SetupMarketData:
+        cached = self._get_cached_setup(symbol)
+        if cached is not None:
+            return cached
         if not self.settings.has_alpaca_credentials:
             return self._fail_or_fallback(
                 symbol,
@@ -217,60 +306,101 @@ class AlpacaPolygonMarketDataAdapter:
                 message="Alpaca paper credentials are missing for latest quote retrieval.",
             )
         try:
-            quote: dict | None = None
-            quote_timestamp: datetime | None = None
-            quote_state = "quote_unavailable"
-            session_state = "closed"
+            upper_symbol = symbol.upper()
+            with ThreadPoolExecutor(max_workers=3) as executor:
+                snapshot_future = executor.submit(self._load_snapshot_payload, upper_symbol)
+                daily_bars_future = executor.submit(self._load_daily_bars, upper_symbol)
+                clock_future = executor.submit(self._market_clock)
+                snapshot_payload = snapshot_future.result()
+                daily_bars = daily_bars_future.result()
+                clock_payload = clock_future.result()
+            snapshot_quote = (
+                snapshot_payload.get("latestQuote") if isinstance(snapshot_payload, dict) else None
+            )
+            latest_trade = (
+                snapshot_payload.get("latestTrade") if isinstance(snapshot_payload, dict) else None
+            )
+            daily_bar = (
+                snapshot_payload.get("dailyBar") if isinstance(snapshot_payload, dict) else None
+            )
+            prev_daily_bar = (
+                snapshot_payload.get("prevDailyBar") if isinstance(snapshot_payload, dict) else None
+            )
             with self._data_client() as client:
-                latest_quote, latest_timestamp = self._latest_quote(client, symbol.upper())
-                if self._has_usable_bid_ask(latest_quote):
-                    quote = latest_quote
-                    quote_timestamp = latest_timestamp
-                    quote_state = "live_quote"
+                quote: dict | None = None
+                quote_timestamp: datetime | None = None
+                quote_state = "quote_unavailable"
+                snapshot_timestamp = self._parse_quote_timestamp(
+                    str((snapshot_quote or {}).get("t") or "")
+                )
+                if self._has_usable_bid_ask(snapshot_quote):
+                    quote = snapshot_quote
+                    quote_timestamp = snapshot_timestamp
+                    quote_state = "cached_quote"
                 else:
-                    snapshot_quote, snapshot_timestamp = self._snapshot_quote(
-                        client, symbol.upper()
-                    )
-                    if self._has_usable_bid_ask(snapshot_quote):
-                        quote = snapshot_quote
-                        quote_timestamp = snapshot_timestamp
-                        quote_state = "cached_quote"
+                    latest_quote, latest_timestamp = self._latest_quote(client, symbol.upper())
+                    if self._has_usable_bid_ask(latest_quote):
+                        quote = latest_quote
+                        quote_timestamp = latest_timestamp
+                        quote_state = "live_quote"
                     else:
                         historical_quote, historical_timestamp = self._historical_quote(
-                            client, symbol.upper()
+                            client, upper_symbol
                         )
-                        if self._has_usable_bid_ask(historical_quote):
+                        if isinstance(historical_quote, dict):
                             quote = historical_quote
                             quote_timestamp = historical_timestamp
                             quote_state = "cached_quote"
-            clock_payload = self._market_clock()
             session_state = self._session_state_from_clock(clock_payload)
             if session_state != "regular_open" and quote_state == "live_quote":
                 quote_state = "cached_quote"
             if not quote:
-                raise ValueError(f"Alpaca quote unavailable for {symbol.upper()} right now.")
+                raise ValueError(f"Alpaca quote unavailable for {upper_symbol} right now.")
+            last_trade_price = self._parse_float((latest_trade or {}).get("p"))
             fallback = self.fallback.get_setup_data(symbol)
-            bid = float(quote.get("bp", fallback.bid))
-            ask = float(quote.get("ap", fallback.ask))
-            return SetupMarketData(
-                symbol=symbol.upper(),
-                provider="alpaca_quote",
-                provider_state="real_quote_fallback_technicals",
+            bid = self._parse_float(quote.get("bp"))
+            ask = self._parse_float(quote.get("ap"))
+            if bid <= 0:
+                bid = last_trade_price
+            if ask <= 0:
+                ask = last_trade_price
+            if bid <= 0 or ask <= 0:
+                raise ValueError(f"Alpaca quote unavailable for {upper_symbol} right now.")
+            if not isinstance(daily_bar, dict):
+                raise ValueError(f"Alpaca daily bar unavailable for {upper_symbol} right now.")
+            lod = self._parse_float(daily_bar.get("l"))
+            hod = self._parse_float(daily_bar.get("h"))
+            prev_close = self._parse_float((prev_daily_bar or {}).get("c"), fallback.prev_close)
+            atr14 = self._atr14(daily_bars)
+            if lod <= 0 or hod <= 0:
+                raise ValueError(f"Alpaca daily range unavailable for {upper_symbol} right now.")
+            if atr14 is None or atr14 <= 0:
+                raise ValueError(f"Alpaca ATR14 unavailable for {upper_symbol} right now.")
+            entry_basis = (
+                "bid_ask_midpoint"
+                if self._parse_float(quote.get("bp")) > 0 and self._parse_float(quote.get("ap")) > 0
+                else "hybrid_quote_trade_midpoint"
+            )
+            payload = SetupMarketData(
+                symbol=upper_symbol,
+                provider="alpaca_market",
+                provider_state="real_quote_range_atr_fallback_technicals",
                 quote_provider="alpaca",
                 technicals_provider="mock",
                 quote_is_real=True,
                 technicals_are_fallback=True,
-                fallback_reason="technicals_fallback_only",
+                fallback_reason="partial_technicals_fallback_only",
                 quote_timestamp=quote_timestamp,
                 session_state=session_state,
                 quote_state=quote_state,
+                entry_basis=entry_basis,
                 bid=bid,
                 ask=ask,
-                last=round((bid + ask) / 2, 2),
-                lod=fallback.lod,
-                hod=fallback.hod,
-                prev_close=fallback.prev_close,
-                atr14=fallback.atr14,
+                last=round(last_trade_price if last_trade_price > 0 else (bid + ask) / 2, 2),
+                lod=lod,
+                hod=hod,
+                prev_close=prev_close,
+                atr14=atr14,
                 sma10=fallback.sma10,
                 sma50=fallback.sma50,
                 sma200=fallback.sma200,
@@ -278,6 +408,7 @@ class AlpacaPolygonMarketDataAdapter:
                 rvol=fallback.rvol,
                 days_to_cover=fallback.days_to_cover,
             )
+            return self._store_cached_setup(symbol, payload)
         except Exception as exc:
             return self._fail_or_fallback(
                 symbol,

--- a/backend/app/adapters/market_data.py
+++ b/backend/app/adapters/market_data.py
@@ -8,7 +8,6 @@ import httpx
 
 from app.core.config import Settings
 
-
 MOCK_MARKET_DATA: dict[str, dict[str, float]] = {
     "AAPL": {
         "bid": 213.85,
@@ -146,7 +145,9 @@ class AlpacaPolygonMarketDataAdapter:
             return self._session_state_from_timestamp(datetime.now(UTC))
         if bool(clock_payload.get("is_open")):
             return "regular_open"
-        current = self._parse_quote_timestamp(str(clock_payload.get("timestamp") or "")) or datetime.now(UTC)
+        current = self._parse_quote_timestamp(
+            str(clock_payload.get("timestamp") or "")
+        ) or datetime.now(UTC)
         return self._session_state_from_timestamp(current)
 
     def _session_state_from_timestamp(self, timestamp: datetime) -> str:
@@ -162,7 +163,9 @@ class AlpacaPolygonMarketDataAdapter:
             return "after_hours"
         return "overnight"
 
-    def _latest_quote(self, client: httpx.Client, symbol: str) -> tuple[dict | None, datetime | None]:
+    def _latest_quote(
+        self, client: httpx.Client, symbol: str
+    ) -> tuple[dict | None, datetime | None]:
         response = client.get(f"/v2/stocks/{symbol}/quotes/latest")
         response.raise_for_status()
         quote = response.json().get("quote")
@@ -170,7 +173,9 @@ class AlpacaPolygonMarketDataAdapter:
             return None, None
         return quote, self._parse_quote_timestamp(str(quote.get("t") or ""))
 
-    def _snapshot_quote(self, client: httpx.Client, symbol: str) -> tuple[dict | None, datetime | None]:
+    def _snapshot_quote(
+        self, client: httpx.Client, symbol: str
+    ) -> tuple[dict | None, datetime | None]:
         response = client.get(f"/v2/stocks/{symbol}/snapshot")
         response.raise_for_status()
         quote = response.json().get("latestQuote")
@@ -178,7 +183,9 @@ class AlpacaPolygonMarketDataAdapter:
             return None, None
         return quote, self._parse_quote_timestamp(str(quote.get("t") or ""))
 
-    def _historical_quote(self, client: httpx.Client, symbol: str) -> tuple[dict | None, datetime | None]:
+    def _historical_quote(
+        self, client: httpx.Client, symbol: str
+    ) -> tuple[dict | None, datetime | None]:
         response = client.get(
             f"/v2/stocks/{symbol}/quotes",
             params={"limit": 1, "sort": "desc", "feed": "iex"},
@@ -221,13 +228,17 @@ class AlpacaPolygonMarketDataAdapter:
                     quote_timestamp = latest_timestamp
                     quote_state = "live_quote"
                 else:
-                    snapshot_quote, snapshot_timestamp = self._snapshot_quote(client, symbol.upper())
+                    snapshot_quote, snapshot_timestamp = self._snapshot_quote(
+                        client, symbol.upper()
+                    )
                     if self._has_usable_bid_ask(snapshot_quote):
                         quote = snapshot_quote
                         quote_timestamp = snapshot_timestamp
                         quote_state = "cached_quote"
                     else:
-                        historical_quote, historical_timestamp = self._historical_quote(client, symbol.upper())
+                        historical_quote, historical_timestamp = self._historical_quote(
+                            client, symbol.upper()
+                        )
                         if self._has_usable_bid_ask(historical_quote):
                             quote = historical_quote
                             quote_timestamp = historical_timestamp

--- a/backend/app/api/deps_auth.py
+++ b/backend/app/api/deps_auth.py
@@ -12,7 +12,11 @@ auth_store = get_auth_store(settings)
 
 
 def _default_user() -> dict[str, Any]:
-    username = settings.auth_admin_username if settings.app_default_role == "admin" else settings.auth_trader_username
+    username = (
+        settings.auth_admin_username
+        if settings.app_default_role == "admin"
+        else settings.auth_trader_username
+    )
     return {
         "user": {
             "id": 0,

--- a/backend/app/api/routes_positions.py
+++ b/backend/app/api/routes_positions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from app.api.deps_auth import require_session
@@ -23,5 +24,16 @@ def build_router(service: CockpitService) -> APIRouter:
     @router.get("/orders/{symbol}", response_model=list[OrderView])
     def get_orders(symbol: str, db: Session = Depends(get_db)) -> list[OrderView]:
         return service.get_orders(db, symbol)
+
+    @router.get("/orders", response_model=list[OrderView])
+    def get_recent_orders(db: Session = Depends(get_db)) -> list[OrderView]:
+        return service.get_recent_orders(db)
+
+    @router.delete("/orders/{broker_order_id}", response_model=OrderView)
+    def cancel_order(broker_order_id: str, db: Session = Depends(get_db)) -> OrderView:
+        try:
+            return service.cancel_recent_order(db, broker_order_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return router

--- a/backend/app/api/routes_trade.py
+++ b/backend/app/api/routes_trade.py
@@ -5,7 +5,14 @@ from sqlalchemy.orm import Session
 
 from app.api.deps_auth import require_session
 from app.db.session import get_db
-from app.schemas.cockpit import MoveToBeRequest, PositionView, ProfitRequest, StopsRequest, TradeEnterRequest, TradePreviewRequest
+from app.schemas.cockpit import (
+    MoveToBeRequest,
+    PositionView,
+    ProfitRequest,
+    StopsRequest,
+    TradeEnterRequest,
+    TradePreviewRequest,
+)
 from app.services.cockpit import CockpitService
 
 

--- a/backend/app/api/routes_trade.py
+++ b/backend/app/api/routes_trade.py
@@ -12,6 +12,7 @@ from app.schemas.cockpit import (
     StopsRequest,
     TradeEnterRequest,
     TradePreviewRequest,
+    TradePreviewResponse,
 )
 from app.services.cockpit import CockpitService
 
@@ -19,8 +20,10 @@ from app.services.cockpit import CockpitService
 def build_router(service: CockpitService) -> APIRouter:
     router = APIRouter(prefix="/api/trade", tags=["trade"], dependencies=[Depends(require_session)])
 
-    @router.post("/preview")
-    def preview(payload: TradePreviewRequest, db: Session = Depends(get_db)) -> dict:
+    @router.post("/preview", response_model=TradePreviewResponse)
+    def preview(
+        payload: TradePreviewRequest, db: Session = Depends(get_db)
+    ) -> TradePreviewResponse:
         try:
             return service.preview_trade(db, payload)
         except ValueError as exc:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -133,7 +133,7 @@ class Settings:
         default_db = (
             sqlite_fallback_url
             if app_env == "test" or allow_sqlite_fallback
-            else "postgresql://traders_cockpit:change-me-postgres@127.0.0.1:55432/traders_cockpit"
+            else "postgresql://traders_cockpit:traders_cockpit@127.0.0.1:55432/traders_cockpit"
         )
         return cls(
             app_env=app_env,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -106,18 +106,30 @@ class Settings:
             "testing": "test",
         }.get(app_env_raw, "development")
         app_default_role_raw = os.getenv("APP_DEFAULT_ROLE", "admin").strip().lower()
-        app_default_role = app_default_role_raw if app_default_role_raw in {"admin", "trader"} else "admin"
+        app_default_role = (
+            app_default_role_raw if app_default_role_raw in {"admin", "trader"} else "admin"
+        )
         allow_role_override_default = "false" if app_env == "production" else "true"
-        allow_role_override = _as_bool(os.getenv("APP_ALLOW_ROLE_OVERRIDE", allow_role_override_default))
+        allow_role_override = _as_bool(
+            os.getenv("APP_ALLOW_ROLE_OVERRIDE", allow_role_override_default)
+        )
         require_ops_auth_default = "true" if app_env == "production" else "false"
         require_ops_auth = _as_bool(os.getenv("OPS_REQUIRE_AUTH", require_ops_auth_default))
-        sqlite_fallback_url = os.getenv("SQLITE_FALLBACK_URL", "sqlite:///./data/traders_cockpit.db").strip()
+        sqlite_fallback_url = os.getenv(
+            "SQLITE_FALLBACK_URL", "sqlite:///./data/traders_cockpit.db"
+        ).strip()
         allow_sqlite_fallback = _as_bool(os.getenv("ALLOW_SQLITE_FALLBACK", "false"))
         auth_db_path = os.getenv("AUTH_DB_PATH", "./data/auth.db").strip() or "./data/auth.db"
         auth_cookie_secure_default = "true" if app_env in {"staging", "production"} else "false"
         auth_cookie_samesite_default = "none" if app_env in {"staging", "production"} else "lax"
-        auth_cookie_samesite_raw = os.getenv("AUTH_COOKIE_SAMESITE", auth_cookie_samesite_default).strip().lower()
-        auth_cookie_samesite = auth_cookie_samesite_raw if auth_cookie_samesite_raw in {"lax", "strict", "none"} else auth_cookie_samesite_default
+        auth_cookie_samesite_raw = (
+            os.getenv("AUTH_COOKIE_SAMESITE", auth_cookie_samesite_default).strip().lower()
+        )
+        auth_cookie_samesite = (
+            auth_cookie_samesite_raw
+            if auth_cookie_samesite_raw in {"lax", "strict", "none"}
+            else auth_cookie_samesite_default
+        )
         default_db = (
             sqlite_fallback_url
             if app_env == "test" or allow_sqlite_fallback
@@ -132,7 +144,9 @@ class Settings:
             auth_session_ttl_hours=max(1, int(os.getenv("AUTH_SESSION_TTL_HOURS", "24"))),
             auth_cookie_name=os.getenv("AUTH_COOKIE_NAME", "traders_cockpit_session").strip(),
             auth_cookie_samesite=auth_cookie_samesite,
-            auth_cookie_secure=_as_bool(os.getenv("AUTH_COOKIE_SECURE", auth_cookie_secure_default)),
+            auth_cookie_secure=_as_bool(
+                os.getenv("AUTH_COOKIE_SECURE", auth_cookie_secure_default)
+            ),
             auth_db_path=auth_db_path,
             auth_seed_users=_as_bool(os.getenv("AUTH_SEED_USERS", "true"), True),
             auth_admin_username=os.getenv("AUTH_ADMIN_USERNAME", "admin").strip(),
@@ -205,8 +219,16 @@ class Settings:
 
     @property
     def local_personal_paper_ready(self) -> bool:
-        return self.broker_mode == "alpaca_paper" and not self.allow_live_trading and self.has_alpaca_credentials
+        return (
+            self.broker_mode == "alpaca_paper"
+            and not self.allow_live_trading
+            and self.has_alpaca_credentials
+        )
 
     @property
     def live_trading_enabled(self) -> bool:
-        return self.broker_mode == "alpaca_live" and self.allow_live_trading and bool(self.live_confirmation_token)
+        return (
+            self.broker_mode == "alpaca_live"
+            and self.allow_live_trading
+            and bool(self.live_confirmation_token)
+        )

--- a/backend/app/schemas/cockpit.py
+++ b/backend/app/schemas/cockpit.py
@@ -11,8 +11,36 @@ class StopMode(BaseModel):
     pct: float | None = None
 
 
+EntryOrderType = Literal["market", "limit", "stop", "stop_limit"]
+TimeInForce = Literal["day", "gtc", "ioc", "fok", "opg", "cls"]
+OrderClass = Literal["simple", "bracket", "oco", "oto"]
+OtoExitSide = Literal["stop_loss", "take_profit"]
+
+
+class TakeProfitDraft(BaseModel):
+    limitPrice: float | None = None
+
+
+class StopLossDraft(BaseModel):
+    stopPrice: float | None = None
+    limitPrice: float | None = None
+
+
+class EntryOrderDraft(BaseModel):
+    orderType: EntryOrderType = "limit"
+    timeInForce: TimeInForce = "day"
+    orderClass: OrderClass = "simple"
+    extendedHours: bool = False
+    limitPrice: float | None = None
+    stopPrice: float | None = None
+    otoExitSide: OtoExitSide = "stop_loss"
+    takeProfit: TakeProfitDraft | None = None
+    stopLoss: StopLossDraft | None = None
+
+
 class TrancheMode(BaseModel):
     mode: Literal["limit", "runner"] = "limit"
+    allocationPct: float | None = None
     trail: float = 2.0
     trailUnit: Literal["$", "%"] = "$"
     target: Literal["1R", "2R", "3R", "Manual"] = "1R"
@@ -25,6 +53,9 @@ class Tranche(BaseModel):
     stop: float
     target: float | None = None
     status: Literal["active", "sold", "canceled"] = "active"
+    exitPrice: float | None = None
+    exitFilledAt: datetime | None = None
+    exitOrderType: str | None = None
     mode: Literal["limit", "runner"] = "limit"
     trail: float = 2.0
     trailUnit: Literal["$", "%"] = "$"
@@ -34,16 +65,22 @@ class Tranche(BaseModel):
 
 class OrderView(BaseModel):
     id: str
+    symbol: str
+    side: str | None = None
     type: str
     qty: int
     origQty: int
+    filledQty: int = 0
+    remainingQty: int = 0
     price: float
     status: str
     tranche: str
     coveredTranches: list[str] = Field(default_factory=list)
     parentId: str | None = None
     brokerOrderId: str | None = None
+    cancelable: bool = False
     createdAt: datetime | None = None
+    updatedAt: datetime | None = None
     filledAt: datetime | None = None
     fillPrice: float | None = None
 
@@ -86,7 +123,12 @@ class SetupResponse(BaseModel):
     )
     quoteState: Literal["live_quote", "cached_quote", "quote_unavailable"] = "quote_unavailable"
     entryBasis: str = "midpoint"
-    stopReferenceDefault: str = "lod"
+    stopReferenceDefault: Literal["lod", "atr", "manual"] = "lod"
+    lodIsValid: bool = True
+    atrIsValid: bool = True
+    lodStop: float
+    atrStop: float
+    manualStopWarning: str | None = None
     bid: float
     ask: float
     last: float
@@ -110,8 +152,26 @@ class SetupResponse(BaseModel):
     perShareRisk: float
     riskPct: float
     accountEquity: float
+    accountBuyingPower: float
+    accountCash: float | None = None
+    equitySource: str = "local_settings"
+    sizingWarning: str | None = None
+    buyingPowerNote: str | None = None
     atrExtension: float
     extFrom10Ma: float
+
+
+class TradePreviewResponse(BaseModel):
+    symbol: str
+    entry: float
+    finalStop: float
+    perShareRisk: float
+    shares: int
+    dollarRisk: float
+    sizingWarning: str | None = None
+    orderType: EntryOrderType = "limit"
+    timeInForce: TimeInForce = "day"
+    orderClass: OrderClass = "simple"
 
 
 class TradePreviewRequest(BaseModel):
@@ -120,6 +180,7 @@ class TradePreviewRequest(BaseModel):
     stopRef: Literal["lod", "atr", "manual"] = "lod"
     stopPrice: float
     riskPct: float
+    order: EntryOrderDraft = Field(default_factory=EntryOrderDraft)
 
 
 class TradeEnterRequest(BaseModel):
@@ -130,6 +191,7 @@ class TradeEnterRequest(BaseModel):
     trancheCount: int = 3
     trancheModes: list[TrancheMode]
     offHoursMode: Literal["queue_for_open", "extended_hours_limit"] | None = None
+    order: EntryOrderDraft = Field(default_factory=EntryOrderDraft)
 
 
 class StopsRequest(BaseModel):
@@ -150,9 +212,11 @@ class MoveToBeRequest(BaseModel):
 class AccountSettingsView(BaseModel):
     equity: float
     buying_power: float
+    cash: float | None = None
     risk_pct: float
     mode: str
     effective_mode: str
+    equity_source: str = "local_settings"
     daily_realized_pnl: float
     allow_live_trading: bool
     max_position_notional_pct: float

--- a/backend/app/schemas/cockpit.py
+++ b/backend/app/schemas/cockpit.py
@@ -81,7 +81,9 @@ class SetupResponse(BaseModel):
     technicalsAreFallback: bool = True
     fallbackReason: str | None = None
     quoteTimestamp: datetime | None = None
-    sessionState: Literal["regular_open", "overnight", "pre_market", "after_hours", "closed"] = "closed"
+    sessionState: Literal["regular_open", "overnight", "pre_market", "after_hours", "closed"] = (
+        "closed"
+    )
     quoteState: Literal["live_quote", "cached_quote", "quote_unavailable"] = "quote_unavailable"
     entryBasis: str = "midpoint"
     stopReferenceDefault: str = "lod"

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -6,7 +6,7 @@ import os
 import secrets
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -35,12 +35,11 @@ class AuthStore:
 
     @staticmethod
     def _now_iso() -> str:
-        return datetime.now(timezone.utc).isoformat()
+        return datetime.now(UTC).isoformat()
 
     def _init_db(self) -> None:
         with self._connect() as conn:
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS auth_users (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     username TEXT NOT NULL UNIQUE,
@@ -51,10 +50,8 @@ class AuthStore:
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 )
-                """
-            )
-            conn.execute(
-                """
+                """)
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS auth_sessions (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     session_token_hash TEXT NOT NULL UNIQUE,
@@ -67,14 +64,11 @@ class AuthStore:
                     ip_addr TEXT,
                     FOREIGN KEY(user_id) REFERENCES auth_users(id) ON DELETE CASCADE
                 )
-                """
-            )
-            conn.execute(
-                """
+                """)
+            conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_auth_sessions_user_active
                 ON auth_sessions(user_id, revoked_at, expires_at)
-                """
-            )
+                """)
             conn.commit()
 
     @staticmethod
@@ -107,7 +101,9 @@ class AuthStore:
         salt_hex, hash_hex = self._hash_password(password)
         now = self._now_iso()
         with self._connect() as conn:
-            existing = conn.execute("SELECT id FROM auth_users WHERE username = ?", (clean_username,)).fetchone()
+            existing = conn.execute(
+                "SELECT id FROM auth_users WHERE username = ?", (clean_username,)
+            ).fetchone()
             if existing is None:
                 conn.execute(
                     """
@@ -185,7 +181,7 @@ class AuthStore:
     ) -> tuple[str, dict[str, Any]]:
         token = secrets.token_urlsafe(48)
         token_hash = self._session_token_hash(token)
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         now_iso = now.isoformat()
         expires_at = (now + timedelta(hours=self.session_ttl_hours)).isoformat()
         with self._connect() as conn:
@@ -222,7 +218,7 @@ class AuthStore:
         token = str(session_token or "").strip()
         if not token:
             return None
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         now_iso = now.isoformat()
         token_hash = self._session_token_hash(token)
         with self._connect() as conn:
@@ -246,13 +242,18 @@ class AuthStore:
             if row is None:
                 return None
             try:
-                expires_dt = datetime.fromisoformat(str(row["expires_at"] or "").replace("Z", "+00:00"))
+                expires_dt = datetime.fromisoformat(
+                    str(row["expires_at"] or "").replace("Z", "+00:00")
+                )
             except ValueError:
                 return None
             if expires_dt.tzinfo is None:
-                expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+                expires_dt = expires_dt.replace(tzinfo=UTC)
             if expires_dt <= now:
-                conn.execute("UPDATE auth_sessions SET revoked_at = ? WHERE id = ?", (now_iso, int(row["session_id"])))
+                conn.execute(
+                    "UPDATE auth_sessions SET revoked_at = ? WHERE id = ?",
+                    (now_iso, int(row["session_id"])),
+                )
                 conn.commit()
                 return None
             if int(row["is_active"] or 0) != 1:
@@ -298,6 +299,8 @@ def get_auth_store(settings: Settings) -> AuthStore:
     cache_key = str(Path(settings.auth_db_path).resolve())
     store = _auth_store_cache.get(cache_key)
     if store is None:
-        store = AuthStore(db_path=settings.auth_db_path, session_ttl_hours=settings.auth_session_ttl_hours)
+        store = AuthStore(
+            db_path=settings.auth_db_path, session_ttl_hours=settings.auth_session_ttl_hours
+        )
         _auth_store_cache[cache_key] = store
     return store

--- a/backend/app/services/cockpit.py
+++ b/backend/app/services/cockpit.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from math import floor
 from random import uniform
 
-from sqlalchemy import desc, func, select
+from sqlalchemy import desc, select
 from sqlalchemy.orm import Session
 
 from app.adapters.broker import AlpacaBrokerAdapter, PaperBrokerAdapter
@@ -157,7 +157,9 @@ class CockpitService:
                 broker = self.broker.place_market_order(symbol, setup.shares, "buy")
                 entry_filled = False
                 broker_status = "PENDING"
-                entry_message = "Market closed. Order accepted and queued for the next regular session."
+                entry_message = (
+                    "Market closed. Order accepted and queued for the next regular session."
+                )
             else:
                 broker = self.broker.place_limit_order(
                     symbol,
@@ -249,7 +251,12 @@ class CockpitService:
             self._log(db, symbol, "exec", entry_message)
         else:
             self._log(db, symbol, "warn", entry_message)
-        self._log(db, symbol, "sys", "Tranches: " + " \u00b7 ".join(f"T{i+1}={qty}sh" for i, qty in enumerate(qtys)))
+        self._log(
+            db,
+            symbol,
+            "sys",
+            "Tranches: " + " \u00b7 ".join(f"T{i+1}={qty}sh" for i, qty in enumerate(qtys)),
+        )
         db.commit()
         view = self.get_position(db, symbol)
         await self._broadcast_position_bundle(db, view, pnl=0.0)
@@ -258,7 +265,9 @@ class CockpitService:
     async def apply_stops(self, db: Session, payload: StopsRequest) -> PositionView:
         position = self._require_position(db, payload.symbol)
         self._ensure_position_is_open(position)
-        self._ensure_position_filled(position, "Protective orders are unavailable until the entry order is filled.")
+        self._ensure_position_filled(
+            position, "Protective orders are unavailable until the entry order is filled."
+        )
         self._validate_stop_mode(payload.stopMode, payload.stopModes)
         self._reject_duplicate_active_stops(db, position.symbol)
         stop_range = round(position.entry_price - position.stop_price, 2)
@@ -305,7 +314,12 @@ class CockpitService:
             qty = sum(item["qty"] for item in group)
             price = position.entry_price if config.mode == "be" else group[0]["stop"]
             stop_lines.append(f"S{index+1} {qty}sh @ {price:.2f} ({pct:.2f}%)")
-        self._log(db, position.symbol, "warn", f"\u2713 Stops applied \u2014 {' \u00b7 '.join(stop_lines)}")
+        self._log(
+            db,
+            position.symbol,
+            "warn",
+            f"\u2713 Stops applied \u2014 {' \u00b7 '.join(stop_lines)}",
+        )
         db.commit()
         view = self.get_position(db, position.symbol)
         await self._broadcast_position_bundle(db, view)
@@ -329,7 +343,9 @@ class CockpitService:
                 runner_stop = self._trail_stop(position.live_price, mode.trail, mode.trailUnit)
                 tranche["mode"] = "runner"
                 tranche["runnerStop"] = runner_stop
-                broker = self.broker.place_trailing_stop(position.symbol, tranche["qty"], mode.trail, mode.trailUnit)
+                broker = self.broker.place_trailing_stop(
+                    position.symbol, tranche["qty"], mode.trail, mode.trailUnit
+                )
                 db.add(
                     OrderEntity(
                         order_id=self._next_order_id(db),
@@ -383,7 +399,12 @@ class CockpitService:
         position.updated_at = utcnow()
         if executed_count == 0 and phase == "runner_only":
             raise ValueError("No executable profit tranches remain; runner already active")
-        self._log(db, position.symbol, "exec", f"\u2713 Profit plan executed \u2014 {executed_count} tranche(s) filled")
+        self._log(
+            db,
+            position.symbol,
+            "exec",
+            f"\u2713 Profit plan executed \u2014 {executed_count} tranche(s) filled",
+        )
         db.commit()
         view = self.get_position(db, position.symbol)
         await self._broadcast_position_bundle(db, view)
@@ -392,18 +413,26 @@ class CockpitService:
     async def move_to_be(self, db: Session, symbol: str) -> PositionView:
         position = self._require_position(db, symbol)
         self._ensure_position_is_open(position)
-        self._ensure_position_filled(position, "Protective orders are unavailable until the entry order is filled.")
+        self._ensure_position_filled(
+            position, "Protective orders are unavailable until the entry order is filled."
+        )
         position.tranches = [
             {**tranche, "stop": position.entry_price} if tranche["status"] == "active" else tranche
             for tranche in deepcopy(position.tranches)
         ]
-        for order in db.scalars(select(OrderEntity).where(OrderEntity.symbol == position.symbol, OrderEntity.type == "STOP")):
+        for order in db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == position.symbol, OrderEntity.type == "STOP"
+            )
+        ):
             if order.status in {"ACTIVE", "MODIFIED"}:
                 order.price = position.entry_price
                 order.status = "MODIFIED"
         position.phase = "protected"
         position.updated_at = utcnow()
-        self._log(db, position.symbol, "warn", f"All stops \u2192 breakeven: {position.entry_price:.2f}")
+        self._log(
+            db, position.symbol, "warn", f"All stops \u2192 breakeven: {position.entry_price:.2f}"
+        )
         db.commit()
         view = self.get_position(db, position.symbol)
         await self._broadcast_position_bundle(db, view)
@@ -413,7 +442,9 @@ class CockpitService:
         position = self._require_position(db, symbol)
         self._ensure_position_is_open(position)
         if position.phase == "entry_pending":
-            root_order = db.scalar(select(OrderEntity).where(OrderEntity.order_id == position.root_order_id))
+            root_order = db.scalar(
+                select(OrderEntity).where(OrderEntity.order_id == position.root_order_id)
+            )
             if root_order and root_order.broker_order_id:
                 self.broker.cancel_order(root_order.broker_order_id)
             if root_order:
@@ -423,7 +454,9 @@ class CockpitService:
                 tranche["status"] = "canceled"
                 canceled_tranches.append(tranche)
             position.tranches = canceled_tranches
-            for order in db.scalars(select(OrderEntity).where(OrderEntity.symbol == position.symbol)):
+            for order in db.scalars(
+                select(OrderEntity).where(OrderEntity.symbol == position.symbol)
+            ):
                 if order.status in {"ACTIVE", "MODIFIED", "PENDING"}:
                     if order.broker_order_id:
                         self.broker.cancel_order(order.broker_order_id)
@@ -470,14 +503,21 @@ class CockpitService:
         position.phase = "closed"
         position.closed_at = utcnow()
         position.updated_at = utcnow()
-        self._log(db, position.symbol, "close", "\u2B1B POSITION FLATTENED \u2014 all tranches closed @ market")
+        self._log(
+            db,
+            position.symbol,
+            "close",
+            "\u2b1b POSITION FLATTENED \u2014 all tranches closed @ market",
+        )
         db.commit()
         view = self.get_position(db, position.symbol)
         await self._broadcast_position_bundle(db, view)
         return view
 
     def get_positions(self, db: Session) -> list[PositionView]:
-        positions = db.scalars(select(PositionEntity).order_by(PositionEntity.created_at.desc())).all()
+        positions = db.scalars(
+            select(PositionEntity).order_by(PositionEntity.created_at.desc())
+        ).all()
         return [self._position_view(db, position) for position in positions]
 
     def get_position(self, db: Session, symbol: str) -> PositionView:
@@ -490,19 +530,24 @@ class CockpitService:
                 select(OrderEntity)
                 .where(
                     OrderEntity.symbol == symbol.upper(),
-                    (OrderEntity.order_id == position.root_order_id) | (OrderEntity.parent_id == position.root_order_id),
+                    (OrderEntity.order_id == position.root_order_id)
+                    | (OrderEntity.parent_id == position.root_order_id),
                 )
                 .order_by(OrderEntity.created_at.asc())
             ).all()
         else:
             rows = db.scalars(
-                select(OrderEntity).where(OrderEntity.symbol == symbol.upper()).order_by(OrderEntity.created_at.asc())
+                select(OrderEntity)
+                .where(OrderEntity.symbol == symbol.upper())
+                .order_by(OrderEntity.created_at.asc())
             ).all()
         return [self._order_view(row) for row in rows]
 
     def get_logs(self, db: Session) -> list[LogEntry]:
         self.ensure_seed_data(db)
-        rows = db.scalars(select(TradeLogEntity).order_by(TradeLogEntity.created_at.desc()).limit(200)).all()
+        rows = db.scalars(
+            select(TradeLogEntity).order_by(TradeLogEntity.created_at.desc()).limit(200)
+        ).all()
         return [LogEntry.model_validate(row, from_attributes=True) for row in rows]
 
     def clear_logs(self, db: Session) -> int:
@@ -536,7 +581,9 @@ class CockpitService:
             ),
         )
 
-    def _build_setup_response(self, market: SetupMarketData, equity: float, risk_pct: float) -> SetupResponse:
+    def _build_setup_response(
+        self, market: SetupMarketData, equity: float, risk_pct: float
+    ) -> SetupResponse:
         entry = round((market.bid + market.ask) / 2, 2)
         final_stop = market.lod
         per_share_risk = round(max(0.01, entry - final_stop), 2)
@@ -615,17 +662,25 @@ class CockpitService:
         base = floor(100 / stop_mode)
         return float(100 - base * index) if index == stop_mode - 1 else float(base)
 
-    def _resolve_target_price(self, entry: float, per_share_risk: float, mode: TrancheMode) -> float:
+    def _resolve_target_price(
+        self, entry: float, per_share_risk: float, mode: TrancheMode
+    ) -> float:
         if mode.target == "Manual" and mode.manualPrice is not None:
             return round(mode.manualPrice, 2)
         multiplier = {"1R": 1, "2R": 2, "3R": 3}[mode.target]
         return round(entry + per_share_risk * multiplier, 2)
 
     def _trail_stop(self, live_price: float, trail: float, trail_unit: str) -> float:
-        return round(live_price - trail, 2) if trail_unit == "$" else round(live_price * (1 - trail / 100), 2)
+        return (
+            round(live_price - trail, 2)
+            if trail_unit == "$"
+            else round(live_price * (1 - trail / 100), 2)
+        )
 
     def _reduce_stop_orders(self, db: Session, symbol: str, tranche_id: str, qty_sold: int) -> None:
-        for order in db.scalars(select(OrderEntity).where(OrderEntity.symbol == symbol, OrderEntity.type == "STOP")):
+        for order in db.scalars(
+            select(OrderEntity).where(OrderEntity.symbol == symbol, OrderEntity.type == "STOP")
+        ):
             if order.status == "CANCELED" or tranche_id not in order.covered_tranches:
                 continue
             order.qty = max(0, order.qty - qty_sold)
@@ -636,13 +691,19 @@ class CockpitService:
         account = self.get_account(db)
         if entry * shares > account.equity * (self.settings.max_position_notional_pct / 100):
             raise ValueError("Position exceeds max notional cap")
-        if account.daily_realized_pnl < -(account.equity * (self.settings.daily_loss_limit_pct / 100)):
+        if account.daily_realized_pnl < -(
+            account.equity * (self.settings.daily_loss_limit_pct / 100)
+        ):
             raise ValueError("Daily loss limit reached")
         open_positions = [row for row in self.get_positions(db) if row.phase != "closed"]
         if len(open_positions) >= self.settings.max_open_positions:
             raise ValueError("Max open positions reached")
         self._cancel_stale_active_orders(db, symbol)
-        active = db.scalars(select(OrderEntity).where(OrderEntity.symbol == symbol, OrderEntity.status.in_(["ACTIVE", "MODIFIED"]))).all()
+        active = db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == symbol, OrderEntity.status.in_(["ACTIVE", "MODIFIED"])
+            )
+        ).all()
         if active:
             raise ValueError("Duplicate active orders exist for this symbol")
 
@@ -666,11 +727,19 @@ class CockpitService:
 
     def _reject_duplicate_active_stops(self, db: Session, symbol: str) -> None:
         self._cancel_stale_active_orders(db, symbol)
-        active = db.scalars(select(OrderEntity).where(OrderEntity.symbol == symbol, OrderEntity.type == "STOP", OrderEntity.status.in_(["ACTIVE", "MODIFIED"]))).all()
+        active = db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == symbol,
+                OrderEntity.type == "STOP",
+                OrderEntity.status.in_(["ACTIVE", "MODIFIED"]),
+            )
+        ).all()
         if active:
             raise ValueError("Active stop orders already exist for this symbol")
 
-    def _reject_duplicate_active_order(self, db: Session, symbol: str, tranche_id: str, order_type: str) -> None:
+    def _reject_duplicate_active_order(
+        self, db: Session, symbol: str, tranche_id: str, order_type: str
+    ) -> None:
         self._cancel_stale_active_orders(db, symbol)
         active = db.scalars(
             select(OrderEntity).where(
@@ -679,13 +748,18 @@ class CockpitService:
                 OrderEntity.status.in_(["ACTIVE", "MODIFIED"]),
             )
         ).all()
-        if any(tranche_id in (order.covered_tranches or []) or order.tranche_label == tranche_id for order in active):
+        if any(
+            tranche_id in (order.covered_tranches or []) or order.tranche_label == tranche_id
+            for order in active
+        ):
             raise ValueError(f"Active {order_type} order already exists for {tranche_id}")
 
     def _cancel_stale_active_orders(self, db: Session, symbol: str) -> None:
         position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == symbol))
-        if position is not None and position.phase != "closed" and any(
-            tranche["status"] == "active" for tranche in position.tranches
+        if (
+            position is not None
+            and position.phase != "closed"
+            and any(tranche["status"] == "active" for tranche in position.tranches)
         ):
             return
         stale_orders = db.scalars(
@@ -718,7 +792,9 @@ class CockpitService:
     def _mark_entry_filled_if_ready(self, db: Session, position: PositionEntity) -> None:
         if position.phase != "entry_pending":
             return
-        root_order = db.scalar(select(OrderEntity).where(OrderEntity.order_id == position.root_order_id))
+        root_order = db.scalar(
+            select(OrderEntity).where(OrderEntity.order_id == position.root_order_id)
+        )
         if root_order is None:
             return
         position.phase = "trade_entered"
@@ -746,9 +822,13 @@ class CockpitService:
 
     def _ensure_profit_actionable(self, position: PositionEntity) -> None:
         self._ensure_position_is_open(position)
-        self._ensure_position_filled(position, "Position management is unavailable until the entry order is filled.")
+        self._ensure_position_filled(
+            position, "Position management is unavailable until the entry order is filled."
+        )
         if position.phase not in {"protected", "P1_done", "P2_done", "runner_only"}:
-            raise ValueError("Profit execution requires a protected or active profit-managed position")
+            raise ValueError(
+                "Profit execution requires a protected or active profit-managed position"
+            )
 
     def _effective_account_mode(self, requested_mode: str) -> str:
         if requested_mode == "alpaca_live" and self._live_disabled_reason(requested_mode):
@@ -790,7 +870,9 @@ class CockpitService:
         if latest_log is not None:
             await self.ws_manager.broadcast(
                 "cockpit",
-                self._event("log_update", symbol=view.symbol, log=latest_log.model_dump(mode="json")),
+                self._event(
+                    "log_update", symbol=view.symbol, log=latest_log.model_dump(mode="json")
+                ),
             )
 
     def _latest_log_entry(self, db: Session, symbol: str | None = None) -> LogEntry | None:
@@ -872,5 +954,7 @@ class CockpitService:
 
     def _pnl(self, position: PositionView) -> float:
         entry = float(position.setup.get("entry", 0.0))
-        active_shares = sum(tranche.qty for tranche in position.tranches if tranche.status == "active")
+        active_shares = sum(
+            tranche.qty for tranche in position.tranches if tranche.status == "active"
+        )
         return round((position.livePrice - entry) * active_shares, 2)

--- a/backend/app/services/cockpit.py
+++ b/backend/app/services/cockpit.py
@@ -8,22 +8,26 @@ from random import uniform
 from sqlalchemy import desc, select
 from sqlalchemy.orm import Session
 
-from app.adapters.broker import AlpacaBrokerAdapter, PaperBrokerAdapter
+from app.adapters.broker import AlpacaBrokerAdapter, BrokerEntryOrder, PaperBrokerAdapter
 from app.adapters.market_data import AlpacaPolygonMarketDataAdapter, SetupMarketData
 from app.core.config import Settings
 from app.models.entities import AccountSettingsEntity, OrderEntity, PositionEntity, TradeLogEntity
 from app.schemas.cockpit import (
     AccountSettingsUpdate,
     AccountSettingsView,
+    EntryOrderDraft,
     LogEntry,
     OrderView,
     PositionView,
     ProfitRequest,
     SetupResponse,
+    StopLossDraft,
     StopMode,
     StopsRequest,
+    TakeProfitDraft,
     TradeEnterRequest,
     TradePreviewRequest,
+    TradePreviewResponse,
     Tranche,
     TrancheMode,
 )
@@ -68,12 +72,25 @@ class CockpitService:
         account = db.scalar(select(AccountSettingsEntity))
         assert account is not None
         effective_mode = self._effective_account_mode(account.mode)
+        equity = account.equity
+        buying_power = account.buying_power
+        cash = None
+        equity_source = "local_settings"
+        if effective_mode == "alpaca_paper":
+            broker_summary = self.broker.get_account_summary()
+            if broker_summary:
+                equity = broker_summary.get("equity", equity)
+                buying_power = broker_summary.get("buying_power", buying_power)
+                cash = broker_summary.get("cash")
+                equity_source = "alpaca_account"
         return AccountSettingsView(
-            equity=account.equity,
-            buying_power=account.buying_power,
+            equity=equity,
+            buying_power=buying_power,
+            cash=cash,
             risk_pct=account.risk_pct,
             mode=account.mode,
             effective_mode=effective_mode,
+            equity_source=equity_source,
             daily_realized_pnl=account.daily_realized_pnl,
             allow_live_trading=self.settings.allow_live_trading,
             max_position_notional_pct=self.settings.max_position_notional_pct,
@@ -103,84 +120,103 @@ class CockpitService:
     def get_setup(self, db: Session, symbol: str) -> SetupResponse:
         account = self.get_account(db)
         market = self.market_data.get_setup_data(symbol)
-        return self._build_setup_response(market, account.equity, account.risk_pct)
+        return self._build_setup_response(
+            market,
+            account.equity,
+            account.buying_power,
+            account.risk_pct,
+            account.equity_source,
+            account.cash,
+        )
 
-    def preview_trade(self, db: Session, payload: TradePreviewRequest) -> dict:
+    def preview_trade(self, db: Session, payload: TradePreviewRequest) -> TradePreviewResponse:
         setup = self.get_setup(db, payload.symbol)
-        self._validate_stop(payload.entry, payload.stopPrice)
-        per_share_risk = round(payload.entry - payload.stopPrice, 2)
-        shares = self._calculate_shares(setup.accountEquity, payload.riskPct, per_share_risk)
+        order = self._normalize_entry_order(payload.order, payload.entry, payload.stopPrice)
+        self._validate_entry_order(order, setup.sessionState)
+        preview_entry = self._preview_entry_price(payload.entry, order)
+        self._validate_stop(preview_entry, payload.stopPrice)
+        per_share_risk = round(preview_entry - payload.stopPrice, 2)
+        shares = self._calculate_shares(
+            setup.accountEquity,
+            setup.accountBuyingPower,
+            preview_entry,
+            payload.riskPct,
+            per_share_risk,
+        )
+        sizing_warning = self._sizing_warning(setup.accountBuyingPower, preview_entry, shares)
         self._log(
             db,
             payload.symbol.upper(),
             "info",
-            f"Preview: {payload.symbol.upper()} buy {shares} sh @ {payload.entry:.2f} stop {payload.stopPrice:.2f}",
+            f"Preview: {payload.symbol.upper()} buy {shares} sh {order.orderType.upper()} {order.timeInForce.upper()} @ {preview_entry:.2f} stop {payload.stopPrice:.2f}",
         )
         db.commit()
-        return {
-            "symbol": payload.symbol.upper(),
-            "entry": payload.entry,
-            "finalStop": payload.stopPrice,
-            "perShareRisk": per_share_risk,
-            "shares": shares,
-            "dollarRisk": round(setup.accountEquity * (payload.riskPct / 100), 2),
-        }
+        return TradePreviewResponse(
+            symbol=payload.symbol.upper(),
+            entry=preview_entry,
+            finalStop=payload.stopPrice,
+            perShareRisk=per_share_risk,
+            shares=shares,
+            dollarRisk=round(setup.accountEquity * (payload.riskPct / 100), 2),
+            sizingWarning=sizing_warning,
+            orderType=order.orderType,
+            timeInForce=order.timeInForce,
+            orderClass=order.orderClass,
+        )
 
     async def enter_trade(self, db: Session, payload: TradeEnterRequest) -> PositionView:
         symbol = payload.symbol.upper()
         setup = self.get_setup(db, symbol)
-        self._validate_stop(payload.entry, payload.stopPrice)
+        order = self._normalize_entry_order(payload.order, payload.entry, payload.stopPrice)
+        self._validate_entry_order(order, setup.sessionState)
+        preview_entry = self._preview_entry_price(payload.entry, order)
+        self._validate_stop(preview_entry, payload.stopPrice)
         self._validate_tranche_modes(payload.trancheCount, payload.trancheModes)
-        self._enforce_risk_checks(db, symbol, payload.entry, setup.shares)
-        qtys = self._split_shares(setup.shares, payload.trancheCount)
+        shares = self._calculate_shares(
+            setup.accountEquity,
+            setup.accountBuyingPower,
+            preview_entry,
+            setup.riskPct,
+            round(preview_entry - payload.stopPrice, 2),
+        )
+        if shares <= 0:
+            raise ValueError(
+                "Calculated shares is zero for this setup. Increase risk or choose a tighter valid stop."
+            )
+        self._enforce_risk_checks(db, symbol, preview_entry, shares)
+        qtys = self._split_shares(shares, payload.trancheCount, payload.trancheModes)
         session_state = setup.sessionState
         enforce_alpaca_offhours = setup.executionProvider == "alpaca_paper"
         entry_message: str
         broker_status = "PENDING"
-        root_order_type = "MKT"
-        if session_state == "regular_open" or not enforce_alpaca_offhours:
-            broker = self.broker.place_market_order(symbol, setup.shares, "buy")
-            entry_filled = True
+        root_order_type = self._local_entry_order_type(order)
+        order_for_broker = self._build_broker_entry_order(
+            symbol, shares, order, payload.offHoursMode, session_state, enforce_alpaca_offhours
+        )
+        broker = self.broker.place_entry_order(order_for_broker)
+        broker_status = broker.status or "PENDING"
+        entry_filled = self._entry_should_start_filled(
+            order_for_broker, broker_status, session_state, enforce_alpaca_offhours
+        )
+        if payload.offHoursMode == "queue_for_open":
+            broker_status = "PENDING"
+            entry_filled = False
+        if entry_filled and order_for_broker.order_type == "market":
             try:
-                self.broker.wait_for_position(symbol, min_qty=setup.shares, timeout_seconds=5.0)
+                self.broker.wait_for_position(symbol, min_qty=shares, timeout_seconds=5.0)
                 broker_status = "FILLED"
             except ValueError:
                 entry_filled = False
                 broker_status = "PENDING"
-            entry_message = f"Trade entered: Buy {setup.shares} sh {symbol} @ {payload.entry:.2f} (Alpaca paper)"
+        if payload.offHoursMode == "queue_for_open":
+            entry_message = "Market closed. Order accepted and queued for the next regular session."
+        elif order_for_broker.extended_hours:
+            entry_message = "Extended-hours limit order submitted."
         else:
-            if payload.offHoursMode not in {"queue_for_open", "extended_hours_limit"}:
-                raise ValueError(
-                    "Market is outside the regular session. Choose Queue For Open or Submit Extended-Hours Limit."
-                )
-            if payload.offHoursMode == "queue_for_open":
-                broker = self.broker.place_market_order(symbol, setup.shares, "buy")
-                entry_filled = False
-                broker_status = "PENDING"
-                entry_message = (
-                    "Market closed. Order accepted and queued for the next regular session."
-                )
-            else:
-                broker = self.broker.place_limit_order(
-                    symbol,
-                    setup.shares,
-                    payload.entry,
-                    side="buy",
-                    time_in_force="day",
-                    extended_hours=True,
-                )
-                root_order_type = "LMT"
-                entry_filled = True
-                try:
-                    self.broker.wait_for_position(symbol, min_qty=setup.shares, timeout_seconds=5.0)
-                    broker_status = "FILLED"
-                except ValueError:
-                    entry_filled = False
-                    broker_status = "PENDING"
-                entry_message = (
-                    "Extended-hours limit order submitted. It will only execute if the limit can trade during "
-                    "Alpaca's supported extended session."
-                )
+            entry_message = (
+                f"Trade entered: Buy {shares} sh {symbol} {order_for_broker.order_type.upper()} "
+                f"{order_for_broker.time_in_force.upper()} @ {preview_entry:.2f}"
+            )
         tranches = [
             Tranche(
                 id=f"T{i+1}",
@@ -199,16 +235,19 @@ class CockpitService:
             position = PositionEntity(
                 symbol=symbol,
                 phase="trade_entered" if entry_filled else "entry_pending",
-                entry_price=payload.entry,
+                entry_price=preview_entry,
                 live_price=setup.last,
-                shares=setup.shares,
+                shares=shares,
                 stop_ref=payload.stopRef,
                 stop_price=payload.stopPrice,
                 tranche_count=payload.trancheCount,
                 tranche_modes=[item.model_dump() for item in payload.trancheModes],
                 stop_modes=[StopMode().model_dump() for _ in range(3)],
                 tranches=tranches,
-                setup_snapshot=setup.model_dump(mode="json"),
+                setup_snapshot={
+                    **setup.model_dump(mode="json"),
+                    "entryOrder": order.model_dump(mode="json"),
+                },
                 root_order_id=root_order_id,
                 created_at=utcnow(),
                 updated_at=utcnow(),
@@ -216,16 +255,19 @@ class CockpitService:
             db.add(position)
         else:
             position.phase = "trade_entered" if entry_filled else "entry_pending"
-            position.entry_price = payload.entry
+            position.entry_price = preview_entry
             position.live_price = setup.last
-            position.shares = setup.shares
+            position.shares = shares
             position.stop_ref = payload.stopRef
             position.stop_price = payload.stopPrice
             position.tranche_count = payload.trancheCount
             position.tranche_modes = [item.model_dump() for item in payload.trancheModes]
             position.stop_modes = [StopMode().model_dump() for _ in range(3)]
             position.tranches = tranches
-            position.setup_snapshot = setup.model_dump(mode="json")
+            position.setup_snapshot = {
+                **setup.model_dump(mode="json"),
+                "entryOrder": order.model_dump(mode="json"),
+            }
             position.root_order_id = root_order_id
             position.updated_at = utcnow()
             position.closed_at = None
@@ -235,16 +277,16 @@ class CockpitService:
                 broker_order_id=broker.broker_order_id,
                 symbol=symbol,
                 type=root_order_type,
-                qty=setup.shares,
-                orig_qty=setup.shares,
-                price=payload.entry,
+                qty=shares,
+                orig_qty=shares,
+                price=preview_entry,
                 status="FILLED" if entry_filled else broker_status,
                 tranche_label=symbol,
                 covered_tranches=[],
                 parent_id=None,
                 created_at=utcnow(),
                 filled_at=utcnow() if entry_filled else None,
-                fill_price=payload.entry if entry_filled else None,
+                fill_price=preview_entry if entry_filled else None,
             )
         )
         if entry_filled:
@@ -387,6 +429,9 @@ class CockpitService:
                 )
                 tranche["status"] = "sold"
                 tranche["target"] = target
+                tranche["exitPrice"] = target
+                tranche["exitFilledAt"] = utcnow().isoformat()
+                tranche["exitOrderType"] = "LMT"
                 self._reduce_stop_orders(db, position.symbol, tranche["id"], tranche["qty"])
                 phase = "P1_done" if index == 0 else "P2_done"
                 executed_count += 1
@@ -498,6 +543,9 @@ class CockpitService:
                 )
                 tranche["status"] = "sold"
                 tranche["target"] = position.live_price
+                tranche["exitPrice"] = position.live_price
+                tranche["exitFilledAt"] = utcnow().isoformat()
+                tranche["exitOrderType"] = "MKT"
             updated_tranches.append(tranche)
         position.tranches = updated_tranches
         position.phase = "closed"
@@ -515,16 +563,23 @@ class CockpitService:
         return view
 
     def get_positions(self, db: Session) -> list[PositionView]:
+        self._reconcile_all_positions(db)
         positions = db.scalars(
             select(PositionEntity).order_by(PositionEntity.created_at.desc())
         ).all()
         return [self._position_view(db, position) for position in positions]
 
     def get_position(self, db: Session, symbol: str) -> PositionView:
-        return self._position_view(db, self._require_position(db, symbol))
+        position = self._require_position(db, symbol)
+        if self._reconcile_position(db, position):
+            db.commit()
+        return self._position_view(db, position)
 
     def get_orders(self, db: Session, symbol: str) -> list[OrderView]:
         position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == symbol.upper()))
+        if position is not None:
+            if self._reconcile_position(db, position):
+                db.commit()
         if position is not None and position.root_order_id:
             rows = db.scalars(
                 select(OrderEntity)
@@ -542,6 +597,72 @@ class CockpitService:
                 .order_by(OrderEntity.created_at.asc())
             ).all()
         return [self._order_view(row) for row in rows]
+
+    def get_recent_orders(self, db: Session, limit: int = 50) -> list[OrderView]:
+        broker_orders_by_symbol = self._recent_broker_orders_by_symbol(limit=max(limit, 100))
+        self._reconcile_all_positions(db, broker_orders_by_symbol)
+        try:
+            broker_payloads = self.broker.list_recent_orders(limit=limit)
+        except ValueError:
+            broker_payloads = []
+        broker_orders = {
+            order["id"]: order
+            for order in broker_payloads
+            if isinstance(order, dict) and order.get("id")
+        }
+        rows = db.scalars(
+            select(OrderEntity).order_by(OrderEntity.created_at.desc()).limit(limit * 3)
+        ).all()
+        merged: list[OrderView] = []
+        seen_broker_ids: set[str] = set()
+        for row in rows:
+            broker_payload = broker_orders.get(row.broker_order_id or "")
+            if broker_payload is not None:
+                seen_broker_ids.add(str(broker_payload.get("id")))
+            merged.append(self._order_view(row, broker_payload))
+        for broker_order_id, broker_payload in broker_orders.items():
+            if broker_order_id in seen_broker_ids:
+                continue
+            merged.append(self._broker_order_view(broker_payload))
+        merged.sort(
+            key=lambda item: (
+                item.updatedAt
+                or item.filledAt
+                or item.createdAt
+                or datetime.min.replace(tzinfo=UTC)
+            ),
+            reverse=True,
+        )
+        return merged[:limit]
+
+    def cancel_recent_order(self, db: Session, broker_order_id: str) -> OrderView:
+        broker_order = self.broker.get_order(broker_order_id)
+        if broker_order is None:
+            raise ValueError("Broker order was not found.")
+        if not self._broker_order_cancelable(broker_order):
+            raise ValueError("Broker order is no longer cancelable.")
+        self.broker.cancel_order(broker_order_id)
+        refreshed = self.broker.get_order(broker_order_id) or {**broker_order, "status": "canceled"}
+        local_orders = db.scalars(
+            select(OrderEntity).where(OrderEntity.broker_order_id == broker_order_id)
+        ).all()
+        for local in local_orders:
+            local.status = str(refreshed.get("status", "canceled")).upper()
+        self._reconcile_canceled_root_orders(db, local_orders)
+        if local_orders:
+            self._log(
+                db,
+                local_orders[0].symbol,
+                "warn",
+                f"Canceled broker order {broker_order_id} for {local_orders[0].symbol}.",
+            )
+        db.commit()
+        local = local_orders[0] if local_orders else None
+        return (
+            self._order_view(local, refreshed)
+            if local is not None
+            else self._broker_order_view(refreshed)
+        )
 
     def get_logs(self, db: Session) -> list[LogEntry]:
         self.ensure_seed_data(db)
@@ -566,6 +687,7 @@ class CockpitService:
             return
         position.live_price = round(max(0.01, position.live_price + uniform(-0.35, 0.35)), 2)
         position.updated_at = utcnow()
+        self._reconcile_position(db, position)
         db.commit()
         base = position.entry_price
         await self.ws_manager.broadcast(
@@ -580,14 +702,215 @@ class CockpitService:
                 delta_pct=round(((position.live_price - base) / base) * 100, 2) if base else 0.0,
             ),
         )
+        view = self._position_view(db, position)
+        await self._broadcast_position_bundle(db, view)
+
+    def _reconcile_all_positions(
+        self,
+        db: Session,
+        broker_orders_by_symbol: dict[str, dict[str, dict]] | None = None,
+    ) -> None:
+        changed = False
+        for position in db.scalars(select(PositionEntity)).all():
+            symbol_orders = None
+            if broker_orders_by_symbol is not None:
+                symbol_orders = broker_orders_by_symbol.get(position.symbol.upper(), {})
+            changed = self._reconcile_position(db, position, symbol_orders) or changed
+        if changed:
+            db.commit()
+
+    def _reconcile_position(
+        self,
+        db: Session,
+        position: PositionEntity,
+        broker_orders: dict[str, dict] | None = None,
+    ) -> bool:
+        changed = False
+        symbol_orders = (
+            broker_orders
+            if broker_orders is not None
+            else self._broker_orders_for_symbol(position.symbol)
+        )
+        root_order = db.scalar(
+            select(OrderEntity).where(OrderEntity.order_id == position.root_order_id)
+        )
+        if position.phase == "entry_pending" and root_order is not None:
+            root_payload = symbol_orders.get(root_order.broker_order_id or "")
+            if root_payload is not None and str(root_payload.get("status", "")).lower() == "filled":
+                self._mark_entry_filled_if_ready(db, position)
+                root_order.fill_price = (
+                    self._broker_fill_price(root_payload, root_order.fill_price)
+                    or position.entry_price
+                )
+                root_order.filled_at = (
+                    self._broker_timestamp(root_payload, "filled_at")
+                    or root_order.filled_at
+                    or utcnow()
+                )
+                changed = True
+        exit_orders = db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == position.symbol,
+                OrderEntity.type.in_(["STOP", "TRAIL"]),
+                OrderEntity.status.in_(["ACTIVE", "MODIFIED", "NEW", "ACCEPTED"]),
+            )
+        ).all()
+        for order in exit_orders:
+            fill_details = self._resolve_exit_fill(
+                position, order, symbol_orders.get(order.broker_order_id or "")
+            )
+            if fill_details is None:
+                continue
+            changed = self._apply_exit_fill(db, position, order, fill_details) or changed
+        return changed
+
+    def _recent_broker_orders_by_symbol(self, limit: int = 100) -> dict[str, dict[str, dict]]:
+        try:
+            recent = self.broker.list_recent_orders(limit=limit)
+        except ValueError:
+            return {}
+        grouped: dict[str, dict[str, dict]] = {}
+        for order in recent:
+            if not isinstance(order, dict):
+                continue
+            symbol = str(order.get("symbol") or "").upper()
+            broker_order_id = str(order.get("id") or "")
+            if not symbol or not broker_order_id:
+                continue
+            grouped.setdefault(symbol, {})[broker_order_id] = order
+        return grouped
+
+    def _broker_orders_for_symbol(self, symbol: str) -> dict[str, dict]:
+        return dict(self._recent_broker_orders_by_symbol(limit=100).get(symbol.upper(), {}))
+
+    def _resolve_exit_fill(
+        self,
+        position: PositionEntity,
+        order: OrderEntity,
+        broker_payload: dict | None,
+    ) -> dict[str, object] | None:
+        if broker_payload is not None:
+            status = str(broker_payload.get("status") or "").lower()
+            if status == "canceled":
+                order.status = "CANCELED"
+                return None
+            if status not in {"filled", "partially_filled"}:
+                return None
+            return {
+                "status": status.upper(),
+                "fill_price": self._broker_fill_price(broker_payload, order.fill_price)
+                or order.price,
+                "filled_at": self._broker_timestamp(broker_payload, "filled_at") or utcnow(),
+                "filled_qty": max(0, self._broker_filled_qty(broker_payload) or order.orig_qty),
+            }
+        if order.status not in {"ACTIVE", "MODIFIED"}:
+            return None
+        if position.phase == "entry_pending":
+            return None
+        if position.live_price > order.price:
+            return None
+        return {
+            "status": "FILLED",
+            "fill_price": order.price,
+            "filled_at": utcnow(),
+            "filled_qty": order.orig_qty,
+        }
+
+    def _apply_exit_fill(
+        self,
+        db: Session,
+        position: PositionEntity,
+        order: OrderEntity,
+        fill_details: dict[str, object],
+    ) -> bool:
+        active_ids = {
+            tranche["id"] for tranche in position.tranches if tranche["status"] == "active"
+        }
+        covered = [
+            tranche_id
+            for tranche_id in (
+                order.covered_tranches
+                or ([order.tranche_label] if order.tranche_label.startswith("T") else [])
+            )
+            if tranche_id in active_ids
+        ]
+        if not covered:
+            order.status = str(fill_details["status"])
+            order.fill_price = float(fill_details["fill_price"])
+            order.filled_at = fill_details["filled_at"]  # type: ignore[assignment]
+            return True
+        tranches = deepcopy(position.tranches)
+        filled_at = fill_details["filled_at"]
+        fill_price = float(fill_details["fill_price"])
+        for tranche in tranches:
+            if tranche["id"] not in covered or tranche["status"] != "active":
+                continue
+            tranche["status"] = "sold"
+            tranche["target"] = fill_price
+            tranche["exitPrice"] = fill_price
+            tranche["exitFilledAt"] = (
+                filled_at.isoformat() if isinstance(filled_at, datetime) else str(filled_at)
+            )
+            tranche["exitOrderType"] = order.type
+        order.status = str(fill_details["status"])
+        order.fill_price = fill_price
+        order.filled_at = filled_at if isinstance(filled_at, datetime) else utcnow()
+        position.tranches = tranches
+        position.phase = self._phase_from_tranches(position, tranches)
+        position.updated_at = utcnow()
+        if position.phase == "closed":
+            position.closed_at = position.closed_at or utcnow()
+        else:
+            position.closed_at = None
+        verb = "Stop hit" if order.type == "STOP" else "Runner stop filled"
+        self._log(
+            db,
+            position.symbol,
+            "warn" if order.type == "STOP" else "exec",
+            f"{verb}: {' · '.join(covered)} @ {fill_price:.2f}",
+        )
+        db.flush()
+        return True
+
+    def _phase_from_tranches(self, position: PositionEntity, tranches: list[dict]) -> str:
+        active = [tranche for tranche in tranches if tranche["status"] == "active"]
+        if not active:
+            return "closed"
+        runner_active = any(tranche.get("mode") == "runner" for tranche in active)
+        sold_count = sum(1 for tranche in tranches if tranche["status"] == "sold")
+        if runner_active and len(active) == 1:
+            return "runner_only"
+        if sold_count >= 2:
+            return "P2_done"
+        if sold_count >= 1:
+            return "P1_done"
+        return "protected"
 
     def _build_setup_response(
-        self, market: SetupMarketData, equity: float, risk_pct: float
+        self,
+        market: SetupMarketData,
+        equity: float,
+        buying_power: float,
+        risk_pct: float,
+        equity_source: str,
+        cash: float | None = None,
     ) -> SetupResponse:
         entry = round((market.bid + market.ask) / 2, 2)
-        final_stop = market.lod
-        per_share_risk = round(max(0.01, entry - final_stop), 2)
-        shares = self._calculate_shares(equity, risk_pct, per_share_risk)
+        lod_stop = round(market.lod, 2)
+        atr_stop = round(max(0.01, entry - market.atr14), 2)
+        lod_is_valid = lod_stop < entry
+        atr_is_valid = 0 < atr_stop < entry
+        stop_reference_default = "lod" if lod_is_valid else "manual"
+        final_stop = lod_stop if lod_is_valid else 0.0
+        manual_stop_warning = (
+            None
+            if lod_is_valid
+            else "Low of day is above the current entry price. Enter a manual stop for this setup."
+        )
+        per_share_risk = round(entry - final_stop, 2) if lod_is_valid else 0.0
+        shares = self._calculate_shares(equity, buying_power, entry, risk_pct, per_share_risk)
+        sizing_warning = self._sizing_warning(buying_power, entry, shares)
+        buying_power_note = self._buying_power_note(equity, buying_power, cash, equity_source)
         return SetupResponse(
             symbol=market.symbol,
             provider=market.provider,
@@ -601,8 +924,13 @@ class CockpitService:
             quoteTimestamp=market.quote_timestamp,
             sessionState=market.session_state,
             quoteState=market.quote_state,
-            entryBasis="bid_ask_midpoint",
-            stopReferenceDefault="lod",
+            entryBasis=market.entry_basis,
+            stopReferenceDefault=stop_reference_default,
+            lodIsValid=lod_is_valid,
+            atrIsValid=atr_is_valid,
+            lodStop=lod_stop,
+            atrStop=atr_stop,
+            manualStopWarning=manual_stop_warning,
             bid=market.bid,
             ask=market.ask,
             last=market.last,
@@ -618,32 +946,112 @@ class CockpitService:
             days_to_cover=market.days_to_cover,
             entry=entry,
             finalStop=final_stop,
-            r1=round(entry + per_share_risk, 2),
-            r2=round(entry + per_share_risk * 2, 2),
-            r3=round(entry + per_share_risk * 3, 2),
+            r1=round(entry + per_share_risk, 2) if per_share_risk > 0 else entry,
+            r2=round(entry + per_share_risk * 2, 2) if per_share_risk > 0 else entry,
+            r3=round(entry + per_share_risk * 3, 2) if per_share_risk > 0 else entry,
             shares=shares,
             dollarRisk=round(equity * (risk_pct / 100), 2),
             perShareRisk=per_share_risk,
             riskPct=risk_pct,
             accountEquity=equity,
+            accountBuyingPower=buying_power,
+            accountCash=cash,
+            equitySource=equity_source,
+            sizingWarning=sizing_warning,
+            buyingPowerNote=buying_power_note,
             atrExtension=round((entry - market.sma50) / market.atr14, 2),
             extFrom10Ma=round(((entry - market.sma10) / market.sma10) * 100, 2),
         )
 
-    def _calculate_shares(self, equity: float, risk_pct: float, per_share_risk: float) -> int:
-        if per_share_risk <= 0:
+    def _calculate_shares(
+        self,
+        equity: float,
+        buying_power: float,
+        entry: float,
+        risk_pct: float,
+        per_share_risk: float,
+    ) -> int:
+        if per_share_risk <= 0 or entry <= 0:
             return 0
-        return max(1, floor((equity * (risk_pct / 100)) / per_share_risk))
+        risk_budget = floor((equity * (risk_pct / 100)) / per_share_risk)
+        max_notional = equity * (self.settings.max_position_notional_pct / 100)
+        effective_notional_cap = (
+            min(buying_power, max_notional) if buying_power > 0 else max_notional
+        )
+        buying_power_cap = (
+            floor(effective_notional_cap / entry) if effective_notional_cap > 0 else 0
+        )
+        capped = min(risk_budget, buying_power_cap)
+        return max(0, capped)
 
-    def _split_shares(self, shares: int, count: int) -> list[int]:
+    def _sizing_warning(self, buying_power: float, entry: float, shares: int) -> str | None:
+        if entry > 0 and buying_power > 0 and buying_power < entry:
+            return "Insufficient buying power to fund even one share at the current entry price."
+        if buying_power <= 0:
+            return "Broker buying power is unavailable or zero."
+        if shares <= 0:
+            return "Calculated shares is zero for this setup."
+        return None
+
+    def _buying_power_note(
+        self,
+        equity: float,
+        buying_power: float,
+        cash: float | None,
+        equity_source: str,
+    ) -> str | None:
+        if equity_source != "alpaca_account":
+            return None
+        if buying_power <= 0:
+            return "Live broker buying power is unavailable or fully reserved by current Alpaca paper orders or positions."
+        if cash is not None and buying_power <= cash:
+            return "Live broker buying power is currently limited by open or pending Alpaca paper orders and positions."
+        if equity > 0 and buying_power < equity * 0.25:
+            return "Live broker buying power is currently much lower than equity because Alpaca is reserving capital for open or pending paper orders."
+        return None
+
+    def _split_shares(
+        self,
+        shares: int,
+        count: int,
+        tranche_modes: list[TrancheMode] | None = None,
+    ) -> list[int]:
         if count <= 1:
             return [shares]
-        if count == 2:
-            first = shares // 2
-            return [first, shares - first]
-        first = floor(shares * 0.33)
-        second = floor(shares * 0.33)
-        return [first, second, shares - first - second]
+        if shares <= 0:
+            return [0 for _ in range(count)]
+        if not tranche_modes:
+            tranche_modes = []
+        allocations = self._normalize_allocation_pcts(tranche_modes, count)
+        raw_shares = [shares * (allocation / 100.0) for allocation in allocations]
+        assigned = [floor(value) for value in raw_shares]
+        remainder = shares - sum(assigned)
+        remainders = sorted(
+            ((raw_shares[index] - assigned[index], index) for index in range(count)),
+            key=lambda item: (-item[0], item[1]),
+        )
+        for _, index in remainders[:remainder]:
+            assigned[index] += 1
+        return assigned
+
+    def _normalize_allocation_pcts(
+        self, tranche_modes: list[TrancheMode], count: int
+    ) -> list[float]:
+        active = tranche_modes[:count]
+        if count == 1:
+            return [100.0]
+        default = 100.0 / count
+        provided = [
+            mode.allocationPct if mode.allocationPct is not None else default for mode in active
+        ]
+        total = sum(provided)
+        if total <= 0:
+            return [round(default, 2) for _ in range(count - 1)] + [
+                round(100.0 - round(default, 2) * (count - 1), 2)
+            ]
+        normalized = [round((value / total) * 100.0, 2) for value in provided]
+        normalized[-1] = round(100.0 - sum(normalized[:-1]), 2)
+        return normalized
 
     def _stop_groups(self, tranches: list[dict], stop_mode: int) -> list[list[dict]]:
         active = [tranche for tranche in tranches if tranche["status"] == "active"]
@@ -706,6 +1114,159 @@ class CockpitService:
         ).all()
         if active:
             raise ValueError("Duplicate active orders exist for this symbol")
+
+    def _normalize_entry_order(
+        self, order: EntryOrderDraft, entry: float, protective_stop: float
+    ) -> EntryOrderDraft:
+        normalized = order.model_copy(deep=True)
+        if normalized.orderType in {"limit", "stop_limit"} and normalized.limitPrice is None:
+            normalized.limitPrice = round(entry, 2)
+        if normalized.orderType == "stop" and normalized.stopPrice is None:
+            normalized.stopPrice = round(entry, 2)
+        if normalized.orderType == "stop_limit" and normalized.stopPrice is None:
+            normalized.stopPrice = round(entry, 2)
+        if normalized.orderClass in {"bracket", "oco"}:
+            normalized.takeProfit = normalized.takeProfit or TakeProfitDraft(
+                limitPrice=round(entry + max(entry - protective_stop, 0.01), 2)
+            )
+            normalized.stopLoss = normalized.stopLoss or StopLossDraft(
+                stopPrice=protective_stop, limitPrice=None
+            )
+        if normalized.orderClass == "oto":
+            if normalized.otoExitSide == "take_profit":
+                normalized.takeProfit = normalized.takeProfit or TakeProfitDraft(
+                    limitPrice=round(entry + max(entry - protective_stop, 0.01), 2)
+                )
+                normalized.stopLoss = None
+            else:
+                normalized.stopLoss = normalized.stopLoss or StopLossDraft(
+                    stopPrice=protective_stop, limitPrice=None
+                )
+                normalized.takeProfit = None
+        return normalized
+
+    def _preview_entry_price(self, entry: float, order: EntryOrderDraft) -> float:
+        if order.orderType == "stop" and order.stopPrice is not None:
+            return round(order.stopPrice, 2)
+        if order.orderType == "stop_limit" and order.limitPrice is not None:
+            return round(order.limitPrice, 2)
+        if order.limitPrice is not None and order.orderType == "limit":
+            return round(order.limitPrice, 2)
+        return round(entry, 2)
+
+    def _validate_entry_order(self, order: EntryOrderDraft, session_state: str) -> None:
+        valid_tif_by_type = {
+            "market": {"day", "gtc", "ioc", "fok", "opg", "cls"},
+            "limit": {"day", "gtc", "ioc", "fok", "opg", "cls"},
+            "stop": {"day", "gtc"},
+            "stop_limit": {"day", "gtc"},
+        }
+        if order.timeInForce not in valid_tif_by_type[order.orderType]:
+            raise ValueError(
+                f"{order.orderType.upper()} orders do not support {order.timeInForce.upper()} time-in-force."
+            )
+        if order.orderType in {"limit", "stop_limit"} and (
+            order.limitPrice is None or order.limitPrice <= 0
+        ):
+            raise ValueError("Limit price is required for limit and stop-limit entries.")
+        if order.orderType in {"stop", "stop_limit"} and (
+            order.stopPrice is None or order.stopPrice <= 0
+        ):
+            raise ValueError("Stop trigger price is required for stop and stop-limit entries.")
+        if order.extendedHours:
+            if order.orderType != "limit" or order.timeInForce not in {"day", "gtc"}:
+                raise ValueError("Extended-hours entries must be LIMIT with DAY or GTC.")
+            if order.orderClass != "simple":
+                raise ValueError("Extended-hours is only available for simple limit entries.")
+        if order.orderClass == "oco":
+            raise ValueError(
+                "OCO is an exit-only Alpaca order class and cannot be used for a new entry."
+            )
+        if order.orderClass == "bracket":
+            if not order.takeProfit or order.takeProfit.limitPrice is None:
+                raise ValueError("Bracket orders require a take-profit limit price.")
+            if not order.stopLoss or order.stopLoss.stopPrice is None:
+                raise ValueError("Bracket orders require a stop-loss stop price.")
+        if order.orderClass == "oto":
+            if order.otoExitSide == "take_profit":
+                if not order.takeProfit or order.takeProfit.limitPrice is None:
+                    raise ValueError("OTO take-profit orders require a take-profit limit price.")
+            else:
+                if not order.stopLoss or order.stopLoss.stopPrice is None:
+                    raise ValueError("OTO stop-loss orders require a stop-loss stop price.")
+        if order.orderClass in {"bracket", "oto"} and order.timeInForce not in {"day", "gtc"}:
+            raise ValueError("Attached exit orders require DAY or GTC time-in-force.")
+        if (
+            session_state != "regular_open"
+            and order.orderType == "market"
+            and order.timeInForce in {"opg", "cls"}
+        ):
+            raise ValueError("Auction-only orders are unavailable outside the regular session.")
+
+    def _build_broker_entry_order(
+        self,
+        symbol: str,
+        shares: int,
+        order: EntryOrderDraft,
+        off_hours_mode: str | None,
+        session_state: str,
+        enforce_alpaca_offhours: bool,
+    ) -> BrokerEntryOrder:
+        extended_hours = False
+        order_type = order.orderType
+        tif = order.timeInForce
+        limit_price = order.limitPrice
+        if session_state != "regular_open" and enforce_alpaca_offhours:
+            if off_hours_mode == "queue_for_open":
+                order_type = "market"
+                tif = "day"
+            elif off_hours_mode == "extended_hours_limit":
+                order_type = "limit"
+                tif = "day"
+                extended_hours = True
+            elif order.orderType == "market":
+                raise ValueError(
+                    "Market is outside the regular session. Choose Queue For Open or Submit Extended-Hours Limit."
+                )
+        stop_loss = order.stopLoss
+        take_profit = order.takeProfit
+        return BrokerEntryOrder(
+            symbol=symbol,
+            qty=shares,
+            side="buy",
+            order_type=order_type,
+            time_in_force=tif,
+            limit_price=limit_price,
+            stop_price=order.stopPrice,
+            order_class=order.orderClass,
+            extended_hours=extended_hours or order.extendedHours,
+            take_profit_limit_price=take_profit.limitPrice if take_profit else None,
+            stop_loss_stop_price=stop_loss.stopPrice if stop_loss else None,
+            stop_loss_limit_price=stop_loss.limitPrice if stop_loss else None,
+        )
+
+    def _entry_should_start_filled(
+        self,
+        order: BrokerEntryOrder,
+        broker_status: str,
+        session_state: str,
+        enforce_alpaca_offhours: bool,
+    ) -> bool:
+        if broker_status.upper() == "FILLED":
+            return True
+        if enforce_alpaca_offhours and session_state != "regular_open":
+            return False
+        return order.order_class == "simple" and order.order_type == "market"
+
+    def _local_entry_order_type(self, order: EntryOrderDraft) -> str:
+        if order.orderClass != "simple":
+            return order.orderClass.upper()
+        return {
+            "market": "MKT",
+            "limit": "LMT",
+            "stop": "STOP",
+            "stop_limit": "STPLMT",
+        }[order.orderType]
 
     def _validate_stop(self, entry: float, stop_price: float) -> None:
         if stop_price >= entry:
@@ -787,6 +1348,31 @@ class CockpitService:
                 self.broker.cancel_order(order.broker_order_id)
             order.status = "CANCELED"
         if active_orders:
+            db.flush()
+
+    def _reconcile_canceled_root_orders(self, db: Session, local_orders: list[OrderEntity]) -> None:
+        for local in local_orders:
+            if local.parent_id is not None:
+                continue
+            position = db.scalar(
+                select(PositionEntity).where(PositionEntity.symbol == local.symbol)
+            )
+            if position is None or position.root_order_id != local.order_id:
+                continue
+            if position.phase != "entry_pending":
+                continue
+            position.phase = "closed"
+            position.closed_at = utcnow()
+            position.updated_at = utcnow()
+            position.tranches = [
+                {**tranche, "status": "canceled"} for tranche in deepcopy(position.tranches)
+            ]
+            siblings = db.scalars(
+                select(OrderEntity).where(OrderEntity.symbol == local.symbol)
+            ).all()
+            for sibling in siblings:
+                if sibling.status in {"ACTIVE", "MODIFIED", "PENDING", "ACCEPTED"}:
+                    sibling.status = "CANCELED"
             db.flush()
 
     def _mark_entry_filled_if_ready(self, db: Session, position: PositionEntity) -> None:
@@ -911,21 +1497,81 @@ class CockpitService:
         next_seq = max(persisted_max, pending_max) + 1
         return f"ORD-{next_seq:04d}"
 
-    def _order_view(self, row: OrderEntity) -> OrderView:
+    def _order_view(self, row: OrderEntity, broker_payload: dict | None = None) -> OrderView:
+        filled_qty = (
+            self._broker_filled_qty(broker_payload)
+            if broker_payload
+            else (row.orig_qty if row.filled_at else 0)
+        )
+        remaining_qty = self._broker_remaining_qty(
+            broker_payload, row.qty, row.orig_qty, filled_qty
+        )
+        side = self._broker_side(broker_payload) or self._local_order_side(row)
+        status = (
+            str(broker_payload.get("status", row.status)).upper() if broker_payload else row.status
+        )
+        price = self._broker_price(broker_payload, row.price) if broker_payload else row.price
         return OrderView(
             id=row.order_id,
+            symbol=row.symbol,
+            side=side,
             type=row.type,
             qty=row.qty,
             origQty=row.orig_qty,
-            price=row.price,
-            status=row.status,
+            filledQty=filled_qty,
+            remainingQty=remaining_qty,
+            price=price,
+            status=status,
             tranche=row.tranche_label,
             coveredTranches=list(row.covered_tranches or []),
             parentId=row.parent_id,
             brokerOrderId=row.broker_order_id,
+            cancelable=(
+                self._broker_order_cancelable(broker_payload)
+                if broker_payload
+                else row.status in {"ACTIVE", "MODIFIED", "PENDING"}
+            ),
             createdAt=row.created_at,
+            updatedAt=(
+                self._broker_timestamp(broker_payload, "updated_at")
+                if broker_payload
+                else row.filled_at or row.created_at
+            ),
             filledAt=row.filled_at,
-            fillPrice=row.fill_price,
+            fillPrice=(
+                self._broker_fill_price(broker_payload, row.fill_price)
+                if broker_payload
+                else row.fill_price
+            ),
+        )
+
+    def _broker_order_view(self, broker_payload: dict) -> OrderView:
+        order_id = str(
+            broker_payload.get("client_order_id") or broker_payload.get("id") or "BROKER"
+        )
+        qty = self._broker_qty(broker_payload)
+        filled_qty = self._broker_filled_qty(broker_payload)
+        remaining_qty = max(0, qty - filled_qty)
+        return OrderView(
+            id=order_id,
+            symbol=str(broker_payload.get("symbol") or ""),
+            side=self._broker_side(broker_payload),
+            type=str(broker_payload.get("type") or "").upper(),
+            qty=qty,
+            origQty=qty,
+            filledQty=filled_qty,
+            remainingQty=remaining_qty,
+            price=self._broker_price(broker_payload, 0.0),
+            status=str(broker_payload.get("status") or "").upper(),
+            tranche="BROKER",
+            coveredTranches=[],
+            parentId=None,
+            brokerOrderId=str(broker_payload.get("id") or ""),
+            cancelable=self._broker_order_cancelable(broker_payload),
+            createdAt=self._broker_timestamp(broker_payload, "created_at"),
+            updatedAt=self._broker_timestamp(broker_payload, "updated_at"),
+            filledAt=self._broker_timestamp(broker_payload, "filled_at"),
+            fillPrice=self._broker_fill_price(broker_payload, None),
         )
 
     def _position_view(self, db: Session, row: PositionEntity) -> PositionView:
@@ -958,3 +1604,90 @@ class CockpitService:
             tranche.qty for tranche in position.tranches if tranche.status == "active"
         )
         return round((position.livePrice - entry) * active_shares, 2)
+
+    def _broker_timestamp(self, payload: dict | None, key: str) -> datetime | None:
+        if not payload:
+            return None
+        raw = payload.get(key)
+        if not raw:
+            return None
+        try:
+            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+    def _broker_qty(self, payload: dict | None) -> int:
+        if not payload:
+            return 0
+        try:
+            return int(float(payload.get("qty") or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def _broker_filled_qty(self, payload: dict | None) -> int:
+        if not payload:
+            return 0
+        try:
+            return int(float(payload.get("filled_qty") or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def _broker_remaining_qty(
+        self, payload: dict | None, qty: int, orig_qty: int, filled_qty: int
+    ) -> int:
+        if payload:
+            try:
+                return max(0, int(float(payload.get("qty") or qty)) - filled_qty)
+            except (TypeError, ValueError):
+                return max(0, qty - filled_qty)
+        return 0 if filled_qty >= orig_qty else qty
+
+    def _broker_price(self, payload: dict | None, fallback: float) -> float:
+        if not payload:
+            return fallback
+        for key in ("limit_price", "stop_price", "trail_price", "notional"):
+            value = payload.get(key)
+            if value not in (None, ""):
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    continue
+        return fallback
+
+    def _broker_fill_price(self, payload: dict | None, fallback: float | None) -> float | None:
+        if not payload:
+            return fallback
+        for key in ("filled_avg_price", "limit_price", "stop_price"):
+            value = payload.get(key)
+            if value not in (None, ""):
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    continue
+        return fallback
+
+    def _broker_side(self, payload: dict | None) -> str | None:
+        if not payload:
+            return None
+        side = payload.get("side")
+        return str(side).upper() if side else None
+
+    def _local_order_side(self, row: OrderEntity) -> str:
+        if row.parent_id is None:
+            return "BUY"
+        return "SELL"
+
+    def _broker_order_cancelable(self, payload: dict | None) -> bool:
+        if not payload:
+            return False
+        status = str(payload.get("status") or "").lower()
+        return status in {
+            "new",
+            "accepted",
+            "pending_new",
+            "partially_filled",
+            "accepted_for_bidding",
+            "stopped",
+            "calculated",
+        }

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -99,7 +99,9 @@ def test_postgres_urls_normalize_to_psycopg_driver() -> None:
     assert _normalize_database_url("sqlite:///./data/test.db") == "sqlite:///./data/test.db"
 
 
-def test_local_personal_paper_ready_requires_real_alpaca_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_local_personal_paper_ready_requires_real_alpaca_creds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("BROKER_MODE", "alpaca_paper")
     monkeypatch.setenv("ALLOW_LIVE_TRADING", "false")
     monkeypatch.setenv("ALPACA_API_KEY_ID", "paper-key")
@@ -110,7 +112,9 @@ def test_local_personal_paper_ready_requires_real_alpaca_creds(monkeypatch: pyte
     assert Settings.from_env().local_personal_paper_ready is False
 
 
-def test_alpaca_market_order_fails_loudly_without_mock_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_alpaca_market_order_fails_loudly_without_mock_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("BROKER_MODE", "alpaca_paper")
     monkeypatch.setenv("ALLOW_CONTROLLER_MOCK", "false")
     monkeypatch.delenv("ALPACA_API_KEY_ID", raising=False)
@@ -140,7 +144,9 @@ def test_setup_fails_loudly_when_real_quote_is_unavailable() -> None:
 
 
 def test_login_creates_session_and_me_resolves_user() -> None:
-    login = client.post("/api/auth/login", json={"username": "admin", "password": "change-me-admin"})
+    login = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "change-me-admin"}
+    )
     assert login.status_code == 200
     payload = login.json()
     assert payload["username"] == "admin"
@@ -167,7 +173,9 @@ def test_staging_cookie_settings_can_support_hosted_preview() -> None:
     routes_auth_module.settings.auth_cookie_samesite = "none"
     routes_auth_module.settings.auth_cookie_secure = True
     try:
-        login = client.post("/api/auth/login", json={"username": "admin", "password": "change-me-admin"})
+        login = client.post(
+            "/api/auth/login", json={"username": "admin", "password": "change-me-admin"}
+        )
         assert login.status_code == 200
         cookie_header = login.headers.get("set-cookie", "").lower()
         assert "samesite=none" in cookie_header
@@ -185,7 +193,9 @@ def test_sensitive_routes_require_session_when_auth_is_enabled() -> None:
         unauthenticated = client.get("/api/account")
         assert unauthenticated.status_code == 401
 
-        login = client.post("/api/auth/login", json={"username": "admin", "password": "change-me-admin"})
+        login = client.post(
+            "/api/auth/login", json={"username": "admin", "password": "change-me-admin"}
+        )
         assert login.status_code == 200
 
         authenticated = client.get("/api/account")
@@ -248,13 +258,16 @@ def test_trade_lifecycle() -> None:
     assert stops.status_code == 200
     assert stops.json()["phase"] == "protected"
 
-    profit = client.post("/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()})
+    profit = client.post(
+        "/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()}
+    )
     assert profit.status_code == 200
     profit_state = profit.json()
     assert profit_state["phase"] in {"P2_done", "runner_only", "closed"}
     assert len(profit_state["orders"]) >= 4
     assert all(
-        order["id"] == profit_state["rootOrderId"] or order.get("parentId") == profit_state["rootOrderId"]
+        order["id"] == profit_state["rootOrderId"]
+        or order.get("parentId") == profit_state["rootOrderId"]
         for order in profit_state["orders"]
     )
 
@@ -305,7 +318,9 @@ def test_three_stop_mode_defaults_to_33_33_34_when_pct_is_blank() -> None:
 
 
 def test_account_update() -> None:
-    update = client.put("/api/account/settings", json={"equity": 30000, "risk_pct": 1.5, "mode": "paper"})
+    update = client.put(
+        "/api/account/settings", json={"equity": 30000, "risk_pct": 1.5, "mode": "paper"}
+    )
     assert update.status_code == 200
     data = update.json()
     assert data["equity"] == 30000
@@ -315,7 +330,9 @@ def test_account_update() -> None:
 
 
 def test_live_mode_is_gated_by_default() -> None:
-    update = client.put("/api/account/settings", json={"equity": 30000, "risk_pct": 1.5, "mode": "alpaca_live"})
+    update = client.put(
+        "/api/account/settings", json={"equity": 30000, "risk_pct": 1.5, "mode": "alpaca_live"}
+    )
     assert update.status_code == 400
     assert "Live trading is disabled" in update.text
 
@@ -365,9 +382,13 @@ def test_runner_cannot_be_reexecuted_once_active() -> None:
             ],
         },
     )
-    first_profit = client.post("/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()})
+    first_profit = client.post(
+        "/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()}
+    )
     assert first_profit.status_code == 200
-    second_profit = client.post("/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()})
+    second_profit = client.post(
+        "/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()}
+    )
     assert second_profit.status_code == 400
     assert "Active TRAIL order already exists" in second_profit.text
 
@@ -439,7 +460,11 @@ def test_off_hours_queue_for_open_creates_pending_entry() -> None:
     def fake_setup(_db, _symbol: str):
         setup = original_get_setup(_db, "AAPL")
         return setup.model_copy(
-            update={"sessionState": "closed", "quoteState": "cached_quote", "executionProvider": "alpaca_paper"}
+            update={
+                "sessionState": "closed",
+                "quoteState": "cached_quote",
+                "executionProvider": "alpaca_paper",
+            }
         )
 
     service.get_setup = fake_setup

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -24,7 +24,13 @@ from app.adapters.market_data import SetupMarketData  # noqa: E402
 from app.db.base import Base  # noqa: E402
 from app.db.session import SessionLocal, engine  # noqa: E402
 from app.main import app, service  # noqa: E402
-from app.models.entities import OrderEntity, PositionEntity, TradeLogEntity  # noqa: E402
+from app.models.entities import (  # noqa: E402
+    AccountSettingsEntity,
+    OrderEntity,
+    PositionEntity,
+    TradeLogEntity,
+)
+from app.schemas.cockpit import TrancheMode  # noqa: E402
 from app.services.auth import get_auth_store  # noqa: E402
 from app.core.config import Settings, _normalize_database_url  # noqa: E402
 from app.api import deps_auth  # noqa: E402
@@ -62,9 +68,30 @@ def reset_db() -> None:
 
 def tranche_modes() -> list[dict]:
     return [
-        {"mode": "limit", "trail": 2, "trailUnit": "$", "target": "1R", "manualPrice": None},
-        {"mode": "limit", "trail": 2, "trailUnit": "$", "target": "2R", "manualPrice": None},
-        {"mode": "runner", "trail": 2, "trailUnit": "$", "target": "3R", "manualPrice": None},
+        {
+            "mode": "limit",
+            "allocationPct": 33.33,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "1R",
+            "manualPrice": None,
+        },
+        {
+            "mode": "limit",
+            "allocationPct": 33.33,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "2R",
+            "manualPrice": None,
+        },
+        {
+            "mode": "runner",
+            "allocationPct": 33.34,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "3R",
+            "manualPrice": None,
+        },
     ]
 
 
@@ -83,8 +110,13 @@ def test_setup_endpoint_returns_contract() -> None:
     assert isinstance(data["quoteIsReal"], bool)
     assert isinstance(data["technicalsAreFallback"], bool)
     assert data["entryBasis"] == "bid_ask_midpoint"
-    assert data["entry"] > data["finalStop"]
-    assert data["shares"] > 0
+    assert data["stopReferenceDefault"] in {"lod", "atr", "manual"}
+    assert isinstance(data["lodIsValid"], bool)
+    assert isinstance(data["atrIsValid"], bool)
+    assert "equitySource" in data
+    if data["stopReferenceDefault"] != "manual":
+        assert data["entry"] > data["finalStop"]
+        assert data["shares"] >= 0
 
 
 def test_postgres_urls_normalize_to_psycopg_driver() -> None:
@@ -141,6 +173,138 @@ def test_setup_fails_loudly_when_real_quote_is_unavailable() -> None:
     finally:
         service.settings.allow_controller_mock = original_allow_mock
         service.market_data.get_setup_data = original_get_setup_data
+
+
+def test_build_setup_defaults_to_manual_when_real_lod_is_invalid() -> None:
+    market = SetupMarketData(
+        symbol="AAPL",
+        provider="alpaca_market",
+        provider_state="real_quote_range_atr_fallback_technicals",
+        quote_provider="alpaca",
+        technicals_provider="mock",
+        quote_is_real=True,
+        technicals_are_fallback=True,
+        fallback_reason="partial_technicals_fallback_only",
+        quote_timestamp=None,
+        session_state="after_hours",
+        quote_state="cached_quote",
+        entry_basis="bid_ask_midpoint",
+        bid=101.00,
+        ask=101.20,
+        last=101.10,
+        lod=101.50,
+        hod=103.00,
+        prev_close=100.00,
+        atr14=2.25,
+        sma10=100.0,
+        sma50=95.0,
+        sma200=90.0,
+        sma200_prev=89.5,
+        rvol=1.2,
+        days_to_cover=2.0,
+    )
+    setup = service._build_setup_response(market, 50000.0, 200000.0, 1.0, "alpaca_account", 15000.0)
+    assert setup.stopReferenceDefault == "manual"
+    assert setup.lodIsValid is False
+    assert setup.manualStopWarning
+    assert setup.shares == 0
+    assert setup.finalStop == 0.0
+
+
+def test_build_setup_uses_real_lod_when_valid() -> None:
+    market = SetupMarketData(
+        symbol="AAPL",
+        provider="alpaca_market",
+        provider_state="real_quote_range_atr_fallback_technicals",
+        quote_provider="alpaca",
+        technicals_provider="mock",
+        quote_is_real=True,
+        technicals_are_fallback=True,
+        fallback_reason="partial_technicals_fallback_only",
+        quote_timestamp=None,
+        session_state="regular_open",
+        quote_state="live_quote",
+        entry_basis="bid_ask_midpoint",
+        bid=101.00,
+        ask=101.20,
+        last=101.10,
+        lod=98.00,
+        hod=103.00,
+        prev_close=100.00,
+        atr14=2.25,
+        sma10=100.0,
+        sma50=95.0,
+        sma200=90.0,
+        sma200_prev=89.5,
+        rvol=1.2,
+        days_to_cover=2.0,
+    )
+    setup = service._build_setup_response(market, 50000.0, 200000.0, 1.0, "alpaca_account", 15000.0)
+    assert setup.stopReferenceDefault == "lod"
+    assert setup.lodIsValid is True
+    assert setup.finalStop == 98.0
+    assert setup.atrStop == round(setup.entry - market.atr14, 2)
+    assert setup.shares > 0
+
+
+def test_get_account_uses_broker_equity_for_alpaca_paper_mode() -> None:
+    original_broker = service.broker
+    original_mode = service.settings.broker_mode
+
+    class StubBroker:
+        def get_account_summary(self) -> dict[str, float]:
+            return {"equity": 76543.21, "buying_power": 123456.78, "cash": 10000.0}
+
+    service.broker = StubBroker()
+    service.settings.broker_mode = "alpaca_paper"
+    try:
+        with SessionLocal() as db:
+            service.ensure_seed_data(db)
+            settings_row = db.scalar(select(AccountSettingsEntity))
+            assert settings_row is not None
+            settings_row.mode = "alpaca_paper"
+            db.commit()
+            account = service.get_account(db)
+        assert account.equity == 76543.21
+        assert account.buying_power == 123456.78
+        assert account.cash == 10000.0
+        assert account.equity_source == "alpaca_account"
+    finally:
+        service.broker = original_broker
+        service.settings.broker_mode = original_mode
+
+
+def test_split_shares_uses_allocation_percentages() -> None:
+    allocations = [
+        {
+            "mode": "limit",
+            "allocationPct": 50.0,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "1R",
+            "manualPrice": None,
+        },
+        {
+            "mode": "limit",
+            "allocationPct": 30.0,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "2R",
+            "manualPrice": None,
+        },
+        {
+            "mode": "runner",
+            "allocationPct": 20.0,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "3R",
+            "manualPrice": None,
+        },
+    ]
+    result = service._split_shares(
+        101, 3, [TrancheMode.model_validate(item) for item in allocations]
+    )
+    assert result == [51, 30, 20]
 
 
 def test_login_creates_session_and_me_resolves_user() -> None:
@@ -493,6 +657,76 @@ def test_off_hours_queue_for_open_creates_pending_entry() -> None:
         service.get_setup = original_get_setup
 
 
+def test_stop_fill_reconciles_realized_loss_for_only_hit_tranche() -> None:
+    client.put(
+        "/api/account/settings",
+        json={"equity": 1000000, "risk_pct": 0.2, "mode": "paper"},
+    )
+    setup = client.get("/api/setup/AAPL").json()
+    enter = client.post(
+        "/api/trade/enter",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "lod",
+            "stopPrice": setup["finalStop"],
+            "trancheCount": 3,
+            "trancheModes": tranche_modes(),
+        },
+    )
+    assert enter.status_code == 200
+
+    stops = client.post(
+        "/api/trade/stops",
+        json={
+            "symbol": "AAPL",
+            "stopMode": 3,
+            "stopModes": [
+                {"mode": "stop", "pct": 33.0},
+                {"mode": "stop", "pct": 66.0},
+                {"mode": "stop", "pct": 100.0},
+            ],
+        },
+    )
+    assert stops.status_code == 200
+    protected = stops.json()
+    s1 = next(
+        order
+        for order in protected["orders"]
+        if order["type"] == "STOP" and order["tranche"] == "S1"
+    )
+    s2 = next(
+        order
+        for order in protected["orders"]
+        if order["type"] == "STOP" and order["tranche"] == "S2"
+    )
+    assert s1["price"] > s2["price"]
+
+    with SessionLocal() as db:
+        position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == "AAPL"))
+        assert position is not None
+        position.live_price = round((s1["price"] + s2["price"]) / 2, 2)
+        db.commit()
+
+    reconciled = client.get("/api/positions/AAPL")
+    assert reconciled.status_code == 200
+    payload = reconciled.json()
+    sold = [tranche for tranche in payload["tranches"] if tranche["status"] == "sold"]
+    active = [tranche for tranche in payload["tranches"] if tranche["status"] == "active"]
+    assert len(sold) == 1
+    assert len(active) == 2
+    assert sold[0]["exitOrderType"] == "STOP"
+    assert sold[0]["exitPrice"] == s1["price"]
+    assert sold[0]["exitFilledAt"] is not None
+    filled_stop_orders = [
+        order
+        for order in payload["orders"]
+        if order["type"] == "STOP" and order["status"] == "FILLED"
+    ]
+    assert len(filled_stop_orders) == 1
+    assert filled_stop_orders[0]["tranche"] == "S1"
+
+
 def test_setup_uses_cached_quote_metadata_when_alpaca_quote_is_off_hours() -> None:
     original_market_data = service.market_data.get_setup_data
 
@@ -510,6 +744,7 @@ def test_setup_uses_cached_quote_metadata_when_alpaca_quote_is_off_hours() -> No
             quote_timestamp=fallback.quote_timestamp,
             session_state="closed",
             quote_state="cached_quote",
+            entry_basis=fallback.entry_basis,
             bid=fallback.bid,
             ask=fallback.ask,
             last=fallback.last,
@@ -535,3 +770,230 @@ def test_setup_uses_cached_quote_metadata_when_alpaca_quote_is_off_hours() -> No
         assert data["quoteState"] == "cached_quote"
     finally:
         service.market_data.get_setup_data = original_market_data
+
+
+def test_recent_orders_merge_broker_state_and_cancel() -> None:
+    with SessionLocal() as db:
+        db.add(
+            OrderEntity(
+                order_id="ORD-9001",
+                broker_order_id="broker-1",
+                symbol="AAPL",
+                type="LMT",
+                qty=10,
+                orig_qty=10,
+                price=101.25,
+                status="PENDING",
+                tranche_label="AAPL",
+                covered_tranches=[],
+                parent_id=None,
+            )
+        )
+        db.commit()
+
+    canceled: list[str] = []
+    original_list_recent_orders = service.broker.list_recent_orders
+    original_get_order = service.broker.get_order
+    original_cancel_order = service.broker.cancel_order
+
+    def fake_list_recent_orders(limit: int = 50):
+        return [
+            {
+                "id": "broker-1",
+                "client_order_id": "client-1",
+                "symbol": "AAPL",
+                "side": "buy",
+                "type": "limit",
+                "qty": "10",
+                "filled_qty": "0",
+                "limit_price": "101.25",
+                "status": "accepted",
+                "created_at": "2026-03-22T10:00:00Z",
+                "updated_at": "2026-03-22T10:00:05Z",
+            },
+            {
+                "id": "broker-2",
+                "client_order_id": "client-2",
+                "symbol": "MSFT",
+                "side": "sell",
+                "type": "market",
+                "qty": "5",
+                "filled_qty": "5",
+                "filled_avg_price": "380.10",
+                "status": "filled",
+                "created_at": "2026-03-22T09:59:00Z",
+                "updated_at": "2026-03-22T09:59:10Z",
+                "filled_at": "2026-03-22T09:59:10Z",
+            },
+        ][:limit]
+
+    def fake_get_order(broker_order_id: str):
+        if broker_order_id == "broker-1" and "broker-1" not in canceled:
+            return {
+                "id": "broker-1",
+                "client_order_id": "client-1",
+                "symbol": "AAPL",
+                "side": "buy",
+                "type": "limit",
+                "qty": "10",
+                "filled_qty": "0",
+                "limit_price": "101.25",
+                "status": "accepted",
+                "created_at": "2026-03-22T10:00:00Z",
+                "updated_at": "2026-03-22T10:00:05Z",
+            }
+        if broker_order_id == "broker-1":
+            return {
+                "id": "broker-1",
+                "client_order_id": "client-1",
+                "symbol": "AAPL",
+                "side": "buy",
+                "type": "limit",
+                "qty": "10",
+                "filled_qty": "0",
+                "limit_price": "101.25",
+                "status": "canceled",
+                "created_at": "2026-03-22T10:00:00Z",
+                "updated_at": "2026-03-22T10:01:00Z",
+            }
+        return None
+
+    def fake_cancel_order(broker_order_id: str):
+        canceled.append(broker_order_id)
+
+    service.broker.list_recent_orders = fake_list_recent_orders
+    service.broker.get_order = fake_get_order
+    service.broker.cancel_order = fake_cancel_order
+    try:
+        response = client.get("/api/orders")
+        assert response.status_code == 200
+        orders = response.json()
+        assert orders[0]["brokerOrderId"] == "broker-1"
+        assert orders[0]["cancelable"] is True
+        assert orders[0]["symbol"] == "AAPL"
+        assert any(order["brokerOrderId"] == "broker-2" for order in orders)
+
+        cancel_response = client.delete("/api/orders/broker-1")
+        assert cancel_response.status_code == 200
+        canceled_view = cancel_response.json()
+        assert canceled_view["status"] == "CANCELED"
+        assert canceled == ["broker-1"]
+
+        with SessionLocal() as db:
+            local = db.scalar(select(OrderEntity).where(OrderEntity.order_id == "ORD-9001"))
+            assert local is not None
+            assert local.status == "CANCELED"
+    finally:
+        service.broker.list_recent_orders = original_list_recent_orders
+        service.broker.get_order = original_get_order
+        service.broker.cancel_order = original_cancel_order
+
+
+def test_cancel_recent_root_order_closes_pending_position() -> None:
+    with SessionLocal() as db:
+        db.add(
+            PositionEntity(
+                symbol="AMD",
+                phase="entry_pending",
+                entry_price=201.22,
+                live_price=201.22,
+                shares=10,
+                stop_ref="lod",
+                stop_price=198.33,
+                tranche_count=3,
+                tranche_modes=tranche_modes(),
+                stop_modes=[{"mode": "stop", "pct": None} for _ in range(3)],
+                tranches=[
+                    {
+                        "id": "T1",
+                        "qty": 3,
+                        "stop": 198.33,
+                        "label": "T1",
+                        "status": "active",
+                        "mode": "limit",
+                        "trail": 2.0,
+                        "trailUnit": "$",
+                        "runnerStop": None,
+                    },
+                    {
+                        "id": "T2",
+                        "qty": 3,
+                        "stop": 198.33,
+                        "label": "T2",
+                        "status": "active",
+                        "mode": "limit",
+                        "trail": 2.0,
+                        "trailUnit": "$",
+                        "runnerStop": None,
+                    },
+                    {
+                        "id": "T3",
+                        "qty": 4,
+                        "stop": 198.33,
+                        "label": "T3",
+                        "status": "active",
+                        "mode": "limit",
+                        "trail": 2.0,
+                        "trailUnit": "$",
+                        "runnerStop": None,
+                    },
+                ],
+                setup_snapshot=service.get_setup(db, "AAPL").model_dump(mode="json"),
+                root_order_id="ORD-9010",
+            )
+        )
+        db.add(
+            OrderEntity(
+                order_id="ORD-9010",
+                broker_order_id="broker-root",
+                symbol="AMD",
+                type="MKT",
+                qty=10,
+                orig_qty=10,
+                price=201.22,
+                status="PENDING",
+                tranche_label="AMD",
+                covered_tranches=[],
+                parent_id=None,
+            )
+        )
+        db.commit()
+
+    original_get_order = service.broker.get_order
+    original_cancel_order = service.broker.cancel_order
+
+    def fake_get_order(broker_order_id: str):
+        if broker_order_id == "broker-root":
+            return {
+                "id": "broker-root",
+                "client_order_id": "client-root",
+                "symbol": "AMD",
+                "side": "buy",
+                "type": "market",
+                "qty": "10",
+                "filled_qty": "0",
+                "status": "accepted",
+                "created_at": "2026-03-22T10:00:00Z",
+                "updated_at": "2026-03-22T10:00:05Z",
+            }
+        return None
+
+    canceled: list[str] = []
+
+    def fake_cancel_order(broker_order_id: str):
+        canceled.append(broker_order_id)
+
+    service.broker.get_order = fake_get_order
+    service.broker.cancel_order = fake_cancel_order
+    try:
+        response = client.delete("/api/orders/broker-root")
+        assert response.status_code == 200
+        assert canceled == ["broker-root"]
+        with SessionLocal() as db:
+            position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == "AMD"))
+            assert position is not None
+            assert position.phase == "closed"
+            assert all(tranche["status"] == "canceled" for tranche in position.tranches)
+    finally:
+        service.broker.get_order = original_get_order
+        service.broker.cancel_order = original_cancel_order

--- a/backend/app/ws/manager.py
+++ b/backend/app/ws/manager.py
@@ -12,7 +12,9 @@ from redis.asyncio import Redis
 
 
 class WebSocketManager:
-    def __init__(self, redis_url: str | None = None, channel_prefix: str = "traders-cockpit") -> None:
+    def __init__(
+        self, redis_url: str | None = None, channel_prefix: str = "traders-cockpit"
+    ) -> None:
         self.connections: dict[str, set[WebSocket]] = defaultdict(set)
         self._lock = asyncio.Lock()
         self._redis_url = redis_url

--- a/docs/issues/2026-03-23-integration-black-blocker.md
+++ b/docs/issues/2026-03-23-integration-black-blocker.md
@@ -1,0 +1,32 @@
+# Integration Black Blocker
+
+> Status: Proposed
+> Branch: `codex/feature-integration-promote-release-prep`
+> Opened: 2026-03-23
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+PR #10 into `codex/integration-app` is blocked by backend CI because `black --check .` wants to reformat `backend/alembic/versions/0001_initial.py`.
+
+## Business value
+
+Clearing this blocker is required before the validated cockpit candidate can merge into `codex/integration-app` and continue through the staged promotion path to `main`.
+
+## Scope
+
+- reformat the Alembic migration file without changing migration behavior
+- re-run the integration candidate validation
+- update the open integration PR with the fix
+
+## Acceptance criteria
+
+- [ ] `backend/alembic/versions/0001_initial.py` passes Black unchanged semantically
+- [ ] GitHub backend CI is green on PR #10
+- [ ] the integration PR is no longer blocked by the migration formatting issue
+
+## Risks / constraints
+
+- do not change migration semantics while reformatting
+- do not mix unrelated behavior changes into this blocker fix

--- a/docs/issues/2026-03-23-release-prep-consolidation.md
+++ b/docs/issues/2026-03-23-release-prep-consolidation.md
@@ -1,0 +1,17 @@
+# Release prep consolidation
+
+## Summary
+Create a clean release-prep branch from codex/integration-app, consolidate the current local cockpit UI/runtime work into a promotable state, and validate against the release checklist.
+
+## Scope
+- audit uncommitted local cockpit changes across active worktrees
+- pull the intended 3010 UI/runtime state into a clean branch
+- fix critical runtime and production blockers discovered during validation
+- run required backend/frontend validation
+- run browser QC and refresh evidence where feasible
+
+## Validation
+- frontend lint, tests, build
+- backend Ruff, Black check, pytest
+- browser QC on the consolidated candidate
+- state clearly what remains non-release-ready if anything still blocks promotion

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,8 +1,8 @@
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap");
 
 :root {
   --bg0: #0a0c0f;
@@ -159,6 +159,11 @@ select {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
+}
+
+.auth-strip-end {
+  margin-left: auto;
 }
 
 .auth-user {
@@ -210,6 +215,15 @@ select {
 
 .ticker-input-wrap {
   position: relative;
+}
+
+.ticker-loading {
+  color: var(--cyan);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .ticker-prefix {
@@ -397,33 +411,90 @@ select {
   border: 1px solid rgba(255, 64, 96, 0.3);
 }
 
-.live-price {
-  margin-left: auto;
+.live-price,
+.entry-live-price {
   font-family: "IBM Plex Mono", monospace;
-  font-size: 18px;
+  font-size: 11px;
   font-weight: 600;
   color: var(--text0);
+  white-space: nowrap;
 }
 
-.live-price .change {
-  margin-left: 8px;
-  font-size: 12px;
+.entry-live-price {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.live-price .up {
+.entry-header-market {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  flex-wrap: nowrap;
+  width: 100%;
+  margin-left: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.entry-header-market::-webkit-scrollbar {
+  display: none;
+}
+
+.entry-quote-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: "IBM Plex Mono", monospace;
+  white-space: nowrap;
+}
+
+.entry-quote-label {
+  color: var(--text2);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.entry-quote-value {
+  color: var(--text1);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.entry-live-symbol {
+  color: var(--text2);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.live-price .change,
+.entry-live-price .change {
+  margin-left: 0;
+  font-size: 11px;
+}
+
+.live-price .up,
+.entry-live-price .up {
   color: var(--green);
 }
 
-.live-price .dn {
+.live-price .dn,
+.entry-live-price .dn {
   color: var(--red);
 }
 
 .workspace {
   display: grid;
-  grid-template-columns: 300px 1fr 280px;
+  grid-template-columns: var(--setup-width, 300px) 6px minmax(0, 1fr) 6px var(--log-width, 280px);
   grid-template-rows: auto auto 1fr;
-  gap: 1px;
   height: calc(100vh - 52px);
+  min-height: 0;
+  overflow: hidden;
   background: var(--border);
 }
 
@@ -436,6 +507,7 @@ select {
 .panel {
   background: var(--bg1);
   overflow: auto;
+  min-height: 0;
 }
 
 .setup-panel {
@@ -444,28 +516,129 @@ select {
 }
 
 .entry-panel {
-  grid-column: 2;
-  grid-row: 1;
   overflow: hidden;
 }
 
+.center-stage {
+  grid-column: 3;
+  grid-row: 1 / 4;
+  display: grid;
+  grid-template-rows: var(--center-top-row, minmax(170px, 28%)) 6px var(--center-bottom-row, minmax(240px, 72%));
+  gap: 1px;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--border);
+}
+
+.execution-row {
+  display: grid;
+  grid-template-columns: minmax(0, var(--execution-left, 50%)) 6px minmax(0, var(--execution-right, 50%));
+  min-height: 0;
+  background: var(--border);
+  overflow: hidden;
+}
+
+.execution-column {
+  display: grid;
+  gap: 1px;
+  min-height: 0;
+  background: var(--border);
+}
+
+.execution-column-left {
+  grid-template-rows: var(--execution-left-top-row, minmax(180px, var(--execution-left-top, 56%))) 6px var(--execution-left-bottom-row, minmax(140px, var(--execution-left-bottom, 44%)));
+}
+
+.execution-column-right {
+  grid-template-rows: var(--monitor-right-top-row, minmax(180px, var(--monitor-right-top, 56%))) 6px var(--monitor-right-bottom-row, minmax(140px, var(--monitor-right-bottom, 44%)));
+}
+
 .protect-panel {
-  grid-column: 2;
-  grid-row: 2;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .manage-panel {
-  grid-column: 2;
-  grid-row: 3;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+}
+
+.orders-monitor-panel,
+.running-pnl-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.open-positions-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
 }
 
 .log-panel {
-  grid-column: 3;
-  grid-row: 1 / 4;
   display: flex;
   flex-direction: column;
+  min-height: 0;
+}
+
+.right-rail {
+  grid-column: 5;
+  grid-row: 1 / 4;
+  display: grid;
+  grid-template-rows: var(--right-rail-top-row, minmax(180px, var(--right-rail-top, 46%))) 6px var(--right-rail-bottom-row, minmax(140px, var(--right-rail-bottom, 54%)));
+  gap: 1px;
+  min-height: 0;
+  background: var(--border);
+}
+
+.workspace-splitter {
+  position: relative;
+  background: var(--bg1);
+  cursor: col-resize;
+}
+
+.workspace-splitter::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 2px;
+  height: 100%;
+  background: var(--border2);
+}
+
+.workspace-splitter-execution {
+  cursor: col-resize;
+}
+
+.workspace-splitter-setup {
+  grid-column: 2;
+  grid-row: 1 / 4;
+}
+
+.workspace-splitter-log {
+  grid-column: 4;
+  grid-row: 1 / 4;
+}
+
+.workspace-splitter-execution::after {
+  height: 100%;
+}
+
+.workspace-splitter-horizontal {
+  cursor: row-resize;
+  position: relative;
+  z-index: 6;
+}
+
+.workspace-splitter-horizontal::after {
+  width: 100%;
+  height: 3px;
 }
 
 .panel-header {
@@ -484,6 +657,7 @@ select {
 .kv-group-label,
 .op-section-label,
 .op-expand-label,
+.op-list-heading,
 .pos-item-label {
   font-family: "IBM Plex Mono", monospace;
   font-size: 9px;
@@ -513,6 +687,50 @@ select {
   font-family: "IBM Plex Mono", monospace;
   font-size: 11px;
   color: var(--text1);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.panel-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.panel-title-row .panel-title {
+  order: 2;
+}
+
+.panel-title-row .panel-collapse-btn {
+  order: 1;
+}
+
+.panel-title-row-clickable {
+  cursor: pointer;
+}
+
+.panel-collapse-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--border2);
+  border-radius: 3px;
+  background: var(--bg3);
+  color: var(--text1);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.panel-collapse-btn:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+.panel-collapsed {
+  min-height: unset;
 }
 
 .ticker-symbol-large {
@@ -563,6 +781,53 @@ select {
 
 .kv-group {
   margin-bottom: 14px;
+}
+
+.setup-meta-card {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border2);
+  border-radius: 4px;
+  background: var(--bg2);
+}
+
+.setup-meta-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.setup-meta-tag,
+.setup-meta-value,
+.setup-meta-copy {
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.setup-meta-tag {
+  color: var(--cyan);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.setup-meta-value {
+  color: var(--text2);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.setup-meta-copy {
+  color: var(--text2);
+  font-size: 9px;
+  line-height: 1.45;
+}
+
+.setup-meta-copy.warning {
+  color: var(--amber);
 }
 
 .kv-group-label {
@@ -660,12 +925,74 @@ select {
   padding: 12px 20px;
 }
 
+.entry-panel-header {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
 .entry-stack {
   display: flex;
   height: 100%;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 12px;
+}
+
+.entry-order-strip {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.entry-ticker-wrap {
+  min-width: 132px;
+}
+
+.entry-order-field {
+  display: grid;
+  gap: 4px;
+}
+
+.entry-order-copy {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  line-height: 1.3;
+  color: var(--text1);
+}
+
+.entry-order-label {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  color: var(--text2);
+  text-transform: uppercase;
+}
+
+.entry-order-input,
+.entry-select {
+  height: 30px;
+  min-width: 92px;
+  padding: 0 8px;
+  border: 1px solid var(--border2);
+  border-radius: 3px;
+  background: var(--bg3);
+  color: var(--text0);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  font-weight: 600;
+  outline: none;
+}
+
+.entry-order-input:focus,
+.entry-select:focus {
+  border-color: var(--cyan);
+}
+
+.entry-select-oto {
+  min-width: 110px;
 }
 
 .offhours-box {
@@ -704,10 +1031,113 @@ select {
   flex-wrap: wrap;
 }
 
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 140;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(10, 12, 15, 0.72);
+  backdrop-filter: blur(4px);
+}
+
+.modal-card {
+  width: min(100%, 560px);
+  padding: 18px 20px;
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  background: linear-gradient(180deg, rgba(20, 24, 32, 0.98), rgba(15, 18, 24, 0.98));
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+}
+
+.modal-eyebrow,
+.modal-title,
+.modal-copy,
+.modal-choice-title,
+.modal-choice-copy {
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.modal-eyebrow {
+  color: var(--amber);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.modal-title {
+  margin: 10px 0 8px;
+  color: var(--text0);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.modal-copy {
+  color: var(--text1);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.modal-choice-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.modal-choice {
+  display: grid;
+  gap: 6px;
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid var(--border2);
+  border-radius: 4px;
+  background: var(--bg2);
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.modal-choice:hover {
+  border-color: var(--text2);
+}
+
+.modal-choice.active {
+  border-color: var(--cyan);
+  background: rgba(0, 200, 212, 0.08);
+}
+
+.modal-choice-title {
+  color: var(--text0);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.modal-choice-copy {
+  color: var(--text2);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
 .entry-row {
   display: flex;
   align-items: center;
-  gap: 28px;
+  gap: 18px;
+}
+
+.entry-row-compact {
+  align-items: flex-start;
 }
 
 .entry-row-labels {
@@ -746,10 +1176,10 @@ select {
 }
 
 .hero-shares {
-  width: 90px;
+  width: 110px;
   color: var(--text0);
   font-family: "IBM Plex Mono", monospace;
-  font-size: 26px;
+  font-size: 20px;
   font-weight: 600;
   line-height: 1;
 }
@@ -764,11 +1194,63 @@ select {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex-wrap: wrap;
 }
 
-.entry-toggle-group {
+.entry-attach-summary {
   display: flex;
-  gap: 2px;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  color: var(--text1);
+}
+
+.entry-attach-empty {
+  color: var(--text3);
+}
+
+.stop-ref-cycle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 62px;
+  height: 26px;
+  padding: 0 12px;
+  border: 1px solid var(--border2);
+  border-radius: 3px;
+  background: var(--bg3);
+  color: var(--text1);
+  cursor: pointer;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: all 0.12s;
+}
+
+.stop-ref-cycle:hover {
+  border-color: var(--text1);
+}
+
+.stop-ref-cycle-lod {
+  border-color: var(--green-dim);
+  background: rgba(0, 208, 122, 0.12);
+  color: var(--green);
+}
+
+.stop-ref-cycle-atr {
+  border-color: rgba(245, 166, 35, 0.4);
+  background: rgba(245, 166, 35, 0.08);
+  color: var(--amber);
+}
+
+.stop-ref-cycle-manual {
+  border-color: rgba(255, 64, 96, 0.32);
+  background: rgba(255, 64, 96, 0.08);
+  color: var(--red);
 }
 
 .manual-stop-wrap,
@@ -867,6 +1349,10 @@ select {
   font-family: "IBM Plex Mono", monospace;
   font-size: 16px;
   font-weight: 600;
+}
+
+.entry-actions-row {
+  margin-top: 2px;
 }
 
 .protect-header,
@@ -1101,10 +1587,62 @@ select {
   color: var(--amber);
 }
 
-.protect-actions {
+.protect-lower {
   display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.orders-monitor-body,
+.running-pnl-body {
+  padding: 10px 14px;
+  min-height: 0;
+  overflow: auto;
+}
+
+.open-positions-body {
+  padding: 10px 14px;
+  min-height: 0;
+  overflow: auto;
+}
+
+.collapsible-section-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.stop-action-line {
+  gap: 10px;
+}
+
+.stop-action-buttons {
+  display: flex;
+  align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
+}
+
+.stop-inline-btn {
+  height: 24px;
+  padding: 0 10px;
+  font-size: 9px;
+}
+
+.stop-action-copy {
+  margin-left: auto;
+  color: var(--text3);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9px;
+  white-space: nowrap;
+}
+
+.orders-in-protect {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 0 14px 12px;
 }
 
 .target-toggle-wrap {
@@ -1140,31 +1678,6 @@ select {
   margin-top: 2px;
 }
 
-.tranche-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-  margin-bottom: 10px;
-}
-
-.tranche-card {
-  padding: 10px 12px;
-  border: 1px solid var(--border2);
-  border-radius: 4px;
-  background: var(--bg2);
-  transition: border-color 0.15s;
-}
-
-.tranche-card.active {
-  border-color: var(--green-dim);
-}
-
-.tranche-card.sold,
-.tranche-card.canceled {
-  border-color: var(--border);
-  opacity: 0.5;
-}
-
 .tranche-label,
 .tranche-stop,
 .tranche-target,
@@ -1180,120 +1693,124 @@ select {
   font-family: "IBM Plex Mono", monospace;
 }
 
-.tranche-label {
-  margin-bottom: 6px;
+.running-pnl-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.running-pnl-card {
+  padding: 10px 12px;
+  border: 1px solid var(--border2);
+  border-radius: 4px;
+  background: var(--bg2);
+}
+
+.running-pnl-label,
+.running-pnl-legs-header,
+.running-pnl-leg-label,
+.running-pnl-leg-time {
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.running-pnl-label,
+.running-pnl-legs-header {
   color: var(--text3);
   font-size: 9px;
   font-weight: 600;
-  letter-spacing: 0.15em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-.tranche-qty {
-  margin-bottom: 4px;
+.running-pnl-value {
+  margin-top: 6px;
   color: var(--text0);
   font-family: "IBM Plex Mono", monospace;
   font-size: 16px;
   font-weight: 600;
 }
 
-.tranche-unit {
-  color: var(--text2);
-  font-size: 10px;
-}
-
-.tranche-stop {
-  margin-bottom: 3px;
-  color: var(--red);
-  font-size: 10px;
-}
-
-.tranche-target {
-  color: var(--green);
-  font-size: 10px;
-}
-
-.tranche-pnl {
-  margin-top: 4px;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 10px;
-}
-
-.tranche-status {
-  display: flex;
-  align-items: center;
-  margin-top: 5px;
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.status-dot {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  margin-right: 5px;
-  border-radius: 50%;
-}
-
-.status-active {
-  color: var(--green);
-}
-
-.status-active .status-dot {
-  background: var(--green);
-  box-shadow: 0 0 5px var(--green);
-}
-
-.status-sold {
-  color: var(--text3);
-}
-
-.status-sold .status-dot {
-  background: var(--text3);
-}
-
-.status-canceled {
-  color: var(--red-dim);
-}
-
-.status-canceled .status-dot {
-  background: var(--red-dim);
-}
-
-.pos-summary {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 12px;
+.running-pnl-legs {
+  display: grid;
+  gap: 6px;
   padding: 8px 12px;
   border: 1px solid var(--border2);
-  border-radius: 3px;
-  background: var(--bg3);
+  border-radius: 4px;
+  background: var(--bg2);
+}
+
+.running-pnl-leg {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) 72px 70px 96px 72px;
+  gap: 10px;
+  align-items: center;
+  padding-top: 6px;
+  border-top: 1px solid rgba(30, 42, 58, 0.6);
+}
+
+.running-pnl-leg:first-of-type {
+  padding-top: 0;
+  border-top: none;
+}
+
+.running-pnl-leg-label,
+.running-pnl-leg-qty,
+.running-pnl-leg-price,
+.running-pnl-leg-pnl,
+.running-pnl-leg-time,
+.running-pnl-empty {
   font-family: "IBM Plex Mono", monospace;
-  font-size: 11px;
+  font-size: 10px;
 }
 
-.pos-item {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.running-pnl-leg-qty,
+.running-pnl-leg-price,
+.running-pnl-leg-time {
+  color: var(--text1);
 }
 
-.pos-item-label {
-  letter-spacing: 0.1em;
-}
-
-.pos-item-val {
-  color: var(--text0);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 13px;
-  font-weight: 600;
+.running-pnl-empty {
+  color: var(--text3);
+  padding-top: 2px;
 }
 
 .orders-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.orders-col-symbol {
+  width: 72px;
+}
+
+.orders-col-side-type {
+  width: 78px;
+}
+
+.orders-col-qty {
+  width: 102px;
+}
+
+.orders-col-price {
+  width: 108px;
+}
+
+.orders-col-status {
+  width: 102px;
+}
+
+.orders-col-time {
+  width: 78px;
+}
+
+.orders-col-context {
+  width: 82px;
+}
+
+.orders-col-action {
+  width: 76px;
 }
 
 .orders-table th {
@@ -1306,6 +1823,7 @@ select {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   white-space: nowrap;
+  position: relative;
 }
 
 .orders-table td {
@@ -1314,6 +1832,8 @@ select {
   color: var(--text1);
   font-size: 11px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .orders-table tr:hover td {
@@ -1349,6 +1869,44 @@ select {
   font-family: "IBM Plex Mono", monospace;
   font-size: 8px;
   letter-spacing: 0.05em;
+}
+
+.order-symbol-cell,
+.order-side-type-cell {
+  white-space: nowrap;
+}
+
+.order-symbol-main {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+}
+
+.order-subtext-truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.order-side-type-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.order-side-code {
+  min-width: 10px;
+  color: var(--text1);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.order-type-code {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .order-id-child {
@@ -1424,6 +1982,7 @@ select {
   padding: 5px 0;
   border-bottom: 1px solid rgba(30, 42, 58, 0.5);
   animation: fadeIn 0.3s ease;
+  content-visibility: auto;
 }
 
 @keyframes fadeIn {
@@ -1493,86 +2052,94 @@ select {
 }
 
 .open-positions-section {
-  margin-top: 10px;
+  margin-top: 0;
 }
 
-.op-section-label {
-  display: flex;
-  justify-content: space-between;
+.op-header-meta {
+  display: inline-flex;
   align-items: center;
-  margin-bottom: 6px;
-  padding: 10px 0 6px;
-  border-bottom: 1px solid var(--border);
+  gap: 8px;
 }
 
-.op-count {
-  color: var(--text3);
-  font-weight: 400;
+.op-header-count {
+  color: var(--text0);
 }
 
-.op-live-badge {
+.op-header-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   color: var(--green);
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 8px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
 }
 
-.op-card {
+.op-header-live::before {
+  content: "\25CF";
+  font-size: 7px;
+}
+
+.op-list-header {
+  display: grid;
+  grid-template-columns: minmax(52px, 1fr) auto 22px 22px;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  padding: 0 10px;
+}
+
+.op-list {
+  display: grid;
+  gap: 4px;
+}
+
+.op-row {
+  display: grid;
+  grid-template-columns: minmax(52px, 1fr) auto 22px 22px;
+  align-items: center;
+  gap: 6px;
   width: 100%;
-  margin-bottom: 6px;
+  padding: 7px 10px;
   border: 1px solid var(--border2);
   border-radius: 4px;
   background: var(--bg2);
-  overflow: hidden;
-  cursor: pointer;
-  transition: border-color 0.15s;
   text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
 }
 
-.op-card:hover,
-.op-card.expanded {
+.op-row:hover,
+.op-row.active {
   border-color: var(--cyan);
+  background: rgba(0, 200, 212, 0.05);
 }
 
-.op-card.expanded {
+.op-row.active {
   border-left: 3px solid var(--cyan);
 }
 
-.op-card-header {
-  padding: 8px 10px;
-}
-
-.op-top-row,
-.op-metrics-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.op-top-row {
-  margin-bottom: 6px;
-}
-
-.op-metrics-row {
-  gap: 10px;
-}
-
-.op-metric {
-  flex-shrink: 0;
-}
-
-.op-symbol {
+.op-row-symbol {
   color: var(--text0);
-  font-size: 15px;
+  font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.05em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
+.op-row-pnl,
 .op-pnl {
   font-family: "IBM Plex Mono", monospace;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
+  justify-self: end;
+}
+
+.op-list-heading-pnl {
+  justify-self: end;
+}
+
+.op-list-heading-badge {
+  justify-self: center;
 }
 
 .op-pnl-pos {
@@ -1583,23 +2150,6 @@ select {
   color: var(--red);
 }
 
-.op-key {
-  color: var(--text3);
-  font-size: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.op-val {
-  color: var(--text0);
-  font-size: 11px;
-  font-weight: 600;
-}
-
-.op-status-wrap {
-  margin-left: auto;
-}
-
 .op-badge {
   padding: 2px 6px;
   border-radius: 2px;
@@ -1607,6 +2157,13 @@ select {
   font-size: 8px;
   font-weight: 600;
   letter-spacing: 0.08em;
+  white-space: nowrap;
+}
+
+.op-badge-letter {
+  min-width: 22px;
+  padding: 2px 0;
+  text-align: center;
 }
 
 .op-badge-live {
@@ -1633,51 +2190,141 @@ select {
   color: var(--text3);
 }
 
-.op-expand {
-  display: flex;
-  flex-direction: column;
+.op-empty-state {
+  margin-top: 0;
+}
+
+.orders-blotter-shell {
+  display: grid;
   gap: 10px;
-  margin: 10px -10px -8px;
-  padding: 10px;
-  border-top: 1px solid var(--border2);
-  background: var(--bg3);
+  min-height: 0;
 }
 
-.op-expand .op-val {
-  color: var(--text1);
+.orders-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
-.op-tranche-pills {
+.orders-filters {
+  display: flex;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
-.op-pill {
-  padding: 2px 6px;
-  border-radius: 2px;
+.orders-filter-btn,
+.orders-cancel-btn {
+  border: 1px solid var(--border);
+  background: var(--bg2);
+  color: var(--text2);
   font-family: "IBM Plex Mono", monospace;
-  font-size: 8px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+}
+
+.orders-filter-btn.active {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+
+.orders-filter-btn:disabled,
+.orders-cancel-btn:disabled {
+  opacity: 0.45;
+}
+
+.orders-cancel-btn {
+  color: var(--amber);
+  border-color: rgba(245, 168, 64, 0.4);
+}
+
+.orders-meta {
+  color: var(--text3);
+  font-size: 10px;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.op-pill-active {
-  border: 1px solid var(--green-dim);
-  background: var(--green-bg);
-  color: var(--green);
+.order-tree-toggle-row td {
+  padding: 6px 0 0;
+  border-bottom: none;
 }
 
-.op-pill-sold {
-  border: 1px solid var(--border);
-  background: rgba(106, 125, 149, 0.1);
+.order-tree-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 10px;
+  border: 1px solid var(--border2);
+  background: var(--bg2);
+  color: var(--text1);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.order-tree-toggle-main {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.order-tree-toggle-meta {
+  max-width: 220px;
+  overflow: hidden;
   color: var(--text3);
-  text-decoration: line-through;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 8px;
+  letter-spacing: 0.05em;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.op-pill-runner {
-  border: 1px solid var(--purple);
-  background: rgba(155, 127, 232, 0.12);
-  color: var(--purple);
+.orders-header-label {
+  display: inline-flex;
+  align-items: center;
+}
+
+.orders-col-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 2;
+}
+
+.orders-col-resize-handle::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 3px;
+  width: 2px;
+  background: rgba(106, 125, 149, 0.35);
+}
+
+.orders-col-resize-handle:hover::after {
+  background: var(--cyan);
+}
+
+.order-tree-indent {
+  padding-left: 18px !important;
+}
+
+.order-child-row td {
+  background: rgba(20, 24, 32, 0.7);
+}
+
+.merged-orders-table .order-row-highlight {
+  background: rgba(49, 196, 218, 0.08);
 }
 
 ::-webkit-scrollbar {
@@ -1694,13 +2341,49 @@ select {
   border-radius: 2px;
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1440px) {
   .workspace {
-    grid-template-columns: 280px 1fr 260px;
+    grid-template-columns: var(--setup-width, 286px) 6px minmax(0, 1fr) 6px var(--log-width, 264px);
+  }
+
+  .protect-controls,
+  .profit-controls {
+    width: min(100%, 496px);
+  }
+
+  .entry-row {
+    gap: 14px;
+  }
+}
+
+@media (max-width: 1240px) {
+  .workspace {
+    grid-template-columns: var(--setup-width, 272px) 6px minmax(0, 1fr) 6px var(--log-width, 240px);
+  }
+
+  .header {
+    gap: 12px;
+    padding: 0 14px;
+  }
+
+  .protect-controls,
+  .profit-controls {
+    grid-template-columns: 52px 40px 60px 80px 80px 1fr;
+    width: min(100%, 452px);
+  }
+
+  .running-pnl-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 1024px) {
+  .header {
+    flex-wrap: wrap;
+    height: auto;
+    padding: 10px 14px;
+  }
+
   .workspace {
     grid-template-columns: 1fr;
     grid-template-rows: auto;
@@ -1708,11 +2391,64 @@ select {
   }
 
   .setup-panel,
-  .entry-panel,
-  .protect-panel,
-  .manage-panel,
-  .log-panel {
+  .center-stage,
+  .right-rail {
     grid-column: auto;
     grid-row: auto;
+  }
+
+  .workspace-splitter {
+    display: none;
+  }
+
+  .execution-row {
+    grid-template-columns: 1fr;
+  }
+
+  .execution-column {
+    grid-template-rows: auto;
+  }
+
+  .execution-column-left,
+  .execution-column-right,
+  .right-rail {
+    grid-template-rows: auto;
+  }
+
+  .entry-body {
+    height: auto;
+    overflow: visible;
+  }
+
+  .entry-row {
+    flex-wrap: wrap;
+  }
+
+  .entry-panel-header {
+    flex-wrap: wrap;
+  }
+
+  .entry-header-market {
+    flex-wrap: wrap;
+    gap: 10px;
+    overflow-x: visible;
+  }
+
+  .entry-live-price {
+    justify-content: flex-start;
+  }
+
+  .protect-controls,
+  .profit-controls {
+    width: 100%;
+  }
+
+  .running-pnl-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .running-pnl-leg {
+    grid-template-columns: 1fr;
+    gap: 4px;
   }
 }

--- a/frontend/components/ActivityLog.tsx
+++ b/frontend/components/ActivityLog.tsx
@@ -1,34 +1,64 @@
 import type { LogEntry } from "@/lib/types";
 import { formatLogTime } from "@/lib/cockpit-ui";
 
-export function ActivityLog({ logs, onClear, clearFlashing = false }: { logs: LogEntry[]; onClear: () => void; clearFlashing?: boolean }) {
+export function ActivityLog({
+  logs,
+  onClear,
+  clearFlashing = false,
+  collapsed = false,
+  onToggleCollapse,
+}: {
+  logs: LogEntry[];
+  onClear: () => void;
+  clearFlashing?: boolean;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+}) {
+  const visibleLogs = logs.slice(0, 60);
+
   return (
-    <div className="panel log-panel">
+    <div className={`panel log-panel ${collapsed ? "panel-collapsed" : ""}`}>
       <div className="panel-header">
-        <div className="panel-title">Activity Log</div>
-        <button type="button" className={`btn btn-ghost log-clear-btn ${clearFlashing ? "flash" : ""}`} onClick={onClear}>CLR</button>
+        <div className="panel-title-row panel-title-row-clickable" onClick={onToggleCollapse}>
+          <button
+            type="button"
+            className="panel-collapse-btn"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleCollapse?.();
+            }}
+          >
+            {collapsed ? "+" : "-"}
+          </button>
+          <div className="panel-title">Activity Log</div>
+        </div>
+        <button type="button" className={`btn btn-ghost log-clear-btn ${clearFlashing ? "flash" : ""}`} onClick={onClear} disabled={collapsed}>
+          CLR
+        </button>
       </div>
-      <div className="log-body">
-        {logs.length ? (
-          logs.map((entry) => (
-            <div className="log-entry" key={entry.id}>
-              <div className="log-time">{formatLogTime(entry.created_at)}</div>
+      {!collapsed ? (
+        <div className="log-body">
+          {visibleLogs.length ? (
+            visibleLogs.map((entry) => (
+              <div className="log-entry" key={entry.id}>
+                <div className="log-time">{formatLogTime(entry.created_at)}</div>
+                <div className="log-msg">
+                  <span className={`tag tag-${entry.tag}`}>{entry.tag.toUpperCase()}</span>
+                  {entry.message}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="log-entry">
+              <div className="log-time">--:--:--</div>
               <div className="log-msg">
-                <span className={`tag tag-${entry.tag}`}>{entry.tag.toUpperCase()}</span>
-                {entry.message}
+                <span className="tag tag-sys">SYS</span>
+                Cockpit initialized. Enter ticker to begin.
               </div>
             </div>
-          ))
-        ) : (
-          <div className="log-entry">
-            <div className="log-time">--:--:--</div>
-            <div className="log-msg">
-              <span className="tag tag-sys">SYS</span>
-              Cockpit initialized. Enter ticker to begin.
-            </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/components/Cockpit.tsx
+++ b/frontend/components/Cockpit.tsx
@@ -1,28 +1,209 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from "react";
 
 import { ActivityLog } from "@/components/ActivityLog";
 import { CockpitHeader } from "@/components/CockpitHeader";
 import { EntryPanel } from "@/components/EntryPanel";
 import { LoginPanel } from "@/components/LoginPanel";
+import { OpenPositionsPanel } from "@/components/OpenPositionsPanel";
 import { ProfitTakingPanel } from "@/components/ProfitTakingPanel";
+import { RecentOrdersPanel } from "@/components/RecentOrdersPanel";
+import { RunningPnlPanel } from "@/components/RunningPnlPanel";
 import { SetupPanel } from "@/components/SetupPanel";
 import { StopProtectionPanel } from "@/components/StopProtectionPanel";
 import { ApiError, api } from "@/lib/api";
-import type { AccountView, AuthUser, LogEntry, OffHoursMode, PositionView, SetupResponse, StopMode, TrancheMode } from "@/lib/types";
+import { defaultAllocationPcts, defaultStopPcts, normalizeAllocationPcts, normalizeStopPcts } from "@/lib/cockpit-ui";
+import type { AccountView, AuthUser, EntryOrderDraft, LogEntry, OffHoursMode, OrderView, PositionView, SetupResponse, StopMode, TrancheMode } from "@/lib/types";
 
 const DEFAULT_STOP_MODES: StopMode[] = [
-  { mode: "stop", pct: null },
-  { mode: "stop", pct: null },
-  { mode: "stop", pct: null }
+  { mode: "stop", pct: 33.33 },
+  { mode: "stop", pct: 66.67 },
+  { mode: "stop", pct: 100.0 }
 ];
 
 const DEFAULT_TRANCHE_MODES: TrancheMode[] = [
-  { mode: "limit", trail: 2, trailUnit: "$", target: "1R", manualPrice: null },
-  { mode: "limit", trail: 2, trailUnit: "$", target: "2R", manualPrice: null },
-  { mode: "runner", trail: 2, trailUnit: "$", target: "3R", manualPrice: null }
+  { mode: "limit", allocationPct: 33.33, trail: 2, trailUnit: "$", target: "1R", manualPrice: null },
+  { mode: "limit", allocationPct: 33.33, trail: 2, trailUnit: "$", target: "2R", manualPrice: null },
+  { mode: "runner", allocationPct: 33.34, trail: 2, trailUnit: "$", target: "3R", manualPrice: null }
 ];
+
+const DEFAULT_ENTRY_ORDER: EntryOrderDraft = {
+  orderType: "limit",
+  timeInForce: "day",
+  orderClass: "simple",
+  extendedHours: false,
+  limitPrice: null,
+  stopPrice: null,
+  otoExitSide: "stop_loss",
+  takeProfit: null,
+  stopLoss: null,
+};
+
+const MAX_LOG_ENTRIES = 120;
+const SETUP_DEBOUNCE_MS = 450;
+const STORAGE_LAYOUT_KEY = "cockpit.layout.v3";
+const STORAGE_COLLAPSE_KEY = "cockpit.collapse.v2";
+
+type PanelCollapseState = {
+  stopProtection: boolean;
+  profitTaking: boolean;
+  recentOrders: boolean;
+  runningPnl: boolean;
+  openPositions: boolean;
+  activityLog: boolean;
+};
+
+type LayoutState = {
+  setupWidth: number;
+  logWidth: number;
+  centerTopPct: number;
+  executionLeftPct: number;
+  executionLeftTopPct: number;
+  monitorRightTopPct: number;
+  rightRailTopPct: number;
+};
+
+const DEFAULT_COLLAPSE_STATE: PanelCollapseState = {
+  stopProtection: false,
+  profitTaking: false,
+  recentOrders: false,
+  runningPnl: false,
+  openPositions: false,
+  activityLog: false,
+};
+
+const DEFAULT_LAYOUT_STATE: LayoutState = {
+  setupWidth: 300,
+  logWidth: 280,
+  centerTopPct: 28,
+  executionLeftPct: 50,
+  executionLeftTopPct: 56,
+  monitorRightTopPct: 56,
+  rightRailTopPct: 46,
+};
+
+function readStoredJson<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    return { ...fallback, ...(JSON.parse(raw) as Partial<T>) };
+  } catch {
+    return fallback;
+  }
+}
+
+function sanitizeLayoutState(layout: LayoutState): LayoutState {
+  return {
+    setupWidth: Math.max(240, Math.min(420, layout.setupWidth)),
+    logWidth: Math.max(220, Math.min(420, layout.logWidth)),
+    centerTopPct: Math.max(18, Math.min(55, layout.centerTopPct)),
+    executionLeftPct: Math.max(30, Math.min(70, layout.executionLeftPct)),
+    executionLeftTopPct: Math.max(25, Math.min(75, layout.executionLeftTopPct)),
+    monitorRightTopPct: Math.max(25, Math.min(75, layout.monitorRightTopPct)),
+    rightRailTopPct: Math.max(25, Math.min(75, layout.rightRailTopPct)),
+  };
+}
+
+function effectiveStopPrice(setup: SetupResponse | null, stopRef: "lod" | "atr" | "manual", manualStop: number | null) {
+  if (!setup) return 0;
+  if (stopRef === "manual") return manualStop ?? 0;
+  return stopRef === "atr" ? setup.atrStop : setup.lodStop;
+}
+
+function deriveSetupForSelection(
+  setup: SetupResponse | null,
+  account: AccountView | null,
+  stopRef: "lod" | "atr" | "manual",
+  manualStop: number | null,
+  entryPrice: number
+) {
+  if (!setup) return null;
+  const equity = account?.equity ?? setup.accountEquity;
+  const buyingPower = account?.buying_power ?? setup.accountBuyingPower;
+  const riskPct = account?.risk_pct ?? setup.riskPct;
+  const stopPrice = stopRef === "manual" ? manualStop : stopRef === "atr" ? setup.atrStop : setup.lodStop;
+  const validStop = typeof stopPrice === "number" && Number.isFinite(stopPrice) && stopPrice > 0 && stopPrice < entryPrice;
+  const perShareRisk = validStop ? Number((entryPrice - stopPrice).toFixed(2)) : 0;
+  const dollarRisk = Number((equity * (riskPct / 100)).toFixed(2));
+  const maxNotionalCap = equity * ((account?.max_position_notional_pct ?? 100) / 100);
+  const effectiveNotionalCap = Math.min(buyingPower, maxNotionalCap);
+  const shares = validStop && entryPrice > 0
+    ? Math.max(0, Math.min(Math.floor(dollarRisk / perShareRisk), Math.floor(effectiveNotionalCap / entryPrice)))
+    : 0;
+
+  return {
+    ...setup,
+    entry: entryPrice,
+    stopReferenceDefault: stopRef,
+    finalStop: validStop ? stopPrice : 0,
+    perShareRisk,
+    dollarRisk,
+    shares,
+    riskPct,
+    accountEquity: equity,
+    accountBuyingPower: buyingPower,
+    r1: perShareRisk > 0 ? Number((entryPrice + perShareRisk).toFixed(2)) : entryPrice,
+    r2: perShareRisk > 0 ? Number((entryPrice + perShareRisk * 2).toFixed(2)) : entryPrice,
+    r3: perShareRisk > 0 ? Number((entryPrice + perShareRisk * 3).toFixed(2)) : entryPrice
+  };
+}
+
+function defaultStopModesFor(stopMode: number): StopMode[] {
+  const defaults = defaultStopPcts(stopMode);
+  return DEFAULT_STOP_MODES.map((mode, index) => ({
+    ...mode,
+    pct: defaults[index] ?? mode.pct,
+  }));
+}
+
+function defaultTrancheModesFor(count: number): TrancheMode[] {
+  const allocations = defaultAllocationPcts(count);
+  return DEFAULT_TRANCHE_MODES.map((mode, index) => ({
+    ...mode,
+    allocationPct: allocations[index] ?? mode.allocationPct,
+  }));
+}
+
+function buildEntryOrderDraft(
+  current: EntryOrderDraft,
+  entryPrice: number,
+  protectiveStop: number,
+  trancheModes: TrancheMode[],
+): EntryOrderDraft {
+  const next = {
+    ...current,
+    limitPrice: current.orderType === "limit" || current.orderType === "stop_limit" ? (current.limitPrice ?? entryPrice) : null,
+    stopPrice: current.orderType === "stop" || current.orderType === "stop_limit" ? (current.stopPrice ?? entryPrice) : null,
+  };
+  const primaryProfitMode = trancheModes[0];
+  const takeProfitLimit = primaryProfitMode
+    ? primaryProfitMode.target === "Manual" && primaryProfitMode.manualPrice !== null
+      ? primaryProfitMode.manualPrice
+      : null
+    : null;
+  if (next.orderClass === "bracket") {
+    next.takeProfit = { limitPrice: takeProfitLimit };
+    next.stopLoss = { stopPrice: protectiveStop, limitPrice: null };
+  } else if (next.orderClass === "oto") {
+    if (next.otoExitSide === "take_profit") {
+      next.takeProfit = { limitPrice: takeProfitLimit };
+      next.stopLoss = null;
+    } else {
+      next.stopLoss = { stopPrice: protectiveStop, limitPrice: null };
+      next.takeProfit = null;
+    }
+  } else {
+    next.takeProfit = null;
+    next.stopLoss = null;
+  }
+  if (next.orderClass === "oco") {
+    next.takeProfit = { limitPrice: takeProfitLimit };
+    next.stopLoss = { stopPrice: protectiveStop, limitPrice: null };
+  }
+  return next;
+}
 
 export function Cockpit() {
   const [flashState, setFlashState] = useState<Record<string, number>>({});
@@ -31,34 +212,142 @@ export function Cockpit() {
   const [authBusy, setAuthBusy] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
   const [runtimeError, setRuntimeError] = useState<string | null>(null);
-  const [ticker, setTicker] = useState("AAPL");
+  const [ticker, setTicker] = useState("");
+  const [activeLoadedTicker, setActiveLoadedTicker] = useState("");
+  const [setupLoadPending, setSetupLoadPending] = useState(false);
+  const [setupLatencyMs, setSetupLatencyMs] = useState<number | null>(null);
   const [account, setAccount] = useState<AccountView | null>(null);
   const [setup, setSetup] = useState<SetupResponse | null>(null);
   const [positions, setPositions] = useState<PositionView[]>([]);
   const [activeSymbol, setActiveSymbol] = useState("");
   const [entryPrice, setEntryPrice] = useState(0);
-  const [manualStop, setManualStop] = useState(0);
+  const [manualStop, setManualStop] = useState<number | null>(null);
   const [offHoursMode, setOffHoursMode] = useState<OffHoursMode>("queue_for_open");
+  const [entryOrder, setEntryOrder] = useState<EntryOrderDraft>(DEFAULT_ENTRY_ORDER);
   const [stopRef, setStopRef] = useState<"lod" | "atr" | "manual">("lod");
   const [stopMode, setStopMode] = useState(3);
   const [stopModes, setStopModes] = useState<StopMode[]>(DEFAULT_STOP_MODES);
   const [trancheCount, setTrancheCount] = useState(3);
   const [trancheModes, setTrancheModes] = useState<TrancheMode[]>(DEFAULT_TRANCHE_MODES);
   const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [recentOrders, setRecentOrders] = useState<OrderView[]>([]);
+  const [cancelingBrokerOrderId, setCancelingBrokerOrderId] = useState<string | null>(null);
+  const [offHoursModalOpen, setOffHoursModalOpen] = useState(false);
+  const [panelCollapse, setPanelCollapse] = useState<PanelCollapseState>(DEFAULT_COLLAPSE_STATE);
+  const [layoutState, setLayoutState] = useState<LayoutState>(DEFAULT_LAYOUT_STATE);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimerRef = useRef<number | null>(null);
+  const setupDebounceRef = useRef<number | null>(null);
+  const setupRequestSeqRef = useRef(0);
+  const setupAbortRef = useRef<AbortController | null>(null);
+  const wsHasOpenedRef = useRef(false);
   const activeSymbolRef = useRef("");
   const setupLoadedRef = useRef(false);
-  const initialAutoloadRef = useRef(false);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
 
   const activePosition = useMemo(
     () => positions.find((position) => position.symbol === activeSymbol) ?? null,
     [positions, activeSymbol]
   );
+  const effectiveSetup = useMemo(
+    () => deriveSetupForSelection(setup, account, stopRef, manualStop, entryPrice || setup?.entry || 0),
+    [account, entryPrice, manualStop, setup, stopRef]
+  );
+  const effectiveEntryOrder = useMemo(
+    () =>
+      buildEntryOrderDraft(
+        entryOrder,
+        entryPrice || effectiveSetup?.entry || 0,
+        effectiveStopPrice(setup, stopRef, manualStop),
+        trancheModes,
+      ),
+    [entryOrder, entryPrice, manualStop, setup, stopRef, effectiveSetup, trancheModes]
+  );
+  const attachedSummary = useMemo(
+    () => ({
+      takeProfit: effectiveEntryOrder.takeProfit?.limitPrice ?? null,
+      stopLoss: effectiveEntryOrder.stopLoss?.stopPrice ?? null,
+    }),
+    [effectiveEntryOrder]
+  );
   const phase = activePosition?.phase ?? (setup ? "setup_loaded" : "idle");
-  const livePrice = activePosition?.livePrice ?? setup?.last ?? null;
-  const delta = livePrice !== null && setup ? livePrice - setup.entry : 0;
-  const deltaPct = livePrice !== null && setup ? ((livePrice - setup.entry) / setup.entry) * 100 : 0;
+  const livePrice = activePosition?.livePrice ?? effectiveSetup?.last ?? null;
+  const delta = livePrice !== null && effectiveSetup ? livePrice - effectiveSetup.entry : 0;
+  const deltaPct = livePrice !== null && effectiveSetup ? ((livePrice - effectiveSetup.entry) / effectiveSetup.entry) * 100 : 0;
+  const normalizedTicker = ticker.trim().toUpperCase();
+  const tickerMatchesActiveSetup = normalizedTicker.length > 0 && normalizedTicker === activeLoadedTicker;
+  const actionTickerMismatch = Boolean(setup) && normalizedTicker.length > 0 && !tickerMatchesActiveSetup;
+  const orderConfigDisabledReason = effectiveEntryOrder.orderClass === "oco"
+    ? "OCO is exit-only at Alpaca and cannot be used for a new entry."
+    : null;
+  const actionsDisabled = !effectiveSetup || setupLoadPending || actionTickerMismatch || Boolean(orderConfigDisabledReason);
+  const disabledReason = setupLoadPending
+    ? `Resolving ${normalizedTicker || activeLoadedTicker || "ticker"}...`
+    : actionTickerMismatch
+      ? `Wait for ${normalizedTicker} to finish loading before previewing or entering a trade.`
+      : orderConfigDisabledReason ?? effectiveSetup?.sizingWarning ?? null;
+  const leftColumnCollapsed = panelCollapse.stopProtection && panelCollapse.profitTaking;
+  const rightColumnCollapsed = panelCollapse.recentOrders && panelCollapse.runningPnl;
+  const effectiveExecutionLeftPct = leftColumnCollapsed && !rightColumnCollapsed
+    ? 18
+    : rightColumnCollapsed && !leftColumnCollapsed
+      ? 82
+      : layoutState.executionLeftPct;
+  const effectiveExecutionLeftTopPct = panelCollapse.stopProtection && !panelCollapse.profitTaking
+    ? 18
+    : panelCollapse.profitTaking && !panelCollapse.stopProtection
+      ? 82
+      : layoutState.executionLeftTopPct;
+  const centerTopRow = `minmax(170px, ${layoutState.centerTopPct}%)`;
+  const centerBottomRow = `minmax(240px, ${100 - layoutState.centerTopPct}%)`;
+  const effectiveLogWidth = layoutState.logWidth;
+  const effectiveMonitorRightTopPct = panelCollapse.recentOrders && !panelCollapse.runningPnl
+    ? 18
+    : panelCollapse.runningPnl && !panelCollapse.recentOrders
+      ? 82
+      : layoutState.monitorRightTopPct;
+  const effectiveRightRailTopPct = panelCollapse.openPositions && !panelCollapse.activityLog
+    ? 18
+    : panelCollapse.activityLog && !panelCollapse.openPositions
+      ? 82
+      : layoutState.rightRailTopPct;
+  const executionLeftTopRow = panelCollapse.stopProtection
+    ? "42px"
+    : `minmax(180px, ${effectiveExecutionLeftTopPct}%)`;
+  const executionLeftBottomRow = panelCollapse.profitTaking
+    ? "42px"
+    : `minmax(140px, ${100 - effectiveExecutionLeftTopPct}%)`;
+  const monitorRightTopRow = panelCollapse.recentOrders
+    ? "42px"
+    : `minmax(180px, ${effectiveMonitorRightTopPct}%)`;
+  const monitorRightBottomRow = panelCollapse.runningPnl
+    ? "42px"
+    : `minmax(140px, ${100 - effectiveMonitorRightTopPct}%)`;
+  const rightRailTopRow = panelCollapse.openPositions
+    ? "42px"
+    : `minmax(180px, ${effectiveRightRailTopPct}%)`;
+  const rightRailBottomRow = panelCollapse.activityLog
+    ? "42px"
+    : `minmax(140px, ${100 - effectiveRightRailTopPct}%)`;
+
+  useEffect(() => {
+    setPanelCollapse(readStoredJson(STORAGE_COLLAPSE_KEY, DEFAULT_COLLAPSE_STATE));
+    setLayoutState(sanitizeLayoutState(readStoredJson(STORAGE_LAYOUT_KEY, DEFAULT_LAYOUT_STATE)));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_COLLAPSE_KEY, JSON.stringify(panelCollapse));
+  }, [panelCollapse]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_LAYOUT_KEY, JSON.stringify(sanitizeLayoutState(layoutState)));
+  }, [layoutState]);
+
+  useEffect(() => () => {
+    dragCleanupRef.current?.();
+  }, []);
 
   useEffect(() => {
     activeSymbolRef.current = activeSymbol;
@@ -103,18 +392,47 @@ export function Cockpit() {
       setupLoadedRef.current = true;
       setActiveSymbol(position.symbol);
       setTicker(position.symbol);
+      setActiveLoadedTicker(position.symbol);
       setSetup(position.setup as SetupResponse);
       setEntryPrice(position.setup.entry);
-      setManualStop(position.setup.finalStop);
+      setStopRef((position.setup.stopReferenceDefault as "lod" | "atr" | "manual") ?? "lod");
+      setManualStop(position.setup.stopReferenceDefault === "manual" ? null : position.setup.finalStop);
+      setEntryOrder({
+        ...DEFAULT_ENTRY_ORDER,
+        limitPrice: position.setup.entry,
+      });
       setOffHoursMode("queue_for_open");
-      setStopMode(position.stopMode || 3);
-      setStopModes(position.stopModes.length ? position.stopModes : DEFAULT_STOP_MODES);
-      setTrancheCount(position.trancheCount || 3);
-      setTrancheModes(position.trancheModes.length ? position.trancheModes : DEFAULT_TRANCHE_MODES);
+      const nextStopMode = position.stopMode || 3;
+      const nextTrancheCount = position.trancheCount || 3;
+      setStopMode(nextStopMode);
+      setStopModes(position.stopModes.length ? position.stopModes : defaultStopModesFor(nextStopMode));
+      setTrancheCount(nextTrancheCount);
+      setTrancheModes(position.trancheModes.length ? position.trancheModes : defaultTrancheModesFor(nextTrancheCount));
       subscribePrice(position.symbol);
     },
     [subscribePrice]
   );
+
+  const clearPendingSetupRequest = useCallback(() => {
+    if (setupDebounceRef.current !== null) {
+      window.clearTimeout(setupDebounceRef.current);
+      setupDebounceRef.current = null;
+    }
+    setupAbortRef.current?.abort();
+    setupAbortRef.current = null;
+    setSetupLoadPending(false);
+  }, []);
+
+  const prependLog = useCallback((tag: string, message: string, symbol?: string | null) => {
+    const nextLog: LogEntry = {
+      id: Date.now(),
+      symbol: symbol ?? null,
+      tag,
+      message,
+      created_at: new Date().toISOString(),
+    };
+    setLogs((current) => [nextLog, ...current].slice(0, MAX_LOG_ENTRIES));
+  }, []);
 
   const hydrate = useCallback(
     async (options?: { autoSelectFirst?: boolean }) => {
@@ -122,8 +440,14 @@ export function Cockpit() {
       let accountView: AccountView;
       let positionRows: PositionView[];
       let logRows: LogEntry[];
+      let recentOrderRows: OrderView[];
       try {
-        [accountView, positionRows, logRows] = await Promise.all([api.getAccount(), api.getPositions(), api.getLogs()]);
+        [accountView, positionRows, logRows, recentOrderRows] = await Promise.all([
+          api.getAccount(),
+          api.getPositions(),
+          api.getLogs(),
+          api.getRecentOrders(),
+        ]);
       } catch (error) {
         if (handleApiError(error)) return false;
         throw error;
@@ -135,6 +459,7 @@ export function Cockpit() {
       setAccount(accountView);
       setPositions(positionRows);
       setLogs(logRows);
+      setRecentOrders(recentOrderRows);
       setAuthRequired(false);
       setAuthError(null);
       setRuntimeError(null);
@@ -168,6 +493,7 @@ export function Cockpit() {
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         setAuthUser(null);
+        setAuthRequired(true);
         return null;
       }
       throw error;
@@ -185,15 +511,15 @@ export function Cockpit() {
 
   useEffect(() => {
     void (async () => {
-      const hydrated = await hydrate({ autoSelectFirst: true });
-      if (hydrated) {
-        await loadSession();
+      const user = await loadSession();
+      if (user) {
+        await hydrate({ autoSelectFirst: true });
       }
     })();
   }, [hydrate, loadSession]);
 
   useEffect(() => {
-    if (authRequired) return;
+    if (authRequired || !authUser) return;
     const wsUrl = process.env.NEXT_PUBLIC_WS_URL ?? "ws://127.0.0.1:8010/ws/cockpit";
     let disposed = false;
     let reconnectDelay = 1000;
@@ -208,7 +534,11 @@ export function Cockpit() {
         if (activeSymbolRef.current) {
           ws.send(JSON.stringify({ action: "subscribe_price", symbol: activeSymbolRef.current }));
         }
-        void hydrate({ autoSelectFirst: Boolean(activeSymbolRef.current) });
+        if (wsHasOpenedRef.current) {
+          void hydrate({ autoSelectFirst: Boolean(activeSymbolRef.current) });
+        } else {
+          wsHasOpenedRef.current = true;
+        }
       };
       ws.onmessage = (event) => {
         const payload = JSON.parse(event.data) as Record<string, unknown>;
@@ -217,12 +547,38 @@ export function Cockpit() {
             current.map((position) =>
               position.symbol === payload.symbol
                 ? { ...position, livePrice: Number(payload.last ?? position.livePrice) }
-                : position
+              : position
             )
           );
         }
-        if (payload.type === "position_update" || payload.type === "order_update" || payload.type === "log_update") {
-          void hydrate({ autoSelectFirst: Boolean(activeSymbolRef.current) });
+        if (payload.type === "position_update" && payload.position && typeof payload.symbol === "string") {
+          const nextPosition = payload.position as PositionView;
+          setPositions((current) => {
+            const next = current.some((position) => position.symbol === nextPosition.symbol)
+              ? current.map((position) => (position.symbol === nextPosition.symbol ? nextPosition : position))
+              : [nextPosition, ...current];
+            return next;
+          });
+          if (activeSymbolRef.current === nextPosition.symbol) {
+            applyPositionState(nextPosition);
+          }
+        }
+        if (payload.type === "order_update" && Array.isArray(payload.orders) && typeof payload.symbol === "string") {
+          setPositions((current) =>
+            current.map((position) =>
+              position.symbol === payload.symbol
+                ? { ...position, orders: payload.orders as PositionView["orders"] }
+                : position
+            )
+          );
+          void api.getRecentOrders().then(setRecentOrders).catch(() => {});
+        }
+        if (payload.type === "log_update" && payload.log) {
+          const nextLog = payload.log as LogEntry;
+          setLogs((current) => {
+            const deduped = current.filter((entry) => entry.id !== nextLog.id);
+            return [nextLog, ...deduped].slice(0, MAX_LOG_ENTRIES);
+          });
         }
       };
       ws.onerror = () => {
@@ -233,7 +589,9 @@ export function Cockpit() {
           wsRef.current = null;
         }
         if (disposed) return;
-        setRuntimeError("Realtime connection lost. Reconnecting...");
+        if (ws.readyState !== WebSocket.OPEN) {
+          setRuntimeError("Realtime connection lost. Reconnecting...");
+        }
         reconnectTimerRef.current = window.setTimeout(() => {
           reconnectDelay = Math.min(reconnectDelay * 2, 5000);
           connect();
@@ -251,44 +609,89 @@ export function Cockpit() {
       wsRef.current?.close();
       wsRef.current = null;
     };
-  }, [authRequired, hydrate]);
+  }, [applyPositionState, authRequired, authUser, hydrate]);
 
-  const loadSetup = useCallback(async () => {
+  const loadSetup = useCallback(async (symbolOverride?: string) => {
+    const nextTicker = (symbolOverride ?? ticker).trim().toUpperCase();
+    if (!nextTicker) {
+      setRuntimeError("Enter a ticker before loading setup.");
+      return;
+    }
+    clearPendingSetupRequest();
+    const requestId = setupRequestSeqRef.current + 1;
+    setupRequestSeqRef.current = requestId;
+    const controller = new AbortController();
+    setupAbortRef.current = controller;
+    setSetupLoadPending(true);
+    const startedAt = performance.now();
     let nextSetup: SetupResponse;
     try {
-      nextSetup = await api.getSetup(ticker);
+      nextSetup = await api.getSetup(nextTicker, controller.signal);
     } catch (error) {
-      if (handleApiError(error)) return;
-      throw error;
+      if (controller.signal.aborted) {
+        return;
+      }
+      if (handleApiError(error)) {
+        setSetupLoadPending(false);
+        return;
+      }
+      const message = error instanceof Error ? error.message : "Unable to load setup.";
+      setRuntimeError(`${nextTicker}: ${message}`);
+      setSetupLoadPending(false);
+      return;
+    }
+    if (setupRequestSeqRef.current !== requestId) {
+      return;
     }
     activeSymbolRef.current = "";
     setupLoadedRef.current = true;
+    setActiveLoadedTicker(nextTicker);
     setSetup(nextSetup);
     setEntryPrice(nextSetup.entry);
-    setManualStop(nextSetup.finalStop);
+    setStopRef(nextSetup.stopReferenceDefault);
+    setManualStop(nextSetup.stopReferenceDefault === "manual" ? null : nextSetup.finalStop);
+    setEntryOrder({
+      ...DEFAULT_ENTRY_ORDER,
+      limitPrice: nextSetup.entry,
+    });
     setActiveSymbol("");
     setStopMode(3);
-    setStopModes(DEFAULT_STOP_MODES);
+    setStopModes(defaultStopModesFor(3));
+    setTrancheCount(3);
+    setTrancheModes(defaultTrancheModesFor(3));
     setOffHoursMode("queue_for_open");
-    subscribePrice(ticker);
-    await hydrate({ autoSelectFirst: false });
+    subscribePrice(nextTicker);
+    setSetupLatencyMs(Math.round(performance.now() - startedAt));
     pulse("load");
     setRuntimeError(null);
-  }, [handleApiError, hydrate, pulse, subscribePrice, ticker]);
+    setSetupLoadPending(false);
+    setupAbortRef.current = null;
+  }, [clearPendingSetupRequest, handleApiError, pulse, subscribePrice, ticker]);
 
   useEffect(() => {
-    if (initialAutoloadRef.current) return;
-    if (!account) return;
-    const hasActivePosition = positions.some((position) =>
-      ["entry_pending", "trade_entered", "protected", "P1_done", "P2_done", "runner_only"].includes(position.phase)
-    );
-    if (setup || hasActivePosition || activeSymbolRef.current) {
-      initialAutoloadRef.current = true;
+    if (!authUser || authRequired) return;
+    const nextTicker = ticker.trim().toUpperCase();
+    if (!nextTicker || nextTicker === activeLoadedTicker) {
+      setSetupLoadPending(false);
       return;
     }
-    initialAutoloadRef.current = true;
-    void loadSetup();
-  }, [account, loadSetup, positions, setup]);
+    if (!/^[A-Z]{2,6}$/.test(nextTicker)) {
+      setSetupLoadPending(false);
+      return;
+    }
+    setSetupLoadPending(true);
+    setupDebounceRef.current = window.setTimeout(() => {
+      setupDebounceRef.current = null;
+      void loadSetup(nextTicker);
+    }, SETUP_DEBOUNCE_MS);
+
+    return () => {
+      if (setupDebounceRef.current !== null) {
+        window.clearTimeout(setupDebounceRef.current);
+        setupDebounceRef.current = null;
+      }
+    };
+  }, [activeLoadedTicker, authRequired, authUser, loadSetup, ticker]);
 
   async function commitRiskPct(nextRiskPct: number) {
     if (!account) return;
@@ -298,11 +701,28 @@ export function Cockpit() {
         risk_pct: nextRiskPct,
         mode: account.mode
       });
-      if (ticker) {
-        const nextSetup = await api.getSetup(ticker);
+      const setupSymbol = activeLoadedTicker || ticker;
+      if (setupSymbol) {
+        const nextSetup = await api.getSetup(setupSymbol);
         setSetup(nextSetup);
         setEntryPrice(nextSetup.entry);
-        setManualStop(nextSetup.finalStop);
+        setStopRef(nextSetup.stopReferenceDefault);
+        setManualStop(nextSetup.stopReferenceDefault === "manual" ? null : nextSetup.finalStop);
+        setEntryOrder({
+          ...DEFAULT_ENTRY_ORDER,
+          limitPrice: nextSetup.entry,
+        });
+        setStopModes(defaultStopModesFor(stopMode));
+        setTrancheModes((current) => {
+          const allocations = normalizeAllocationPcts(
+            current.slice(0, trancheCount).map((item) => item.allocationPct),
+            0,
+            trancheCount
+          );
+          return current.map((item, index) =>
+            index < trancheCount ? { ...item, allocationPct: allocations[index] } : item
+          );
+        });
       }
       await hydrate({ autoSelectFirst: false });
       setRuntimeError(null);
@@ -313,18 +733,27 @@ export function Cockpit() {
   }
 
   async function previewTrade() {
-    if (!setup) return;
+    if (!setup || actionsDisabled) return;
+    if (stopRef === "manual" && (!manualStop || manualStop <= 0)) {
+      setRuntimeError("Enter a valid manual stop price.");
+      return;
+    }
     try {
-      await api.previewTrade({
-        symbol: ticker,
+      const preview = await api.previewTrade({
+        symbol: activeLoadedTicker || ticker,
         entry: entryPrice,
         stopRef,
-        stopPrice: stopRef === "manual" ? manualStop : setup.finalStop,
-        riskPct: account?.risk_pct ?? setup.riskPct
+        stopPrice: effectiveStopPrice(setup, stopRef, manualStop),
+        riskPct: account?.risk_pct ?? setup.riskPct,
+        order: effectiveEntryOrder,
       });
-      await hydrate({ autoSelectFirst: false });
+      prependLog(
+        "info",
+        `Preview: ${preview.symbol} buy ${preview.shares} sh @ ${preview.entry.toFixed(2)} stop ${preview.finalStop.toFixed(2)}`,
+        preview.symbol
+      );
       pulse("preview");
-      setRuntimeError(null);
+      setRuntimeError(preview.sizingWarning ?? null);
     } catch (error) {
       if (handleApiError(error)) return;
       throw error;
@@ -332,18 +761,33 @@ export function Cockpit() {
   }
 
   async function enterTrade() {
+    if (!setup || actionsDisabled) return;
+    if (stopRef === "manual" && (!manualStop || manualStop <= 0)) {
+      setRuntimeError("Enter a valid manual stop price.");
+      return;
+    }
+    if (setup.sessionState !== "regular_open" && effectiveEntryOrder.orderType === "market") {
+      setOffHoursModalOpen(true);
+      return;
+    }
+    await submitEnterTrade(null);
+  }
+
+  async function submitEnterTrade(mode: OffHoursMode | null) {
     if (!setup) return;
     try {
       const position = await api.enterTrade({
-        symbol: ticker,
+        symbol: activeLoadedTicker || ticker,
         entry: entryPrice,
         stopRef,
-        stopPrice: stopRef === "manual" ? manualStop : setup.finalStop,
+        stopPrice: effectiveStopPrice(setup, stopRef, manualStop),
         trancheCount,
-        trancheModes,
-        offHoursMode: setup.sessionState === "regular_open" ? null : offHoursMode
+        trancheModes: trancheModes.slice(0, trancheCount),
+        offHoursMode: setup.sessionState === "regular_open" ? null : mode,
+        order: effectiveEntryOrder,
       });
       setStopMode((current) => current || 3);
+      setOffHoursModalOpen(false);
       await hydrate({ autoSelectFirst: false });
       selectPosition(position.symbol, [position, ...positions]);
       pulse("enter");
@@ -406,6 +850,7 @@ export function Cockpit() {
       if (position.phase === "closed") {
         activeSymbolRef.current = "";
         setActiveSymbol("");
+        setActiveLoadedTicker("");
       }
       pulse("flatten");
       setRuntimeError(null);
@@ -425,6 +870,88 @@ export function Cockpit() {
       if (handleApiError(error)) return;
       throw error;
     }
+  }
+
+  async function cancelOrder(brokerOrderId: string) {
+    try {
+      setCancelingBrokerOrderId(brokerOrderId);
+      await api.cancelOrder(brokerOrderId);
+      await hydrate({ autoSelectFirst: false });
+      prependLog("warn", `Canceled broker order ${brokerOrderId}.`, activeSymbol || activeLoadedTicker || null);
+      setRuntimeError(null);
+    } catch (error) {
+      if (handleApiError(error)) return;
+      throw error;
+    } finally {
+      setCancelingBrokerOrderId(null);
+    }
+  }
+
+  function updateCollapse(key: keyof PanelCollapseState) {
+    setPanelCollapse((current) => ({ ...current, [key]: !current[key] }));
+  }
+
+  function beginDrag(mode: "setup" | "log" | "center" | "execution" | "execution-left" | "monitor-right" | "right-rail", event: ReactMouseEvent<HTMLDivElement>) {
+    if (typeof window === "undefined" || window.innerWidth <= 1024) return;
+    event.preventDefault();
+    dragCleanupRef.current?.();
+    const start = { ...layoutState };
+    const startX = event.clientX;
+    const startY = event.clientY;
+
+    const onMove = (moveEvent: MouseEvent) => {
+      setLayoutState((current) => {
+        if (mode === "setup") {
+          const deltaX = moveEvent.clientX - startX;
+          return { ...current, setupWidth: Math.max(240, Math.min(420, start.setupWidth + deltaX)) };
+        }
+        if (mode === "log") {
+          const deltaX = moveEvent.clientX - startX;
+          return { ...current, logWidth: Math.max(220, Math.min(420, start.logWidth - deltaX)) };
+        }
+        if (mode === "center") {
+          const host = document.querySelector(".center-stage") as HTMLElement | null;
+          const hostHeight = host?.getBoundingClientRect().height ?? window.innerHeight;
+          const deltaY = moveEvent.clientY - startY;
+          const nextPct = Math.max(18, Math.min(55, start.centerTopPct + (deltaY / Math.max(hostHeight, 1)) * 100));
+          return { ...current, centerTopPct: Number(nextPct.toFixed(2)) };
+        }
+        if (mode === "execution") {
+          const deltaX = moveEvent.clientX - startX;
+          const nextPct = Math.max(30, Math.min(70, start.executionLeftPct + (deltaX / window.innerWidth) * 100));
+          return { ...current, executionLeftPct: Number(nextPct.toFixed(2)) };
+        }
+        if (mode === "execution-left") {
+          const host = document.querySelector(".execution-column-left") as HTMLElement | null;
+          const hostHeight = host?.getBoundingClientRect().height ?? window.innerHeight;
+          const deltaY = moveEvent.clientY - startY;
+          const nextPct = Math.max(25, Math.min(75, start.executionLeftTopPct + (deltaY / Math.max(hostHeight, 1)) * 100));
+          return { ...current, executionLeftTopPct: Number(nextPct.toFixed(2)) };
+        }
+        if (mode === "monitor-right") {
+          const host = document.querySelector(".execution-column-right") as HTMLElement | null;
+          const hostHeight = host?.getBoundingClientRect().height ?? window.innerHeight;
+          const deltaY = moveEvent.clientY - startY;
+          const nextPct = Math.max(25, Math.min(75, start.monitorRightTopPct + (deltaY / Math.max(hostHeight, 1)) * 100));
+          return { ...current, monitorRightTopPct: Number(nextPct.toFixed(2)) };
+        }
+        const host = document.querySelector(".right-rail") as HTMLElement | null;
+        const hostHeight = host?.getBoundingClientRect().height ?? window.innerHeight;
+        const deltaY = moveEvent.clientY - startY;
+        const nextPct = Math.max(25, Math.min(75, start.rightRailTopPct + (deltaY / Math.max(hostHeight, 1)) * 100));
+        return { ...current, rightRailTopPct: Number(nextPct.toFixed(2)) };
+      });
+    };
+
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      dragCleanupRef.current = null;
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    dragCleanupRef.current = onUp;
   }
 
   async function submitLogin(payload: { username: string; password: string }) {
@@ -454,11 +981,20 @@ export function Cockpit() {
       setAuthRequired(true);
       setAuthError(null);
       setRuntimeError(null);
+      setSetupLatencyMs(null);
+      wsHasOpenedRef.current = false;
+      clearPendingSetupRequest();
       setSetup(null);
       setPositions([]);
       setLogs([]);
+      setRecentOrders([]);
       setAccount(null);
       setActiveSymbol("");
+      setActiveLoadedTicker("");
+      setTicker("");
+      setEntryPrice(0);
+      setManualStop(null);
+      setEntryOrder(DEFAULT_ENTRY_ORDER);
       activeSymbolRef.current = "";
       setupLoadedRef.current = false;
     }
@@ -471,94 +1007,214 @@ export function Cockpit() {
   return (
     <main>
       <CockpitHeader
-        ticker={ticker}
-        onTickerChange={setTicker}
-        onLoad={() => void loadSetup()}
-        onReset={() => {
-          activeSymbolRef.current = "";
-          setupLoadedRef.current = false;
-          setSetup(null);
-          setActiveSymbol("");
-          setTicker("");
-          setEntryPrice(0);
-          setManualStop(0);
-          setOffHoursMode("queue_for_open");
-          setStopMode(3);
-          setStopModes(DEFAULT_STOP_MODES);
-          setTrancheCount(3);
-          setTrancheModes(DEFAULT_TRANCHE_MODES);
-          void hydrate({ autoSelectFirst: false });
-          pulse("reset");
-        }}
-        loadFlashing={Boolean(flashState.load)}
-        resetFlashing={Boolean(flashState.reset)}
         phase={phase}
-        livePrice={livePrice}
-        delta={delta}
-        deltaPct={deltaPct}
         account={account}
         authUser={authUser}
         onLogout={() => void logout()}
       />
       {runtimeError ? <div className="runtime-banner">{runtimeError}</div> : null}
-      <div className="workspace">
+      <div
+        className="workspace"
+        style={
+          {
+            "--setup-width": `${layoutState.setupWidth}px`,
+            "--log-width": `${effectiveLogWidth}px`,
+            "--center-top-row": centerTopRow,
+            "--center-bottom-row": centerBottomRow,
+            "--execution-left": `${effectiveExecutionLeftPct}%`,
+            "--execution-right": `${100 - effectiveExecutionLeftPct}%`,
+            "--execution-left-top": `${effectiveExecutionLeftTopPct}%`,
+            "--execution-left-bottom": `${100 - effectiveExecutionLeftTopPct}%`,
+            "--monitor-right-top": `${effectiveMonitorRightTopPct}%`,
+            "--monitor-right-bottom": `${100 - effectiveMonitorRightTopPct}%`,
+            "--right-rail-top": `${effectiveRightRailTopPct}%`,
+            "--right-rail-bottom": `${100 - effectiveRightRailTopPct}%`,
+            "--execution-left-top-row": executionLeftTopRow,
+            "--execution-left-bottom-row": executionLeftBottomRow,
+            "--monitor-right-top-row": monitorRightTopRow,
+            "--monitor-right-bottom-row": monitorRightBottomRow,
+            "--right-rail-top-row": rightRailTopRow,
+            "--right-rail-bottom-row": rightRailBottomRow,
+          } as CSSProperties
+        }
+      >
         <SetupPanel
-          symbol={activeSymbol || ticker}
-          setup={setup}
+          symbol={activeSymbol || activeLoadedTicker}
+          setup={effectiveSetup}
           account={account}
-          positions={positions}
-          onSelectPosition={selectPosition}
+          setupLatencyMs={setupLatencyMs}
           onRiskPctCommit={(value) => void commitRiskPct(value)}
         />
-        <EntryPanel
-          setup={setup}
-          entryPrice={entryPrice || setup?.entry || 0}
-          stopRef={stopRef}
-          manualStop={manualStop || setup?.finalStop || 0}
-          offHoursMode={offHoursMode}
-          previewFlashing={Boolean(flashState.preview)}
-          enterFlashing={Boolean(flashState.enter)}
-          onEntryChange={setEntryPrice}
-          onStopRefChange={setStopRef}
-          onManualStopChange={setManualStop}
-          onOffHoursModeChange={setOffHoursMode}
-          onPreview={() => void previewTrade()}
-          onEnterTrade={() => void enterTrade()}
-        />
-        <StopProtectionPanel
-          setup={setup}
-          phase={activePosition?.phase ?? null}
-          stopMode={stopMode}
-          stopModes={stopModes}
-          tranches={activePosition?.tranches ?? []}
-          orders={activePosition?.orders ?? []}
-          executeFlashing={Boolean(flashState.stop)}
-          moveToBeFlashing={Boolean(flashState.be)}
-          flattenFlashing={Boolean(flashState.flatten)}
-          onStopModeChange={setStopMode}
-          onStopModeValueChange={(index, value) =>
-            setStopModes((current) => current.map((item, itemIndex) => (itemIndex === index ? value : item)))
-          }
-          onExecute={() => void executeStops()}
-          onMoveToBe={() => void moveToBe()}
-          onFlatten={() => void flatten()}
-        />
-        <ProfitTakingPanel
-          setup={setup}
-          activePosition={activePosition}
-          trancheCount={trancheCount}
-          trancheModes={trancheModes}
-          tranches={activePosition?.tranches ?? []}
-          orders={activePosition?.orders ?? []}
-          executeFlashing={Boolean(flashState.profit)}
-          onTrancheCountChange={setTrancheCount}
-          onTrancheModeChange={(index, value) =>
-            setTrancheModes((current) => current.map((item, itemIndex) => (itemIndex === index ? value : item)))
-          }
-          onExecute={() => void executeProfit()}
-        />
-        <ActivityLog logs={logs} clearFlashing={Boolean(flashState.clear)} onClear={() => void clearLogs()} />
+        <div className="workspace-splitter workspace-splitter-setup" onMouseDown={(event) => beginDrag("setup", event)} />
+        <div className="center-stage">
+          <EntryPanel
+            ticker={ticker}
+            setupLoadPending={setupLoadPending}
+            onTickerChange={setTicker}
+            onLoad={() => void loadSetup()}
+            setup={effectiveSetup}
+            activeSymbolLabel={activeSymbol || activeLoadedTicker || normalizedTicker}
+            livePrice={livePrice}
+            delta={delta}
+            deltaPct={deltaPct}
+            entryPrice={entryPrice || effectiveSetup?.entry || 0}
+            stopRef={stopRef}
+            manualStop={manualStop}
+            order={effectiveEntryOrder}
+            attachedSummary={attachedSummary}
+            actionsDisabled={actionsDisabled}
+            disabledReason={disabledReason}
+            previewFlashing={Boolean(flashState.preview)}
+            enterFlashing={Boolean(flashState.enter)}
+            onEntryChange={setEntryPrice}
+            onStopRefChange={setStopRef}
+            onManualStopChange={setManualStop}
+            onOrderChange={setEntryOrder}
+            onPreview={() => void previewTrade()}
+            onEnterTrade={() => void enterTrade()}
+          />
+          <div className="workspace-splitter workspace-splitter-horizontal workspace-splitter-center" onMouseDown={(event) => beginDrag("center", event)} />
+          <div className="execution-row">
+            <div className="execution-column execution-column-left">
+              <StopProtectionPanel
+                setup={effectiveSetup}
+                phase={activePosition?.phase ?? null}
+                stopMode={stopMode}
+                stopModes={stopModes}
+                tranches={activePosition?.tranches ?? []}
+                orders={activePosition?.orders ?? []}
+                executeFlashing={Boolean(flashState.stop)}
+                moveToBeFlashing={Boolean(flashState.be)}
+                flattenFlashing={Boolean(flashState.flatten)}
+                collapsed={panelCollapse.stopProtection}
+                onToggleCollapse={() => updateCollapse("stopProtection")}
+                onStopModeChange={(value) => {
+                  setStopMode(value);
+                  setStopModes(defaultStopModesFor(value));
+                }}
+                onStopModeValueChange={(index, value) =>
+                  setStopModes((current) => {
+                    const next = current.map((item, itemIndex) => (itemIndex === index ? value : item));
+                    if (value.mode === "be") {
+                      for (let itemIndex = 0; itemIndex <= index; itemIndex += 1) {
+                        next[itemIndex] = { ...next[itemIndex], mode: "be", pct: 0 };
+                      }
+                      const remaining = stopMode - (index + 1);
+                      for (let itemIndex = index + 1; itemIndex < stopMode; itemIndex += 1) {
+                        next[itemIndex] = {
+                          ...next[itemIndex],
+                          mode: "stop",
+                          pct: Number((((itemIndex - index) / Math.max(1, remaining)) * 100).toFixed(2)),
+                        };
+                      }
+                      return next;
+                    }
+                    return normalizeStopPcts(
+                      next,
+                      stopMode,
+                      index,
+                      Number(value.pct ?? defaultStopPcts(stopMode)[index] ?? 100)
+                    );
+                  })
+                }
+                onExecute={() => void executeStops()}
+                onMoveToBe={() => void moveToBe()}
+                onFlatten={() => void flatten()}
+              />
+              <div className="workspace-splitter workspace-splitter-horizontal workspace-splitter-execution-left" onMouseDown={(event) => beginDrag("execution-left", event)} />
+              <ProfitTakingPanel
+                setup={effectiveSetup}
+                activePosition={activePosition}
+                trancheCount={trancheCount}
+                trancheModes={trancheModes}
+                executeFlashing={Boolean(flashState.profit)}
+                collapsed={panelCollapse.profitTaking}
+                onToggleCollapse={() => updateCollapse("profitTaking")}
+                onTrancheCountChange={(value) => {
+                  setTrancheCount(value);
+                  setTrancheModes(defaultTrancheModesFor(value));
+                }}
+                onTrancheModeChange={(index, value) =>
+                  setTrancheModes((current) => {
+                    const next = current.map((item, itemIndex) => (itemIndex === index ? value : item));
+                    const allocations = normalizeAllocationPcts(
+                      next.slice(0, trancheCount).map((item) => item.allocationPct),
+                      index,
+                      trancheCount
+                    );
+                    return next.map((item, itemIndex) =>
+                      itemIndex < trancheCount ? { ...item, allocationPct: allocations[itemIndex] } : item
+                    );
+                  })
+                }
+                onExecute={() => void executeProfit()}
+              />
+            </div>
+            <div className="workspace-splitter workspace-splitter-execution" onMouseDown={(event) => beginDrag("execution", event)} />
+            <div className="execution-column execution-column-right">
+              <RecentOrdersPanel
+                orders={recentOrders}
+                activeSymbol={activeSymbol}
+                cancelingBrokerOrderId={cancelingBrokerOrderId}
+                collapsed={panelCollapse.recentOrders}
+                onToggleCollapse={() => updateCollapse("recentOrders")}
+                onCancelOrder={(brokerOrderId) => void cancelOrder(brokerOrderId)}
+              />
+              <div className="workspace-splitter workspace-splitter-horizontal workspace-splitter-monitor-right" onMouseDown={(event) => beginDrag("monitor-right", event)} />
+              <RunningPnlPanel
+                activePosition={activePosition}
+                setup={effectiveSetup}
+                collapsed={panelCollapse.runningPnl}
+                onToggleCollapse={() => updateCollapse("runningPnl")}
+              />
+            </div>
+          </div>
+        </div>
+        <div className="workspace-splitter workspace-splitter-log" onMouseDown={(event) => beginDrag("log", event)} />
+        <div className="right-rail">
+          <OpenPositionsPanel
+            positions={positions}
+            activeSymbol={activeSymbol}
+            collapsed={panelCollapse.openPositions}
+            onToggleCollapse={() => updateCollapse("openPositions")}
+            onSelectPosition={selectPosition}
+          />
+          <div className="workspace-splitter workspace-splitter-horizontal workspace-splitter-right-rail" onMouseDown={(event) => beginDrag("right-rail", event)} />
+          <ActivityLog
+            logs={logs}
+            clearFlashing={Boolean(flashState.clear)}
+            onClear={() => void clearLogs()}
+            collapsed={panelCollapse.activityLog}
+            onToggleCollapse={() => updateCollapse("activityLog")}
+          />
+        </div>
       </div>
+      {offHoursModalOpen && effectiveSetup ? (
+        <div className="modal-backdrop" role="presentation" onClick={() => setOffHoursModalOpen(false)}>
+          <div className="modal-card" role="dialog" aria-modal="true" aria-labelledby="offhoursTitle" onClick={(event) => event.stopPropagation()}>
+            <div className="modal-eyebrow">Alpaca Off-Hours Entry</div>
+            <h2 id="offhoursTitle" className="modal-title">{activeLoadedTicker || effectiveSetup.symbol}</h2>
+            <div className="modal-copy">
+              Session is {effectiveSetup.sessionState.replaceAll("_", " ")}. Standard market orders queue for the next regular session.
+              Extended-hours submission must be a limit order and will use the current entry price {effectiveSetup.entry.toFixed(2)}.
+            </div>
+            <div className="modal-choice-grid">
+              <button type="button" className={`modal-choice ${offHoursMode === "queue_for_open" ? "active" : ""}`} onClick={() => setOffHoursMode("queue_for_open")}>
+                <span className="modal-choice-title">Queue For Open</span>
+                <span className="modal-choice-copy">Submit a regular Alpaca day market order to wait for the next regular session.</span>
+              </button>
+              <button type="button" className={`modal-choice ${offHoursMode === "extended_hours_limit" ? "active" : ""}`} onClick={() => setOffHoursMode("extended_hours_limit")}>
+                <span className="modal-choice-title">Submit Extended-Hours Limit</span>
+                <span className="modal-choice-copy">Submit a day limit order with extended-hours enabled using the current entry price.</span>
+              </button>
+            </div>
+            <div className="modal-actions">
+              <button type="button" className="btn btn-ghost" onClick={() => setOffHoursModalOpen(false)}>CANCEL</button>
+              <button type="button" className="btn btn-cyan" onClick={() => void submitEnterTrade(offHoursMode)}>CONFIRM</button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/frontend/components/CockpitHeader.tsx
+++ b/frontend/components/CockpitHeader.tsx
@@ -1,17 +1,8 @@
 import type { AccountView, AuthUser } from "@/lib/types";
-import { fp, phaseLabel } from "@/lib/cockpit-ui";
+import { phaseLabel } from "@/lib/cockpit-ui";
 
 type Props = {
-  ticker: string;
-  onTickerChange: (value: string) => void;
-  onLoad: () => void;
-  onReset: () => void;
-  loadFlashing?: boolean;
-  resetFlashing?: boolean;
   phase: string;
-  livePrice: number | null;
-  delta: number;
-  deltaPct: number;
   account: AccountView | null;
   authUser: AuthUser | null;
   onLogout: () => void;
@@ -19,16 +10,7 @@ type Props = {
 
 export function CockpitHeader(props: Props) {
   const {
-    ticker,
-    onTickerChange,
-    onLoad,
-    onReset,
-    loadFlashing = false,
-    resetFlashing = false,
     phase,
-    livePrice,
-    delta,
-    deltaPct,
     account,
     authUser,
     onLogout
@@ -38,31 +20,10 @@ export function CockpitHeader(props: Props) {
       <div className="logo">
         TRADER&apos;S <span>/ COCKPIT</span>
       </div>
-      <div className="divider-v" />
-      <div className="ticker-bar">
-        <div className="ticker-input-wrap">
-          <div className="ticker-prefix">$</div>
-          <input
-            id="tickerInput"
-            value={ticker}
-            onChange={(event) => onTickerChange(event.target.value.toUpperCase())}
-            onKeyDown={(event) => event.key === "Enter" && onLoad()}
-            placeholder="AAPL"
-            maxLength={6}
-            autoComplete="off"
-          />
-        </div>
-        <button type="button" className={`btn btn-cyan ${loadFlashing ? "flash" : ""}`} onClick={onLoad}>
-          {"\u2193"} LOAD SETUP
-        </button>
-        <button type="button" className={`btn btn-ghost ${resetFlashing ? "flash" : ""}`} onClick={onReset}>
-          RESET
-        </button>
-      </div>
       <div className="badge badge-paper">{account?.effective_mode?.includes("live") ? "LIVE" : "\u25CF PAPER"}</div>
       <div className={`state-display state-${phase}`}>{phaseLabel(phase)}</div>
       {authUser ? (
-        <div className="auth-strip">
+        <div className="auth-strip auth-strip-end">
           <div className="auth-user">
             {authUser.username}
             <span>{authUser.role}</span>
@@ -72,15 +33,6 @@ export function CockpitHeader(props: Props) {
           </button>
         </div>
       ) : null}
-      <div className="live-price" style={{ display: livePrice === null ? "none" : "block" }}>
-        <span>{ticker}</span>
-        <span> {fp(livePrice)}</span>
-        <span className={`change ${delta >= 0 ? "up" : "dn"}`}>
-          {delta >= 0 ? "+" : ""}
-          {fp(delta)} ({deltaPct >= 0 ? "+" : ""}
-          {deltaPct.toFixed(2)}%)
-        </span>
-      </div>
     </div>
   );
 }

--- a/frontend/components/EntryPanel.tsx
+++ b/frontend/components/EntryPanel.tsx
@@ -1,117 +1,316 @@
-import { fp, sessionStateLabel } from "@/lib/cockpit-ui";
-import type { OffHoursMode, SetupResponse } from "@/lib/types";
+import { fp } from "@/lib/cockpit-ui";
+import type { EntryOrderDraft, EntryOrderType, OtoExitSide, OrderClass, SetupResponse, TimeInForce } from "@/lib/types";
+
+const ORDER_TYPE_OPTIONS: Array<{ value: EntryOrderType; label: string }> = [
+  { value: "limit", label: "LIMIT" },
+  { value: "market", label: "MARKET" },
+  { value: "stop", label: "STOP" },
+  { value: "stop_limit", label: "STOP LIMIT" },
+];
+
+const ORDER_CLASS_OPTIONS: Array<{ value: OrderClass; label: string }> = [
+  { value: "simple", label: "SIMPLE" },
+  { value: "bracket", label: "BRACKET" },
+  { value: "oto", label: "OTO" },
+  { value: "oco", label: "OCO" },
+];
+
+const TIF_OPTIONS: Array<{ value: TimeInForce; label: string }> = [
+  { value: "day", label: "DAY" },
+  { value: "gtc", label: "GTC" },
+  { value: "ioc", label: "IOC" },
+  { value: "fok", label: "FOK" },
+  { value: "opg", label: "OPG" },
+  { value: "cls", label: "CLS" },
+];
+
+function tifAllowed(orderType: EntryOrderType, tif: TimeInForce) {
+  if (orderType === "market" || orderType === "limit") return true;
+  return tif === "day" || tif === "gtc";
+}
 
 type Props = {
+  ticker: string;
+  setupLoadPending: boolean;
+  onTickerChange: (value: string) => void;
+  onLoad: () => void;
   setup: SetupResponse | null;
+  activeSymbolLabel: string;
+  livePrice: number | null;
+  delta: number;
+  deltaPct: number;
   entryPrice: number;
   stopRef: "lod" | "atr" | "manual";
-  manualStop: number;
-  offHoursMode: OffHoursMode;
+  manualStop: number | null;
+  order: EntryOrderDraft;
+  attachedSummary: { takeProfit: number | null; stopLoss: number | null };
+  actionsDisabled?: boolean;
+  disabledReason?: string | null;
   previewFlashing?: boolean;
   enterFlashing?: boolean;
   onEntryChange: (value: number) => void;
   onStopRefChange: (value: "lod" | "atr" | "manual") => void;
-  onManualStopChange: (value: number) => void;
-  onOffHoursModeChange: (value: OffHoursMode) => void;
+  onManualStopChange: (value: number | null) => void;
+  onOrderChange: (value: EntryOrderDraft) => void;
   onPreview: () => void;
   onEnterTrade: () => void;
 };
 
 export function EntryPanel(props: Props) {
   const {
+    ticker,
+    setupLoadPending,
+    onTickerChange,
+    onLoad,
     setup,
+    activeSymbolLabel,
+    livePrice,
+    delta,
+    deltaPct,
     entryPrice,
     stopRef,
     manualStop,
-    offHoursMode,
+    order,
+    attachedSummary,
+    actionsDisabled = false,
+    disabledReason = null,
     previewFlashing = false,
     enterFlashing = false,
     onEntryChange,
     onStopRefChange,
     onManualStopChange,
-    onOffHoursModeChange,
+    onOrderChange,
     onPreview,
-    onEnterTrade
+    onEnterTrade,
   } = props;
-  const stopPrice = stopRef === "manual" ? manualStop : setup?.finalStop ?? 0;
-  const isOffHours = Boolean(setup && setup.sessionState !== "regular_open");
+
+  const stopPrice = stopRef === "manual" ? manualStop : stopRef === "atr" ? setup?.atrStop ?? null : setup?.lodStop ?? null;
+  const cycleStopRef = () => {
+    if (!setup) return;
+    const availableRefs: Array<"lod" | "atr" | "manual"> = [
+      ...(setup.lodIsValid ? ["lod" as const] : []),
+      ...(setup.atrIsValid ? ["atr" as const] : []),
+      "manual",
+    ];
+    const currentIndex = availableRefs.indexOf(stopRef);
+    const nextRef = availableRefs[(currentIndex + 1 + availableRefs.length) % availableRefs.length] ?? "manual";
+    onStopRefChange(nextRef);
+  };
+  const stopRefLabel = stopRef === "lod" ? "LoD" : stopRef === "atr" ? "ATR" : "Manual";
+  const showLimitInput = order.orderType === "limit" || order.orderType === "stop_limit";
+  const showTriggerInput = order.orderType === "stop" || order.orderType === "stop_limit";
+  const showAttachedSummary = order.orderClass !== "simple";
 
   return (
     <div className="panel entry-panel">
-      <div className="panel-header"><div className="panel-title">Trade Entry</div></div>
+      <div className="panel-header entry-panel-header">
+        <div className="panel-title">Trade Entry</div>
+        <div className="entry-header-market" style={{ display: setup ? "flex" : "none" }}>
+          <div className="entry-live-price" style={{ display: livePrice === null ? "none" : "flex" }}>
+            <span className="entry-live-symbol">{activeSymbolLabel}</span>
+            <span>{fp(livePrice)}</span>
+            <span className={`change ${delta >= 0 ? "up" : "dn"}`}>
+              {delta >= 0 ? "+" : ""}
+              {fp(delta)} ({deltaPct >= 0 ? "+" : ""}
+              {deltaPct.toFixed(2)}%)
+            </span>
+          </div>
+          {setup ? (
+            <>
+              <div className="entry-quote-item">
+                <span className="entry-quote-label">Suggested Entry</span>
+                <span className="entry-quote-value cyan">{fp(setup.entry)}</span>
+              </div>
+              <div className="entry-quote-item">
+                <span className="entry-quote-label">Bid / Ask</span>
+                <span className="entry-quote-value">{fp(setup.bid)} / {fp(setup.ask)}</span>
+              </div>
+              <div className="entry-quote-item">
+                <span className="entry-quote-label">Last</span>
+                <span className="entry-quote-value">{fp(setup.last)}</span>
+              </div>
+            </>
+          ) : null}
+        </div>
+      </div>
       <div className="panel-body entry-body">
-        {!setup ? (
-          <div className="entry-empty">Load a setup to enable entry actions.</div>
-        ) : (
-          <div className="entry-stack">
-            <div className="entry-row entry-row-labels">
-              <div className="entry-caption">Entry Price</div>
-              <div className="entry-caption">Shares to Buy</div>
-              <div className="entry-spacer" />
-              <div className="entry-caption">Stop Reference</div>
+        <div className="entry-stack">
+          <div className="entry-order-strip">
+            <div className="ticker-input-wrap entry-ticker-wrap">
+              <div className="ticker-prefix">$</div>
+              <input
+                id="tickerInput"
+                value={ticker}
+                onChange={(event) => onTickerChange(event.target.value.toUpperCase())}
+                onKeyDown={(event) => event.key === "Enter" && onLoad()}
+                placeholder="AAPL"
+                maxLength={6}
+                autoComplete="off"
+              />
             </div>
-            <div className="entry-row entry-row-main">
+            {setupLoadPending ? <div className="ticker-loading">SYNCING</div> : null}
+            <div className="entry-order-field">
+              <span className="entry-order-label">Entry</span>
               <input
                 id="heroEntry"
                 type="number"
                 inputMode="decimal"
                 value={entryPrice}
-                className="hero-entry"
+                className="entry-order-input"
                 onChange={(event) => onEntryChange(Number(event.target.value))}
               />
-              <div className="hero-shares">{setup.shares}</div>
-              <div className="entry-v-divider" />
-              <div className="stop-ref-wrap">
-                <div className="entry-toggle-group">
-                  <button type="button" className={`tranche-count-btn ${stopRef === "lod" ? "active" : ""}`} onClick={() => onStopRefChange("lod")}>LoD</button>
-                  <button type="button" className={`tranche-count-btn ${stopRef === "atr" ? "active" : ""}`} onClick={() => onStopRefChange("atr")}>ATR</button>
-                  <button type="button" className={`tranche-count-btn ${stopRef === "manual" ? "active" : ""}`} onClick={() => onStopRefChange("manual")}>Manual</button>
-                </div>
-                <div className="manual-stop-wrap">
-                  <span className="manual-stop-prefix">$</span>
-                  <input
-                    type="number"
-                    inputMode="decimal"
-                    value={manualStop}
-                    className="manual-stop-input"
-                    onChange={(event) => onManualStopChange(Number(event.target.value))}
-                    disabled={stopRef !== "manual"}
-                  />
-                </div>
-                <span className="hero-stop-price">{fp(stopPrice)}</span>
+              <div className="entry-order-copy">
+                Active stop:{" "}
+                {setup
+                  ? stopRef === "lod"
+                    ? `LoD ${fp(setup.lodStop)}`
+                    : stopRef === "atr"
+                      ? `ATR ${fp(setup.atrStop)}`
+                      : manualStop !== null
+                        ? `Manual ${fp(manualStop)}`
+                        : "Manual required"
+                  : "Load setup"}
               </div>
             </div>
-            <div className="entry-actions-row">
-              <button type="button" className={`btn btn-ghost ${previewFlashing ? "flash" : ""}`} onClick={onPreview}>PREVIEW</button>
-              <button type="button" className={`btn btn-cyan ${enterFlashing ? "flash" : ""}`} onClick={onEnterTrade}>{"\u2197"} ENTER TRADE</button>
+            <div className="entry-order-field">
+              <span className="entry-order-label">Type</span>
+              <select
+                className="entry-select"
+                value={order.orderType}
+                onChange={(event) => onOrderChange({ ...order, orderType: event.target.value as EntryOrderType })}
+              >
+                {ORDER_TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
             </div>
-            {isOffHours ? (
-              <div className="offhours-box">
-                <div className="offhours-eyebrow">Alpaca Off-Hours Entry</div>
-                <div className="offhours-copy">
-                  Session: {sessionStateLabel(setup.sessionState)}. Standard market orders queue for the next regular
-                  session. Extended-hours submission is limit-only and uses the current entry price.
-                </div>
-                <div className="offhours-toggle-group">
-                  <button
-                    type="button"
-                    className={`tranche-count-btn ${offHoursMode === "queue_for_open" ? "active" : ""}`}
-                    onClick={() => onOffHoursModeChange("queue_for_open")}
-                  >
-                    Queue For Open
-                  </button>
-                  <button
-                    type="button"
-                    className={`tranche-count-btn ${offHoursMode === "extended_hours_limit" ? "active" : ""}`}
-                    onClick={() => onOffHoursModeChange("extended_hours_limit")}
-                  >
-                    Submit Extended-Hours Limit
-                  </button>
-                </div>
+            <div className="entry-order-field">
+              <span className="entry-order-label">TIF</span>
+              <select
+                className="entry-select"
+                value={order.timeInForce}
+                onChange={(event) => onOrderChange({ ...order, timeInForce: event.target.value as TimeInForce })}
+              >
+                {TIF_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value} disabled={!tifAllowed(order.orderType, option.value)}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="entry-order-field">
+              <span className="entry-order-label">Class</span>
+              <select
+                className="entry-select"
+                value={order.orderClass}
+                onChange={(event) => onOrderChange({ ...order, orderClass: event.target.value as OrderClass })}
+              >
+                {ORDER_CLASS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {showLimitInput ? (
+              <div className="entry-order-field">
+                <span className="entry-order-label">Limit</span>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  value={order.limitPrice ?? ""}
+                  className="entry-order-input"
+                  onChange={(event) =>
+                    onOrderChange({
+                      ...order,
+                      limitPrice: event.target.value === "" ? null : Number(event.target.value),
+                    })
+                  }
+                />
               </div>
             ) : null}
+            {showTriggerInput ? (
+              <div className="entry-order-field">
+                <span className="entry-order-label">Trigger</span>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  value={order.stopPrice ?? ""}
+                  className="entry-order-input"
+                  onChange={(event) =>
+                    onOrderChange({
+                      ...order,
+                      stopPrice: event.target.value === "" ? null : Number(event.target.value),
+                    })
+                  }
+                />
+              </div>
+            ) : null}
+            <div className="entry-order-field">
+              <span className="entry-order-label">Stop Ref</span>
+              <button type="button" className={`stop-ref-cycle stop-ref-cycle-${stopRef}`} onClick={cycleStopRef}>
+                {stopRefLabel}
+              </button>
+            </div>
           </div>
-        )}
+          {!setup ? (
+            <div className="entry-empty">Load a setup to enable entry actions.</div>
+          ) : (
+            <>
+              <div className="entry-row entry-row-labels">
+                <div className="entry-caption">Shares to Buy</div>
+                <div className="entry-caption">Protective Stop</div>
+                <div className="entry-caption">Attached Exits</div>
+              </div>
+              <div className="entry-row entry-row-compact">
+                <div className="hero-shares">{setup.shares}</div>
+                <div className="stop-ref-wrap">
+                  <div className="manual-stop-wrap">
+                    <span className="manual-stop-prefix">$</span>
+                    <input
+                      type="number"
+                      inputMode="decimal"
+                      value={manualStop ?? ""}
+                      className="manual-stop-input"
+                      onChange={(event) => onManualStopChange(event.target.value === "" ? null : Number(event.target.value))}
+                      disabled={stopRef !== "manual"}
+                    />
+                  </div>
+                  <span className="hero-stop-price">{fp(stopPrice)}</span>
+                </div>
+                <div className="entry-attach-summary">
+                  {showAttachedSummary ? (
+                    <>
+                      {attachedSummary.takeProfit !== null ? <span>TP {fp(attachedSummary.takeProfit)}</span> : null}
+                      {attachedSummary.stopLoss !== null ? <span>SL {fp(attachedSummary.stopLoss)}</span> : null}
+                      {order.orderClass === "oto" ? (
+                        <select
+                          className="entry-select entry-select-oto"
+                          value={order.otoExitSide}
+                          onChange={(event) => onOrderChange({ ...order, otoExitSide: event.target.value as OtoExitSide })}
+                        >
+                          <option value="stop_loss">OTO STOP</option>
+                          <option value="take_profit">OTO PROFIT</option>
+                        </select>
+                      ) : null}
+                    </>
+                  ) : (
+                    <span className="entry-attach-empty">Separate stop/profit panels active</span>
+                  )}
+                </div>
+              </div>
+              {setup.manualStopWarning ? <div className="offhours-copy">{setup.manualStopWarning}</div> : null}
+              {setup.sizingWarning ? <div className="offhours-copy">{setup.sizingWarning}</div> : null}
+              {disabledReason ? <div className="offhours-copy">{disabledReason}</div> : null}
+              <div className="entry-actions-row">
+                <button type="button" className={`btn btn-ghost ${previewFlashing ? "flash" : ""}`} onClick={onPreview} disabled={actionsDisabled}>PREVIEW</button>
+                <button type="button" className={`btn btn-cyan ${enterFlashing ? "flash" : ""}`} onClick={onEnterTrade} disabled={actionsDisabled}>{"\u2197"} ENTER TRADE</button>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/components/OpenPositionsList.tsx
+++ b/frontend/components/OpenPositionsList.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import type { PositionView } from "@/lib/types";
-import { activeShares, fp, isActivePhase, phaseLabel, signedMoney } from "@/lib/cockpit-ui";
+import { activeShares, isActivePhase, signedMoney } from "@/lib/cockpit-ui";
 
 type Props = {
   positions: PositionView[];
@@ -14,83 +16,58 @@ function profitEnabled(position: PositionView, activeSymbol: string): boolean {
 
 export function OpenPositionsList({ positions, activeSymbol, onSelect }: Props) {
   const openPositions = positions.filter((position) => isActivePhase(position.phase));
-  if (!openPositions.length) {
-    return null;
-  }
 
   return (
     <div className="open-positions-section">
-      <div className="op-section-label">
-        <span>
-          Open Positions <span className="op-count">({openPositions.length})</span>
-        </span>
-        <span className="op-live-badge">{"\u25CF"} LIVE</span>
-      </div>
-      {openPositions.map((position) => {
-        const live = position.livePrice || position.setup.entry;
-        const activeQty = activeShares(position);
-        const pnl = (live - position.setup.entry) * activeQty;
-        const stopEnabled = position.stopMode > 0;
-        const isProfitEnabled = profitEnabled(position, activeSymbol);
-        const isActive = position.symbol === activeSymbol;
+      {!openPositions.length ? (
+        <div className="empty-state op-empty-state">
+          <div className="empty-icon">{"\u25C8"}</div>
+          No open positions
+        </div>
+      ) : (
+        <>
+          <div className="op-list-header" aria-hidden="true">
+            <span className="op-list-heading">Symbol</span>
+            <span className="op-list-heading op-list-heading-pnl">U P&amp;L</span>
+            <span className="op-list-heading op-list-heading-badge">S</span>
+            <span className="op-list-heading op-list-heading-badge">P</span>
+          </div>
+          <div className="op-list">
+            {openPositions.map((position) => {
+              const live = position.livePrice || position.setup.entry;
+              const activeQty = activeShares(position);
+              const pnl = (live - position.setup.entry) * activeQty;
+              const stopEnabled = position.stopMode > 0;
+              const isProfitEnabled = profitEnabled(position, activeSymbol);
+              const isSelected = position.symbol === activeSymbol;
 
-        return (
-          <button
-            key={position.symbol}
-            type="button"
-            className={`op-card ${isActive ? "expanded" : ""}`}
-            onClick={() => onSelect(position.symbol)}
-          >
-            <div className="op-card-header">
-              <div className="op-top-row">
-                <span className="op-symbol">{position.symbol}</span>
-                <span className={`op-pnl ${pnl >= 0 ? "op-pnl-pos" : "op-pnl-neg"}`}>{signedMoney(pnl)}</span>
-              </div>
-              <div className="op-metrics-row">
-                <div className="op-metric">
-                  <span className="op-key">ENTRY</span>
-                  <br />
-                  <span className="op-val">{fp(position.setup.entry)}</span>
-                </div>
-                <div className="op-metric">
-                  <span className="op-key">LIVE</span>
-                  <br />
-                  <span className="op-val">{fp(live)}</span>
-                </div>
-                <div className="op-status-wrap">
-                  <span className={`op-badge ${stopEnabled ? "op-badge-live" : "op-badge-danger"}`}>STOP {stopEnabled ? "SET" : "\u2014"}</span>
-                  <span className={`op-badge ${isProfitEnabled ? "op-badge-info" : "op-badge-off"}`}>PROFIT {isProfitEnabled ? "ON" : "\u2014"}</span>
-                </div>
-              </div>
-              {isActive ? (
-                <div className="op-expand">
-                  <div>
-                    <div className="op-expand-label">Tranches</div>
-                    <div className="op-tranche-pills">
-                      {position.tranches.map((tranche) => {
-                        const pillClass = tranche.status === "sold"
-                          ? "op-pill-sold"
-                          : tranche.mode === "runner"
-                            ? "op-pill-runner"
-                            : "op-pill-active";
-                        return (
-                          <span key={tranche.id} className={`op-pill ${pillClass}`}>
-                            {tranche.id}
-                          </span>
-                        );
-                      })}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="op-expand-label">Phase</div>
-                    <div className="op-val">{phaseLabel(position.phase)}</div>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </button>
-        );
-      })}
+              return (
+                <button
+                  key={position.symbol}
+                  type="button"
+                  className={`op-row ${isSelected ? "active" : ""}`}
+                  onClick={() => onSelect(position.symbol)}
+                >
+                  <span className="op-row-symbol">{position.symbol}</span>
+                  <span className={`op-row-pnl ${pnl >= 0 ? "op-pnl-pos" : "op-pnl-neg"}`}>{signedMoney(pnl)}</span>
+                  <span
+                    className={`op-badge op-badge-letter ${stopEnabled ? "op-badge-live" : "op-badge-danger"}`}
+                    title={stopEnabled ? "Stop protection active" : "No stop protection active"}
+                  >
+                    S
+                  </span>
+                  <span
+                    className={`op-badge op-badge-letter ${isProfitEnabled ? "op-badge-info" : "op-badge-off"}`}
+                    title={isProfitEnabled ? "Profit taking active" : "No profit taking active"}
+                  >
+                    P
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/components/OpenPositionsPanel.tsx
+++ b/frontend/components/OpenPositionsPanel.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { OpenPositionsList } from "@/components/OpenPositionsList";
+import type { PositionView } from "@/lib/types";
+
+type Props = {
+  positions: PositionView[];
+  activeSymbol: string;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  onSelectPosition: (symbol: string) => void;
+};
+
+export function OpenPositionsPanel({
+  positions,
+  activeSymbol,
+  collapsed = false,
+  onToggleCollapse,
+  onSelectPosition,
+}: Props) {
+  const openCount = positions.filter((position) =>
+    ["entry_filled", "protected", "P1_done", "P2_done", "runner_only"].includes(position.phase),
+  ).length;
+
+  return (
+    <div className={`panel open-positions-panel ${collapsed ? "panel-collapsed" : ""}`}>
+      <div className="panel-header">
+        <div className="panel-title-row panel-title-row-clickable" onClick={onToggleCollapse}>
+          <button
+            type="button"
+            className="panel-collapse-btn"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleCollapse?.();
+            }}
+          >
+            {collapsed ? "+" : "-"}
+          </button>
+          <div className="panel-title">Open Positions</div>
+        </div>
+        <div className="panel-symbol op-header-meta">
+          <span className="op-header-count">{openCount}</span>
+          <span className="op-header-live">LIVE</span>
+        </div>
+      </div>
+      {!collapsed ? (
+        <div className="panel-body open-positions-body">
+          <OpenPositionsList positions={positions} activeSymbol={activeSymbol} onSelect={onSelectPosition} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/OrdersBlotter.tsx
+++ b/frontend/components/OrdersBlotter.tsx
@@ -1,92 +1,359 @@
-import type { OrderView } from "@/lib/types";
+"use client";
+
+import { Fragment, useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+
 import { formatLogTime, fp } from "@/lib/cockpit-ui";
+import type { OrderView } from "@/lib/types";
+
+type Scope = "all" | "active" | "open";
+
+type Props = {
+  orders: OrderView[];
+  activeSymbol: string;
+  onCancel: (brokerOrderId: string) => void;
+  cancelingBrokerOrderId?: string | null;
+};
+
+type OrderNode = {
+  key: string;
+  root: OrderView;
+  children: OrderView[];
+};
+
+type ColumnWidths = {
+  symbol: number;
+  sideType: number;
+};
+
+const STORAGE_KEY = "cockpit.orders-cols.v1";
+const DEFAULT_WIDTHS: ColumnWidths = {
+  symbol: 104,
+  sideType: 108,
+};
+
+function compactSide(side?: string | null): string {
+  const value = (side ?? "").trim().toUpperCase();
+  if (value === "BUY" || value === "B") return "BUY";
+  if (value === "SELL" || value === "S") return "SELL";
+  return value || "-";
+}
+
+function normalizeType(type: string): string {
+  const value = type.trim().toUpperCase();
+  if (value === "MARKET" || value === "MKT") return "MKT";
+  if (value === "LIMIT" || value === "LMT") return "LMT";
+  if (value === "STOP" || value === "STP") return "STOP";
+  if (value === "TRAIL" || value === "TRAILING") return "TRAIL";
+  return value;
+}
 
 function typeColorClass(type: string): string {
-  if (type === "STOP") return "order-type-stop";
-  if (type === "LMT") return "order-type-limit";
-  if (type === "MKT") return "order-type-market";
-  if (type === "TRAIL") return "order-type-trail";
+  const value = normalizeType(type);
+  if (value === "STOP") return "order-type-stop";
+  if (value === "LMT") return "order-type-limit";
+  if (value === "MKT") return "order-type-market";
+  if (value === "TRAIL") return "order-type-trail";
   return "";
 }
 
-export function OrdersBlotter({ orders }: { orders: OrderView[] }) {
-  const roots = orders.filter((order) => !order.parentId);
-  const childrenOf = (id: string) => orders.filter((order) => order.parentId === id);
+function statusClass(status: string): string {
+  return `order-status-${status.toUpperCase()}`;
+}
+
+function orderTime(order: OrderView): string {
+  return formatLogTime(order.updatedAt ?? order.filledAt ?? order.createdAt ?? "");
+}
+
+function orderSortTime(order: OrderView): number {
+  const value = order.updatedAt ?? order.filledAt ?? order.createdAt ?? "";
+  return new Date(value).getTime() || 0;
+}
+
+function sanitizeWidths(widths: ColumnWidths): ColumnWidths {
+  return {
+    symbol: Math.max(88, Math.min(240, widths.symbol)),
+    sideType: Math.max(68, Math.min(160, widths.sideType)),
+  };
+}
+
+function readStoredWidths(): ColumnWidths {
+  if (typeof window === "undefined") return DEFAULT_WIDTHS;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_WIDTHS;
+    return sanitizeWidths({ ...DEFAULT_WIDTHS, ...(JSON.parse(raw) as Partial<ColumnWidths>) });
+  } catch {
+    return DEFAULT_WIDTHS;
+  }
+}
+
+function groupOrders(orders: OrderView[]): OrderNode[] {
+  const byId = new Map<string, OrderView>();
+  const childrenByParent = new Map<string, OrderView[]>();
+
+  for (const order of orders) {
+    byId.set(order.id, order);
+    if (order.parentId) {
+      const bucket = childrenByParent.get(order.parentId) ?? [];
+      bucket.push(order);
+      childrenByParent.set(order.parentId, bucket);
+    }
+  }
+
+  const roots: OrderNode[] = [];
+  const handled = new Set<string>();
+
+  for (const order of orders) {
+    if (order.parentId && byId.has(order.parentId)) continue;
+    const keyBase = order.parentId ?? order.id ?? order.brokerOrderId ?? `${order.symbol}-${order.createdAt ?? ""}`;
+    const key = `${keyBase}:${order.id}:${order.createdAt ?? ""}`;
+    const children = [...(childrenByParent.get(order.id) ?? [])].sort((left, right) => orderSortTime(right) - orderSortTime(left));
+    roots.push({ key, root: order, children });
+    handled.add(order.id);
+    for (const child of children) handled.add(child.id);
+  }
+
+  for (const order of orders) {
+    if (handled.has(order.id)) continue;
+    roots.push({ key: `${order.id}:${order.createdAt ?? ""}`, root: order, children: [] });
+  }
+
+  return roots.sort((left, right) => orderSortTime(right.root) - orderSortTime(left.root));
+}
+
+function orderMatchesScope(order: OrderView, scope: Scope, activeSymbol: string): boolean {
+  if (scope === "active" && activeSymbol) return order.symbol === activeSymbol;
+  if (scope === "open") return order.cancelable;
+  return true;
+}
+
+function renderOrderRow(
+  order: OrderView,
+  activeSymbol: string,
+  cancelingBrokerOrderId: string | null,
+  onCancel: (brokerOrderId: string) => void,
+  depth: 0 | 1,
+) {
+  const isActiveSymbol = Boolean(activeSymbol) && order.symbol === activeSymbol;
+  const cancelDisabled = !order.cancelable || !order.brokerOrderId || cancelingBrokerOrderId === order.brokerOrderId;
+  const compactType = normalizeType(order.type);
+  const sideCode = compactSide(order.side);
 
   return (
-    <table className="orders-table">
-      <thead>
-        <tr>
-          <th>Order ID</th>
-          <th>Type</th>
-          <th>Qty</th>
-          <th>Price</th>
-          <th>Status</th>
-          <th>Tranche</th>
-        </tr>
-      </thead>
-      <tbody>
-        {!orders.length ? (
-          <tr>
-            <td colSpan={6} className="orders-empty-cell">No orders yet</td>
-          </tr>
+    <tr
+      key={`${order.brokerOrderId ?? order.id}-${order.updatedAt ?? order.createdAt ?? ""}`}
+      className={`${isActiveSymbol ? "order-row-highlight" : ""} ${depth ? "order-child-row" : "order-root-row"}`}
+      title={order.brokerOrderId ?? undefined}
+    >
+      <td className={`${depth ? "order-tree-indent " : ""}order-symbol-cell`}>
+        <div className="order-symbol-main">{order.symbol}</div>
+        {order.brokerOrderId ? <div className="order-subtext order-subtext-truncate">{order.brokerOrderId}</div> : null}
+      </td>
+      <td className="order-side-type-cell">
+        <div className="order-side-type-main">
+          <span className="order-side-code">{sideCode}</span>
+          <span className={`order-type-code ${typeColorClass(compactType)}`}>{compactType}</span>
+        </div>
+      </td>
+      <td>
+        <div>{order.qty}</div>
+        <div className="order-subtext">fill {order.filledQty} / rem {order.remainingQty}</div>
+      </td>
+      <td>
+        <div>{fp(order.price)}</div>
+        {order.fillPrice !== null && order.fillPrice !== undefined ? (
+          <div className="order-subtext">fill {fp(order.fillPrice)}</div>
+        ) : null}
+      </td>
+      <td className={statusClass(order.status)}>
+        <div>{order.status}</div>
+        {order.cancelable ? <div className="order-subtext">cancelable</div> : null}
+      </td>
+      <td>{orderTime(order)}</td>
+      <td>
+        <div>{order.tranche}</div>
+        <div className="order-subtext">{order.parentId ? "child" : "root"}</div>
+      </td>
+      <td>
+        {order.cancelable && order.brokerOrderId ? (
+          <button
+            type="button"
+            className="orders-cancel-btn"
+            disabled={cancelDisabled}
+            onClick={() => onCancel(order.brokerOrderId!)}
+          >
+            {cancelingBrokerOrderId === order.brokerOrderId ? "..." : "Cancel"}
+          </button>
         ) : (
-          roots.flatMap((root) => {
-            const children = childrenOf(root.id);
-            const rootRow = (
-              <tr key={root.id} className={children.length ? "order-root-row order-root-open" : "order-root-row"} title={root.brokerOrderId ?? undefined}>
-                <td className="order-id-root">
-                  <div>{root.id}</div>
-                  {root.brokerOrderId ? <div className="order-subtext">{root.brokerOrderId}</div> : null}
-                </td>
-                <td className={typeColorClass(root.type)}>{root.type}</td>
-                <td>{root.qty}</td>
-                <td>
-                  <div>{fp(root.price)}</div>
-                  {root.fillPrice !== null && root.fillPrice !== undefined && root.fillPrice !== root.price ? (
-                    <div className="order-subtext">fill {fp(root.fillPrice)}</div>
-                  ) : null}
-                </td>
-                <td className={`order-status-${root.status}`}>
-                  <div>{root.status}</div>
-                  {root.filledAt ? <div className="order-subtext">{formatLogTime(root.filledAt)}</div> : root.createdAt ? <div className="order-subtext">{formatLogTime(root.createdAt)}</div> : null}
-                </td>
-                <td>{root.tranche}</td>
-              </tr>
-            );
-
-            const childRows = children.map((child, index) => {
-              const isLast = index === children.length - 1;
-              return (
-                <tr key={child.id} className={`order-child-row ${isLast ? "order-child-last" : ""}`} title={child.brokerOrderId ?? undefined}>
-                  <td className="order-id-child">
-                    <span className="order-tree-glyph">{isLast ? "\u2514\u2500" : "\u251C\u2500"}</span>
-                    <span>{child.id}</span>
-                  </td>
-                  <td className={typeColorClass(child.type)}>{child.type}</td>
-                  <td className={child.qty < child.origQty ? "order-qty-reduced" : ""}>
-                    {child.qty}
-                    {child.qty < child.origQty ? <span className="order-orig-qty">({child.origQty})</span> : null}
-                  </td>
-                  <td>
-                    <div>{fp(child.price)}</div>
-                    {child.fillPrice !== null && child.fillPrice !== undefined && child.fillPrice !== child.price ? (
-                      <div className="order-subtext">fill {fp(child.fillPrice)}</div>
-                    ) : null}
-                  </td>
-                  <td className={`order-status-${child.status}`}>
-                    <div>{child.status}</div>
-                    {child.filledAt ? <div className="order-subtext">{formatLogTime(child.filledAt)}</div> : child.createdAt ? <div className="order-subtext">{formatLogTime(child.createdAt)}</div> : null}
-                  </td>
-                  <td>{child.tranche}</td>
-                </tr>
-              );
-            });
-
-            return [rootRow, ...childRows];
-          })
+          <span className="order-subtext">-</span>
         )}
-      </tbody>
-    </table>
+      </td>
+    </tr>
+  );
+}
+
+export function OrdersBlotter({ orders, activeSymbol, onCancel, cancelingBrokerOrderId = null }: Props) {
+  const [scope, setScope] = useState<Scope>("all");
+  const [expandedRoots, setExpandedRoots] = useState<Record<string, boolean>>({});
+  const [columnWidths, setColumnWidths] = useState<ColumnWidths>(DEFAULT_WIDTHS);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    setColumnWidths(readStoredWidths());
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(sanitizeWidths(columnWidths)));
+  }, [columnWidths]);
+
+  useEffect(() => () => {
+    dragCleanupRef.current?.();
+  }, []);
+
+  function beginColumnDrag(column: keyof ColumnWidths, event: ReactMouseEvent<HTMLSpanElement>) {
+    if (typeof window === "undefined" || window.innerWidth <= 1024) return;
+    event.preventDefault();
+    event.stopPropagation();
+    dragCleanupRef.current?.();
+    const startX = event.clientX;
+    const start = { ...columnWidths };
+
+    const onMove = (moveEvent: MouseEvent) => {
+      const deltaX = moveEvent.clientX - startX;
+      setColumnWidths((current) =>
+        sanitizeWidths({
+          ...current,
+          [column]: start[column] + deltaX,
+        }),
+      );
+    };
+
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      dragCleanupRef.current = null;
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    dragCleanupRef.current = onUp;
+  }
+
+  const groupedOrders = useMemo(() => {
+    const safeOrders = Array.isArray(orders) ? orders : [];
+    return groupOrders(safeOrders)
+      .map((node) => {
+        const matchingChildren = node.children.filter((order) => orderMatchesScope(order, scope, activeSymbol));
+        const rootMatches = orderMatchesScope(node.root, scope, activeSymbol);
+        if (!rootMatches && matchingChildren.length === 0) return null;
+        return {
+          ...node,
+          children: matchingChildren,
+          rootVisible: rootMatches || matchingChildren.length > 0,
+        };
+      })
+      .filter((node): node is OrderNode & { rootVisible: true } => Boolean(node && node.rootVisible));
+  }, [activeSymbol, orders, scope]);
+
+  const totalVisibleRows = groupedOrders.reduce((sum, node) => {
+    const expanded = expandedRoots[node.key] ?? false;
+    return sum + 1 + (expanded ? node.children.length : 0);
+  }, 0);
+
+  return (
+    <div className="orders-blotter-shell">
+      <div className="orders-toolbar">
+        <div className="orders-filters">
+          <button type="button" className={`orders-filter-btn ${scope === "all" ? "active" : ""}`} onClick={() => setScope("all")}>
+            All
+          </button>
+          <button
+            type="button"
+            className={`orders-filter-btn ${scope === "active" ? "active" : ""}`}
+            onClick={() => setScope("active")}
+            disabled={!activeSymbol}
+          >
+            Active Symbol
+          </button>
+          <button type="button" className={`orders-filter-btn ${scope === "open" ? "active" : ""}`} onClick={() => setScope("open")}>
+            Open / Working
+          </button>
+        </div>
+        <div className="orders-meta">{totalVisibleRows} visible row{totalVisibleRows === 1 ? "" : "s"}</div>
+      </div>
+      <table className="orders-table merged-orders-table">
+        <colgroup>
+          <col className="orders-col-symbol" style={{ width: `${columnWidths.symbol}px` }} />
+          <col className="orders-col-side-type" style={{ width: `${columnWidths.sideType}px` }} />
+          <col className="orders-col-qty" />
+          <col className="orders-col-price" />
+          <col className="orders-col-status" />
+          <col className="orders-col-time" />
+          <col className="orders-col-context" />
+          <col className="orders-col-action" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th>
+              <span className="orders-header-label">Symbol</span>
+              <span className="orders-col-resize-handle" onMouseDown={(event) => beginColumnDrag("symbol", event)} />
+            </th>
+            <th>
+              <span className="orders-header-label">Side / Type</span>
+              <span className="orders-col-resize-handle" onMouseDown={(event) => beginColumnDrag("sideType", event)} />
+            </th>
+            <th>Qty</th>
+            <th>Price</th>
+            <th>Status</th>
+            <th>Time</th>
+            <th>Context</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {!groupedOrders.length ? (
+            <tr>
+              <td colSpan={8} className="orders-empty-cell">No recent orders in this view</td>
+            </tr>
+          ) : (
+            groupedOrders.map((node) => {
+              const expanded = expandedRoots[node.key] ?? false;
+              return (
+                <Fragment key={node.key}>
+                  {node.children.length ? (
+                    <tr className="order-tree-toggle-row">
+                      <td colSpan={8}>
+                        <button
+                          type="button"
+                          className="order-tree-toggle"
+                          onClick={() =>
+                            setExpandedRoots((current) => ({
+                              ...current,
+                              [node.key]: !expanded,
+                            }))
+                          }
+                        >
+                          <span className="order-tree-toggle-main">
+                            {expanded ? "-" : "+"} {node.root.symbol} {node.root.tranche} {node.children.length} child order{node.children.length === 1 ? "" : "s"}
+                          </span>
+                          {node.root.brokerOrderId ? (
+                            <span className="order-tree-toggle-meta" title={node.root.brokerOrderId}>
+                              {node.root.brokerOrderId}
+                            </span>
+                          ) : null}
+                        </button>
+                      </td>
+                    </tr>
+                  ) : null}
+                  {renderOrderRow(node.root, activeSymbol, cancelingBrokerOrderId, onCancel, 0)}
+                  {expanded ? node.children.map((order) => renderOrderRow(order, activeSymbol, cancelingBrokerOrderId, onCancel, 1)) : null}
+                </Fragment>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/frontend/components/ProfitTakingPanel.tsx
+++ b/frontend/components/ProfitTakingPanel.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import { OrdersBlotter } from "@/components/OrdersBlotter";
-import { activeShares, f2, fp, soldShares, splitShares, targetPrice, trailingStop } from "@/lib/cockpit-ui";
-import type { OrderView, PositionView, SetupResponse, Tranche, TrancheMode } from "@/lib/types";
+import { fp, splitShares, targetPrice, trailingStop } from "@/lib/cockpit-ui";
+import type { PositionView, SetupResponse, TrancheMode } from "@/lib/types";
 
 type Props = {
   setup: SetupResponse | null;
   activePosition: PositionView | null;
   trancheCount: number;
   trancheModes: TrancheMode[];
-  tranches: Tranche[];
-  orders: OrderView[];
   executeFlashing?: boolean;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
   onTrancheCountChange: (value: number) => void;
   onTrancheModeChange: (index: number, value: TrancheMode) => void;
   onExecute: () => void;
@@ -23,36 +22,35 @@ export function ProfitTakingPanel(props: Props) {
     activePosition,
     trancheCount,
     trancheModes,
-    tranches,
-    orders,
     executeFlashing = false,
+    collapsed = false,
+    onToggleCollapse,
     onTrancheCountChange,
     onTrancheModeChange,
     onExecute
   } = props;
-  const plannedShares = setup ? splitShares(setup.shares, trancheCount) : [];
-  const activeQty = activePosition ? activeShares(activePosition) : 0;
-  const soldQty = activePosition ? soldShares(activePosition) : 0;
+  const plannedShares = setup
+    ? splitShares(setup.shares, trancheCount, trancheModes.slice(0, trancheCount).map((mode) => mode.allocationPct ?? null))
+    : [];
   const plannedSetup = setup;
   const canExecuteProfit = activePosition ? ["protected", "P1_done", "P2_done", "runner_only"].includes(activePosition.phase) : false;
-  const visibleTranches = activePosition
-    ? tranches.filter((tranche) => tranche.status === "sold" || tranche.status === "canceled" || (tranche.id === "T3" && activePosition.phase === "runner_only"))
-    : [];
-  const showManageState = Boolean(activePosition);
 
   return (
-    <div className="panel manage-panel">
+    <div className={`panel manage-panel ${collapsed ? "panel-collapsed" : ""}`}>
       <div className="panel-header profit-header">
-        <div className="panel-title">Profit Taking</div>
+        <div className="panel-title-row">
+          <button type="button" className="panel-collapse-btn" onClick={onToggleCollapse}>{collapsed ? "+" : "-"}</button>
+          <div className="panel-title">Profit Taking</div>
+        </div>
         <div className="profit-controls">
           <span className="protect-caption">TRANCHES</span>
           <button type="button" className={`tranche-count-btn ${trancheCount === 1 ? "active" : ""}`} onClick={() => onTrancheCountChange(1)}>P1</button>
           <button type="button" className={`tranche-count-btn ${trancheCount === 2 ? "active" : ""}`} onClick={() => onTrancheCountChange(2)}>P1{"\u00B7"}P2</button>
           <button type="button" className={`tranche-count-btn ${trancheCount === 3 ? "active" : ""}`} onClick={() => onTrancheCountChange(3)}>P1{"\u00B7"}P2{"\u00B7"}P3</button>
           <button type="button" className={`stop-ok-btn ${canExecuteProfit ? "stop-ok-ready" : ""} ${executeFlashing ? "flash" : ""}`} disabled={!canExecuteProfit} onClick={onExecute}>EXECUTE</button>
-          <div className="position-summary-header">{activePosition ? `${activeQty}sh active / ${soldQty}sh sold` : "No position"}</div>
         </div>
       </div>
+      {!collapsed ? <>
       <div className="exit-plan-shell">
         <div className="section-label stop-plan-title">Exit Plan</div>
         <div className="exit-plan-content">
@@ -74,7 +72,16 @@ export function ProfitTakingPanel(props: Props) {
                 >
                   {mode.mode === "runner" ? "RUNNER" : "LIMIT"}
                 </button>
-                <span className="plan-pct">{qty ? `${Math.round((qty / plannedSetup.shares) * 100)}%` : "-"}</span>
+                <div className="pct-input-wrap">
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    className="pct-input"
+                    value={Number((mode.allocationPct ?? 0).toFixed(2))}
+                    onChange={(event) => onTrancheModeChange(index, { ...mode, allocationPct: Number(event.target.value) })}
+                  />
+                  <span className="pct-suffix">%</span>
+                </div>
                 <span className="plan-price">{price !== null ? fp(price) : "-"}</span>
                 <span className="plan-qty">{qty} sh</span>
                 {mode.mode === "runner" ? (
@@ -122,50 +129,7 @@ export function ProfitTakingPanel(props: Props) {
           })}
         </div>
       </div>
-      <div className="manage-scroll">
-        <div className="section-label manage-section-label" style={{ display: showManageState ? "block" : "none" }}>Exits</div>
-        {activePosition ? (
-          <>
-            <div className="tranche-grid">
-              {visibleTranches.map((tranche) => {
-                const pnl = tranche.status === "sold" && tranche.target ? (tranche.target - (setup?.entry ?? 0)) * tranche.qty : null;
-                const trancheSuffix = tranche.label.includes("\u00B7")
-                  ? tranche.label.split("\u00B7").slice(-1)[0]?.trim() ?? tranche.label
-                  : tranche.label;
-                return (
-                  <div key={tranche.id} className={`tranche-card ${tranche.status}`}>
-                    <div className="tranche-label">{tranche.id} {"\u00B7"} {trancheSuffix}</div>
-                    <div className="tranche-qty">{tranche.qty} <span className="tranche-unit">sh</span></div>
-                    <div className="tranche-stop">{"\u2193"} STOP {fp(tranche.stop)}</div>
-                    <div className="tranche-target">{tranche.target ? `${"\u2191"} TGT ${fp(tranche.target)}` : `${"\u2191"} ${tranche.mode.toUpperCase()}`}</div>
-                    {pnl !== null ? (
-                      <div className={`tranche-pnl ${pnl >= 0 ? "green" : "red"}`}>{pnl >= 0 ? "+" : ""}{f2(pnl)}</div>
-                    ) : null}
-                    <div className={`tranche-status status-${tranche.status}`}>
-                      <span className="status-dot" />
-                      {tranche.status.toUpperCase()}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-            <div className="pos-summary">
-              <div className="pos-item"><div className="pos-item-label">Total Shares</div><div className="pos-item-val">{setup?.shares ?? 0}</div></div>
-              <div className="pos-item"><div className="pos-item-label">Active</div><div className="pos-item-val green">{activeQty} sh</div></div>
-              <div className="pos-item"><div className="pos-item-label">Sold</div><div className="pos-item-val">{soldQty} sh</div></div>
-              <div className="pos-item"><div className="pos-item-label">Entry</div><div className="pos-item-val">{fp(setup?.entry)}</div></div>
-              <div className="pos-item"><div className="pos-item-label">Notional</div><div className="pos-item-val">{f2((setup?.entry ?? 0) * activeQty)}</div></div>
-            </div>
-            <div className="section-label manage-section-label">Orders</div>
-            <OrdersBlotter orders={orders} />
-          </>
-        ) : (
-          <div id="manageEmpty" className="empty-state">
-            <div className="empty-icon">{"\u25C8"}</div>
-            Set stop protection, then take profits manually
-          </div>
-        )}
-      </div>
+      </> : null}
     </div>
   );
 }

--- a/frontend/components/RecentOrdersPanel.tsx
+++ b/frontend/components/RecentOrdersPanel.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { OrdersBlotter } from "@/components/OrdersBlotter";
+import type { OrderView } from "@/lib/types";
+
+type Props = {
+  orders: OrderView[];
+  activeSymbol: string;
+  cancelingBrokerOrderId?: string | null;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  onCancelOrder: (brokerOrderId: string) => void;
+};
+
+export function RecentOrdersPanel({
+  orders,
+  activeSymbol,
+  cancelingBrokerOrderId = null,
+  collapsed = false,
+  onToggleCollapse,
+  onCancelOrder,
+}: Props) {
+  return (
+    <div className={`panel orders-monitor-panel ${collapsed ? "panel-collapsed" : ""}`}>
+      <div className="panel-header">
+        <div className="panel-title-row panel-title-row-clickable" onClick={onToggleCollapse}>
+          <button
+            type="button"
+            className="panel-collapse-btn"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleCollapse?.();
+            }}
+          >
+            {collapsed ? "+" : "-"}
+          </button>
+          <div className="panel-title">Recent Orders</div>
+        </div>
+      </div>
+      {!collapsed ? (
+        <div className="panel-body orders-monitor-body">
+          <OrdersBlotter
+            orders={orders}
+            activeSymbol={activeSymbol}
+            cancelingBrokerOrderId={cancelingBrokerOrderId}
+            onCancel={onCancelOrder}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/RunningPnlPanel.tsx
+++ b/frontend/components/RunningPnlPanel.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { f2, formatLogTime, fp, runningPnlSummary } from "@/lib/cockpit-ui";
+import type { PositionView, SetupResponse } from "@/lib/types";
+
+type Props = {
+  activePosition: PositionView | null;
+  setup: SetupResponse | null;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+};
+
+export function RunningPnlPanel({ activePosition, setup, collapsed = false, onToggleCollapse }: Props) {
+  const pnlSummary = runningPnlSummary(activePosition, setup);
+
+  return (
+    <div className={`panel running-pnl-panel ${collapsed ? "panel-collapsed" : ""}`}>
+      <div className="panel-header">
+        <div className="panel-title-row panel-title-row-clickable" onClick={onToggleCollapse}>
+          <button
+            type="button"
+            className="panel-collapse-btn"
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleCollapse?.();
+            }}
+          >
+            {collapsed ? "+" : "-"}
+          </button>
+          <div className="panel-title">Running P&amp;L</div>
+        </div>
+        <div className="position-summary-header">
+          {pnlSummary ? `${pnlSummary.remainingShares}sh open / ${pnlSummary.closedShares}sh closed` : "No filled position"}
+        </div>
+      </div>
+      {!collapsed ? (
+        <div className="panel-body running-pnl-body">
+          {pnlSummary ? (
+            <>
+              <div className="running-pnl-grid">
+                <div className="running-pnl-card">
+                  <div className="running-pnl-label">Total Shares</div>
+                  <div className="running-pnl-value">{pnlSummary.totalShares}</div>
+                </div>
+                <div className="running-pnl-card">
+                  <div className="running-pnl-label">Closed</div>
+                  <div className="running-pnl-value">{pnlSummary.closedShares} sh</div>
+                </div>
+                <div className="running-pnl-card">
+                  <div className="running-pnl-label">Remaining</div>
+                  <div className="running-pnl-value green">{pnlSummary.remainingShares} sh</div>
+                </div>
+                <div className="running-pnl-card">
+                  <div className="running-pnl-label">Realized P&amp;L</div>
+                  <div className={`running-pnl-value ${pnlSummary.realizedPnl >= 0 ? "green" : "red"}`}>
+                    {pnlSummary.realizedPnl >= 0 ? "+" : "-"}
+                    {f2(Math.abs(pnlSummary.realizedPnl))}
+                  </div>
+                </div>
+                <div className="running-pnl-card">
+                  <div className="running-pnl-label">Open P&amp;L</div>
+                  <div className={`running-pnl-value ${pnlSummary.unrealizedPnl >= 0 ? "green" : "red"}`}>
+                    {pnlSummary.unrealizedPnl >= 0 ? "+" : "-"}
+                    {f2(Math.abs(pnlSummary.unrealizedPnl))}
+                  </div>
+                </div>
+                <div className="running-pnl-card">
+                  <div className="running-pnl-label">Open Risk</div>
+                  <div className="running-pnl-value red">-{f2(Math.abs(pnlSummary.openRisk))}</div>
+                </div>
+              </div>
+              <div className="running-pnl-legs">
+                <div className="running-pnl-legs-header">Filled Legs</div>
+                {pnlSummary.filledLegs.length ? (
+                  pnlSummary.filledLegs.map((leg) => (
+                    <div className="running-pnl-leg" key={`${leg.label}-${leg.filledAt ?? leg.qty}`}>
+                      <span className="running-pnl-leg-label">{leg.label}</span>
+                      <span className="running-pnl-leg-qty">{leg.qty} sh</span>
+                      <span className="running-pnl-leg-price">{leg.exitPrice !== null ? fp(leg.exitPrice) : "-"}</span>
+                      <span className={`running-pnl-leg-pnl ${leg.pnl >= 0 ? "green" : "red"}`}>
+                        {leg.pnl >= 0 ? "+" : "-"}
+                        {f2(Math.abs(leg.pnl))}
+                      </span>
+                      <span className="running-pnl-leg-time">{leg.filledAt ? formatLogTime(leg.filledAt) : "-"}</span>
+                    </div>
+                  ))
+                ) : (
+                  <div className="running-pnl-empty">No partial exits filled yet.</div>
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="empty-state">
+              <div className="empty-icon">◇</div>
+              Running P&amp;L appears after a real fill and updates through partial exits.
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/components/SetupPanel.tsx
+++ b/frontend/components/SetupPanel.tsx
@@ -1,17 +1,15 @@
-import { OpenPositionsList } from "@/components/OpenPositionsList";
 import { formatQuoteTimestamp, fp, sessionStateLabel } from "@/lib/cockpit-ui";
-import type { AccountView, PositionView, SetupResponse } from "@/lib/types";
+import type { AccountView, SetupResponse } from "@/lib/types";
 
 type Props = {
   symbol: string;
   setup: SetupResponse | null;
   account: AccountView | null;
-  positions: PositionView[];
-  onSelectPosition: (symbol: string) => void;
+  setupLatencyMs?: number | null;
   onRiskPctCommit: (value: number) => void;
 };
 
-export function SetupPanel({ symbol, setup, account, positions, onSelectPosition, onRiskPctCommit }: Props) {
+export function SetupPanel({ symbol, setup, account, setupLatencyMs = null, onRiskPctCommit }: Props) {
   const atrExtension = setup?.atrExtension;
   const rvol = setup?.rvol;
   const extFrom10Ma = setup?.extFrom10Ma;
@@ -21,20 +19,25 @@ export function SetupPanel({ symbol, setup, account, positions, onSelectPosition
   const extFrom10Text = Number.isFinite(extFrom10Ma) ? `${extFrom10Ma?.toFixed(2)}%` : "--";
   const daysToCoverText = Number.isFinite(daysToCover) ? `${daysToCover?.toFixed(1)}` : "--";
   const providerStateLabel = setup
-    ? `${setup.quoteIsReal ? "Real quote" : "Quote unavailable"} via ${setup.quoteProvider} | execution ${setup.executionProvider}`
+    ? `${setup.quoteIsReal ? "REAL QUOTE" : "QUOTE UNAVAILABLE"} VIA ${setup.quoteProvider.toUpperCase()}`
     : "";
   const providerSubnote = setup?.technicalsAreFallback
-    ? "Derived metrics are still fallback-backed locally."
+    ? "LoD and ATR are real. Remaining derived metrics are fallback-backed locally."
     : "All displayed setup fields are provider-backed.";
   const quoteTimestamp = setup?.quoteTimestamp ? formatQuoteTimestamp(setup.quoteTimestamp) : "--";
+  const stopDefaultLabel =
+    setup?.stopReferenceDefault === "manual"
+      ? "MANUAL REQUIRED"
+      : setup?.stopReferenceDefault === "atr"
+        ? "ATR"
+        : "LOD";
+  const setupSymbol = setup && symbol ? symbol : "\u2014";
 
   return (
     <div className="panel setup-panel">
       <div className="panel-header">
         <div className="panel-title">Setup Parameters</div>
-        <div className="panel-symbol" id="setupSymbol">
-          {setup && symbol ? <span className="ticker-symbol-large">{symbol}</span> : "\u2014"}
-        </div>
+        <div className="panel-symbol" id="setupSymbol">{setupSymbol}</div>
       </div>
       <div className="panel-body" id="setupBody">
         {!setup ? (
@@ -44,37 +47,44 @@ export function SetupPanel({ symbol, setup, account, positions, onSelectPosition
           </div>
         ) : (
           <>
-            <div className="kv-group">
-              <div className="kv-group-label">Quote</div>
-              <div className="kv-row">
-                <span className="kv-label">Bid</span>
-                <span className="kv-val">{fp(setup.bid)}</span>
+            <div className="setup-meta-card">
+              <div className="setup-meta-line">
+                <span className="setup-meta-tag">{providerStateLabel}</span>
+                <span className="setup-meta-value">{sessionStateLabel(setup.sessionState)}</span>
               </div>
-              <div className="kv-row">
-                <span className="kv-label">Ask</span>
-                <span className="kv-val">{fp(setup.ask)}</span>
-              </div>
-              <div className="kv-row">
-                <span className="kv-label">Suggested Entry</span>
-                <span className="kv-val cyan">{fp(setup.entry)}</span>
-              </div>
-              <div className="provider-note">{providerStateLabel}</div>
-              <div className="provider-subnote">
-                Session: {setup ? sessionStateLabel(setup.sessionState) : "--"} | Quote state: {setup?.quoteState ?? "--"}
-              </div>
-              <div className="provider-subnote">Using latest available Alpaca quote from {quoteTimestamp}</div>
-              <div className="provider-subnote">{providerSubnote}</div>
-              {setup.fallbackReason ? <div className="provider-subnote">Fallback reason: {setup.fallbackReason}</div> : null}
+              <div className="setup-meta-copy">Using latest available Alpaca quote from {quoteTimestamp}</div>
+              <div className="setup-meta-copy">Execution path: {setup.executionProvider}. {providerSubnote}</div>
+              {setupLatencyMs !== null ? <div className="setup-meta-copy">Setup latency: {setupLatencyMs} ms</div> : null}
+              {setup?.manualStopWarning ? <div className="setup-meta-copy warning">{setup.manualStopWarning}</div> : null}
+              {setup?.sizingWarning ? <div className="setup-meta-copy warning">{setup.sizingWarning}</div> : null}
+              {setup?.buyingPowerNote ? <div className="setup-meta-copy warning">{setup.buyingPowerNote}</div> : null}
+              {setup.fallbackReason ? <div className="setup-meta-copy">Fallback reason: {setup.fallbackReason}</div> : null}
             </div>
             <div className="kv-group">
-              <div className="kv-group-label">Stop Levels</div>
+              <div className="kv-group-label">Stop Reference</div>
               <div className="kv-row">
                 <span className="kv-label">Low of Day</span>
                 <span className="kv-val">{fp(setup.lod)}</span>
               </div>
               <div className="kv-row">
+                <span className="kv-label">High of Day</span>
+                <span className="kv-val">{fp(setup.hod)}</span>
+              </div>
+              <div className="kv-row">
                 <span className="kv-label">ATR (14)</span>
                 <span className="kv-val amber">{fp(setup.atr14)}</span>
+              </div>
+              <div className="kv-row">
+                <span className="kv-label">LoD Stop</span>
+                <span className={`kv-val ${setup.lodIsValid ? "" : "red"}`}>{fp(setup.lodStop)}</span>
+              </div>
+              <div className="kv-row">
+                <span className="kv-label">ATR Stop</span>
+                <span className={`kv-val ${setup.atrIsValid ? "amber" : "red"}`}>{fp(setup.atrStop)}</span>
+              </div>
+              <div className="kv-row">
+                <span className="kv-label">Stop Default</span>
+                <span className={`kv-val ${setup.stopReferenceDefault === "manual" ? "red" : ""}`}>{stopDefaultLabel}</span>
               </div>
               <div className="kv-row">
                 <span className="kv-label">Final Stop</span>
@@ -86,6 +96,14 @@ export function SetupPanel({ symbol, setup, account, positions, onSelectPosition
               <div className="kv-row">
                 <span className="kv-label">Account Equity</span>
                 <span className="kv-val">{fp(account?.equity ?? setup.accountEquity)}</span>
+              </div>
+              <div className="kv-row">
+                <span className="kv-label">Buying Power</span>
+                <span className="kv-val">{fp(account?.buying_power ?? setup.accountBuyingPower)}</span>
+              </div>
+              <div className="kv-row">
+                <span className="kv-label">Cash</span>
+                <span className="kv-val">{fp(account?.cash ?? setup.accountCash)}</span>
               </div>
               <div className="kv-row">
                 <span className="kv-label">Risk %</span>
@@ -122,43 +140,50 @@ export function SetupPanel({ symbol, setup, account, positions, onSelectPosition
                 <span className="kv-label">Calc. Shares</span>
                 <span className="kv-val green">{setup.shares} sh</span>
               </div>
+              <div className="provider-subnote">Sizing uses {setup.equitySource === "alpaca_account" ? "real Alpaca account equity and buying power" : "local account settings"}.</div>
             </div>
-            <div className="kv-group">
-              <div className="kv-group-label">Reference</div>
-              <div className="kv-row">
-                <span className="kv-label">10 SMA</span>
-                <span className="kv-val">{fp(setup.sma10)}</span>
+            {setup.technicalsAreFallback ? (
+              <div className="kv-group">
+                <div className="kv-group-label">Reference</div>
+                <div className="provider-subnote">Fallback-only reference metrics are hidden until they are symbol-accurate.</div>
               </div>
-              <div className="kv-row">
-                <span className="kv-label">50 SMA</span>
-                <span className="kv-val">{fp(setup.sma50)}</span>
+            ) : (
+              <div className="kv-group">
+                <div className="kv-group-label">Reference</div>
+                <div className="kv-row">
+                  <span className="kv-label">10 SMA</span>
+                  <span className="kv-val">{fp(setup.sma10)}</span>
+                </div>
+                <div className="kv-row">
+                  <span className="kv-label">50 SMA</span>
+                  <span className="kv-val">{fp(setup.sma50)}</span>
+                </div>
+                <div className="kv-row">
+                  <span className="kv-label">200 MA</span>
+                  <span className="kv-val">{fp(setup.sma200)}</span>
+                </div>
+                <div className="kv-row">
+                  <span className="kv-label">ATR Ext from 50MA</span>
+                  <span className="kv-val">{atrExtensionText}</span>
+                </div>
+                <div className="kv-row">
+                  <span className="kv-label">RVOL</span>
+                  <span className="kv-val">{rvolText}</span>
+                </div>
+                <div className="kv-row">
+                  <span className="kv-label">Ext from 10 MA</span>
+                  <span className="kv-val">{extFrom10Text}</span>
+                </div>
+                <div className="kv-row">
+                  <span className="kv-label">Days to Cover</span>
+                  <span className="kv-val">
+                    {daysToCoverText} <span className="kv-val-unit">days</span>
+                  </span>
+                </div>
               </div>
-              <div className="kv-row">
-                <span className="kv-label">200 MA</span>
-                <span className="kv-val">{fp(setup.sma200)}</span>
-              </div>
-              <div className="kv-row">
-                <span className="kv-label">ATR Ext from 50MA</span>
-                <span className="kv-val">{atrExtensionText}</span>
-              </div>
-              <div className="kv-row">
-                <span className="kv-label">RVOL</span>
-                <span className="kv-val">{rvolText}</span>
-              </div>
-              <div className="kv-row">
-                <span className="kv-label">Ext from 10 MA</span>
-                <span className="kv-val">{extFrom10Text}</span>
-              </div>
-              <div className="kv-row">
-                <span className="kv-label">Days to Cover</span>
-                <span className="kv-val">
-                  {daysToCoverText} <span className="kv-val-unit">days</span>
-                </span>
-              </div>
-            </div>
+            )}
           </>
         )}
-        <OpenPositionsList positions={positions} activeSymbol={symbol} onSelect={onSelectPosition} />
       </div>
     </div>
   );

--- a/frontend/components/StopProtectionPanel.tsx
+++ b/frontend/components/StopProtectionPanel.tsx
@@ -11,6 +11,8 @@ type Props = {
   executeFlashing?: boolean;
   moveToBeFlashing?: boolean;
   flattenFlashing?: boolean;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
   onStopModeChange: (value: number) => void;
   onStopModeValueChange: (index: number, value: StopMode) => void;
   onExecute: () => void;
@@ -29,6 +31,8 @@ export function StopProtectionPanel(props: Props) {
     executeFlashing = false,
     moveToBeFlashing = false,
     flattenFlashing = false,
+    collapsed = false,
+    onToggleCollapse,
     onStopModeChange,
     onStopModeValueChange,
     onExecute,
@@ -52,9 +56,12 @@ export function StopProtectionPanel(props: Props) {
           : "S1\u00B7S2\u00B7S3";
 
   return (
-    <div className="panel protect-panel">
+    <div className={`panel protect-panel ${collapsed ? "panel-collapsed" : ""}`}>
       <div className="panel-header protect-header">
-        <div className="panel-title">Stop Protection</div>
+        <div className="panel-title-row">
+          <button type="button" className="panel-collapse-btn" onClick={onToggleCollapse}>{collapsed ? "+" : "-"}</button>
+          <div className="panel-title">Stop Protection</div>
+        </div>
         <div className="protect-controls">
           <span className="protect-caption">STOPS</span>
           <button type="button" className={`tranche-count-btn ${stopMode === 1 ? "active" : ""}`} disabled={!hasTrade || waitingForFill} onClick={() => onStopModeChange(1)}>S1</button>
@@ -64,9 +71,10 @@ export function StopProtectionPanel(props: Props) {
           <div className="stop-mode-label">{stopModeLabel}</div>
         </div>
       </div>
+      {!collapsed ? <>
       <div className="stop-plan-shell">
         <div className="section-label stop-plan-title">
-          Stop Plan <span className="section-hint">{waitingForFill ? "\u2014 Protective orders are unavailable until the entry order is filled" : hasTrade ? "" : hasSetup ? "\u2014 Enter trade first" : ""}</span>
+          Stop Plan <span className="section-hint">{waitingForFill ? "— Protective orders are unavailable until the entry order is filled" : hasTrade ? "" : hasSetup ? "— Enter trade first" : ""}</span>
         </div>
         <div className="stop-plan-content">
           {!hasSetup ? null : rows.map((row, index) => {
@@ -112,12 +120,21 @@ export function StopProtectionPanel(props: Props) {
               </div>
             );
           })}
+          {hasSetup ? (
+            <div className="plan-line stop-action-line">
+              <span className="plan-line-label">ACT</span>
+              <div className="stop-action-buttons">
+                <button type="button" className={`btn btn-ghost stop-inline-btn ${moveToBeFlashing ? "flash" : ""}`} disabled={!hasTrade || waitingForFill} onClick={onMoveToBe}>ALL {"\u2192"} BE</button>
+                <button type="button" className={`btn btn-red stop-inline-btn ${flattenFlashing ? "flash" : ""}`} disabled={!hasTrade} onClick={onFlatten}>{"\u2B1B"} FLATTEN</button>
+              </div>
+              <span className="stop-action-copy">
+                {waitingForFill ? "Awaiting broker fill" : hasTrade ? "Stop actions ready" : "No live trade"}
+              </span>
+            </div>
+          ) : null}
         </div>
       </div>
-      <div className="panel-body protect-actions">
-        <button type="button" className={`btn btn-ghost ${moveToBeFlashing ? "flash" : ""}`} disabled={!hasTrade || waitingForFill} onClick={onMoveToBe}>ALL {"\u2192"} BE</button>
-        <button type="button" className={`btn btn-red ${flattenFlashing ? "flash" : ""}`} disabled={!hasTrade} onClick={onFlatten}>{"\u2B1B"} FLATTEN</button>
-      </div>
+      </> : null}
     </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,16 @@
-import type { AccountView, AuthUser, LogEntry, OffHoursMode, PositionView, SetupResponse, StopMode, TrancheMode } from "@/lib/types";
+import type {
+  AccountView,
+  AuthUser,
+  EntryOrderDraft,
+  LogEntry,
+  OffHoursMode,
+  OrderView,
+  PositionView,
+  SetupResponse,
+  StopMode,
+  TradePreviewResponse,
+  TrancheMode,
+} from "@/lib/types";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8000";
 
@@ -87,14 +99,16 @@ export const api = {
   getAccount: () => request<AccountView>("/api/account"),
   updateAccount: (payload: { equity: number; risk_pct: number; mode: string }) =>
     request<AccountView>("/api/account/settings", { method: "PUT", body: JSON.stringify(payload) }),
-  getSetup: (symbol: string) => request<SetupResponse>(`/api/setup/${symbol}`),
+  getSetup: (symbol: string, signal?: AbortSignal) => request<SetupResponse>(`/api/setup/${symbol}`, { signal }),
   getPositions: () => request<PositionView[]>("/api/positions"),
-  getOrders: (symbol: string) => request(`/api/orders/${symbol}`),
+  getOrders: (symbol: string) => request<OrderView[]>(`/api/orders/${symbol}`),
+  getRecentOrders: () => request<OrderView[]>("/api/orders"),
+  cancelOrder: (brokerOrderId: string) => request<OrderView>(`/api/orders/${brokerOrderId}`, { method: "DELETE" }),
   getLogs: () => request<LogEntry[]>("/api/activity-log"),
   clearLogs: () => request<{ cleared: number }>("/api/activity-log", { method: "DELETE" }),
-  previewTrade: (payload: { symbol: string; entry: number; stopRef: string; stopPrice: number; riskPct: number }) =>
-    request("/api/trade/preview", { method: "POST", body: JSON.stringify(payload) }),
-  enterTrade: (payload: { symbol: string; entry: number; stopRef: string; stopPrice: number; trancheCount: number; trancheModes: TrancheMode[]; offHoursMode?: OffHoursMode | null }) =>
+  previewTrade: (payload: { symbol: string; entry: number; stopRef: string; stopPrice: number; riskPct: number; order: EntryOrderDraft }) =>
+    request<TradePreviewResponse>("/api/trade/preview", { method: "POST", body: JSON.stringify(payload) }),
+  enterTrade: (payload: { symbol: string; entry: number; stopRef: string; stopPrice: number; trancheCount: number; trancheModes: TrancheMode[]; offHoursMode?: OffHoursMode | null; order: EntryOrderDraft }) =>
     request<PositionView>("/api/trade/enter", { method: "POST", body: JSON.stringify(payload) }),
   applyStops: (payload: { symbol: string; stopMode: number; stopModes: StopMode[] }) =>
     request<PositionView>("/api/trade/stops", { method: "POST", body: JSON.stringify(payload) }),

--- a/frontend/lib/cockpit-ui.ts
+++ b/frontend/lib/cockpit-ui.ts
@@ -58,15 +58,111 @@ export function phaseLabel(phase: string): string {
   return PHASE_LABELS[phase] ?? phase.replaceAll("_", " ").toUpperCase();
 }
 
-export function splitShares(total: number, count: number): number[] {
-  if (count <= 1) return [total];
-  if (count === 2) {
-    const first = Math.floor(total / 2);
-    return [first, total - first];
+export function defaultAllocationPcts(count: number): number[] {
+  if (count <= 1) return [100];
+  const even = Math.floor((100 / count) * 100) / 100;
+  const allocations = Array.from({ length: count }, () => even);
+  allocations[count - 1] = Number((100 - even * (count - 1)).toFixed(2));
+  return allocations;
+}
+
+export function normalizeAllocationPcts(
+  values: Array<number | null | undefined>,
+  changedIndex: number,
+  count: number
+): number[] {
+  const next = defaultAllocationPcts(count);
+  const clampedChanged = Math.max(0, Math.min(100, Number(values[changedIndex] ?? next[changedIndex])));
+  next[changedIndex] = Number(clampedChanged.toFixed(2));
+  const otherIndexes = Array.from({ length: count }, (_, index) => index).filter((index) => index !== changedIndex);
+  if (otherIndexes.length === 0) return [100];
+  const remaining = Math.max(0, Number((100 - next[changedIndex]).toFixed(2)));
+  const originalOtherTotal = otherIndexes.reduce((sum, index) => sum + Math.max(0, Number(values[index] ?? next[index])), 0);
+  if (originalOtherTotal <= 0) {
+    const even = Number((remaining / otherIndexes.length).toFixed(2));
+    otherIndexes.forEach((index, itemIndex) => {
+      next[index] = itemIndex === otherIndexes.length - 1
+        ? Number((remaining - even * (otherIndexes.length - 1)).toFixed(2))
+        : even;
+    });
+  } else {
+    let assigned = 0;
+    otherIndexes.forEach((index, itemIndex) => {
+      if (itemIndex === otherIndexes.length - 1) {
+        next[index] = Number((remaining - assigned).toFixed(2));
+        return;
+      }
+      const proportional = Number((((Math.max(0, Number(values[index] ?? 0)) / originalOtherTotal) * remaining)).toFixed(2));
+      next[index] = proportional;
+      assigned = Number((assigned + proportional).toFixed(2));
+    });
   }
-  const first = Math.floor(total * 0.33);
-  const second = Math.floor(total * 0.33);
-  return [first, second, total - first - second];
+  return next;
+}
+
+export function splitShares(total: number, count: number, allocationPcts?: Array<number | null | undefined>): number[] {
+  if (count <= 1) return [total];
+  if (!total) return Array.from({ length: count }, () => 0);
+  const allocations = allocationPcts && allocationPcts.length >= count
+    ? allocationPcts.slice(0, count).map((value, index) => value ?? defaultAllocationPcts(count)[index])
+    : defaultAllocationPcts(count);
+  const raw = allocations.map((allocation) => (total * allocation) / 100);
+  const assigned = raw.map((value) => Math.floor(value));
+  let remaining = total - assigned.reduce((sum, value) => sum + value, 0);
+  const remainders = raw
+    .map((value, index) => ({ index, remainder: value - assigned[index] }))
+    .sort((left, right) => right.remainder - left.remainder || left.index - right.index);
+  for (const item of remainders) {
+    if (remaining <= 0) break;
+    assigned[item.index] += 1;
+    remaining -= 1;
+  }
+  return assigned;
+}
+
+export function defaultStopPcts(stopMode: number): number[] {
+  if (stopMode <= 1) return [100];
+  return Array.from({ length: stopMode }, (_, index) =>
+    Number((((index + 1) / stopMode) * 100).toFixed(2))
+  );
+}
+
+export function normalizeStopPcts(
+  stopModes: StopMode[],
+  stopMode: number,
+  changedIndex: number,
+  nextPct: number
+): StopMode[] {
+  const current = stopModes.slice(0, stopMode).map((mode, index) => ({
+    mode: mode.mode,
+    pct: mode.mode === "be" ? 0 : mode.pct ?? defaultStopPcts(stopMode)[index],
+  }));
+  const normalizedDefaults = defaultStopPcts(stopMode);
+  const lowerAnchor = changedIndex === 0 ? 0 : (current[changedIndex - 1]?.mode === "be" ? 0 : Number(current[changedIndex - 1]?.pct ?? normalizedDefaults[changedIndex - 1]));
+  const upperAnchor = changedIndex === stopMode - 1 ? 100 : (current[changedIndex + 1]?.mode === "be" ? normalizedDefaults[changedIndex + 1] : Number(current[changedIndex + 1]?.pct ?? normalizedDefaults[changedIndex + 1]));
+  const clamped = Math.max(lowerAnchor, Math.min(upperAnchor, nextPct));
+  current[changedIndex] = { ...current[changedIndex], pct: Number(clamped.toFixed(2)) };
+
+  let previous = 0;
+  for (let index = 0; index < stopMode; index += 1) {
+    if (current[index].mode === "be") {
+      current[index].pct = 0;
+      continue;
+    }
+    if (index < changedIndex) {
+      const slots = changedIndex - index + 1;
+      current[index].pct = Number((previous + (clamped - previous) / slots).toFixed(2));
+    } else if (index > changedIndex) {
+      const nextSlots = stopMode - changedIndex;
+      current[index].pct = Number((clamped + ((100 - clamped) * (index - changedIndex)) / nextSlots).toFixed(2));
+    }
+    previous = Number(current[index].pct ?? 0);
+  }
+
+  return stopModes.map((mode, index) => {
+    if (index >= stopMode) return mode;
+    return current[index];
+  });
 }
 
 export function targetPrice(setup: SetupResponse, mode: TrancheMode): number | null {
@@ -135,7 +231,11 @@ export function stopPlanRows(
   }
   const previewTranches = tranches.length
     ? tranches
-    : splitShares(setup.shares, modeCount).map((qty, index) => ({
+    : splitShares(
+        setup.shares,
+        modeCount,
+        defaultAllocationPcts(modeCount)
+      ).map((qty, index) => ({
         id: `T${index + 1}`,
         qty,
         stop: setup.finalStop,
@@ -182,4 +282,71 @@ export function soldShares(position: PositionView): number {
   return position.tranches
     .filter((tranche) => tranche.status === "sold")
     .reduce((sum, tranche) => sum + tranche.qty, 0);
+}
+
+export type RunningPnlSummary = {
+  totalShares: number;
+  closedShares: number;
+  remainingShares: number;
+  realizedPnl: number;
+  unrealizedPnl: number;
+  openRisk: number;
+  filledLegs: Array<{
+    label: string;
+    qty: number;
+    exitPrice: number | null;
+    pnl: number;
+    filledAt: string | null;
+  }>;
+};
+
+export function runningPnlSummary(position: PositionView | null, setup: SetupResponse | null): RunningPnlSummary | null {
+  if (!position || !setup || position.phase === "entry_pending") return null;
+  const entry = setup.entry;
+  const totalShares = position.tranches.reduce((sum, tranche) => sum + tranche.qty, 0);
+  const activeTranches = position.tranches.filter((tranche) => tranche.status === "active");
+  const closedTranches = position.tranches.filter((tranche) => tranche.status === "sold");
+  const remainingShares = activeTranches.reduce((sum, tranche) => sum + tranche.qty, 0);
+  const closedShares = closedTranches.reduce((sum, tranche) => sum + tranche.qty, 0);
+
+  const filledLegs = closedTranches.map((tranche) => {
+    const fillOrder = [...position.orders]
+      .filter((order) => order.status === "FILLED" && (order.tranche === tranche.id || order.coveredTranches.includes(tranche.id)))
+      .sort((left, right) => {
+        const leftTime = left.filledAt ?? left.updatedAt ?? left.createdAt ?? "";
+        const rightTime = right.filledAt ?? right.updatedAt ?? right.createdAt ?? "";
+        return rightTime.localeCompare(leftTime);
+      })[0];
+    const exitPrice = tranche.exitPrice ?? fillOrder?.fillPrice ?? tranche.target ?? null;
+    const pnl = exitPrice !== null ? Number(((exitPrice - entry) * tranche.qty).toFixed(2)) : 0;
+    const exitOrderType = tranche.exitOrderType ?? fillOrder?.type ?? null;
+    const label = exitOrderType === "STOP"
+      ? `Stop hit · ${tranche.id}`
+      : exitOrderType === "TRAIL"
+        ? `Runner exit · ${tranche.id}`
+        : `${tranche.id} filled`;
+    return {
+      label,
+      qty: tranche.qty,
+      exitPrice,
+      pnl,
+      filledAt: tranche.exitFilledAt ?? fillOrder?.filledAt ?? fillOrder?.updatedAt ?? fillOrder?.createdAt ?? null,
+    };
+  });
+
+  const realizedPnl = Number(filledLegs.reduce((sum, leg) => sum + leg.pnl, 0).toFixed(2));
+  const unrealizedPnl = Number(((position.livePrice - entry) * remainingShares).toFixed(2));
+  const openRisk = Number(
+    activeTranches.reduce((sum, tranche) => sum + Math.max(0, (entry - tranche.stop) * tranche.qty), 0).toFixed(2)
+  );
+
+  return {
+    totalShares,
+    closedShares,
+    remainingShares,
+    realizedPnl,
+    unrealizedPnl,
+    openRisk,
+    filledLegs,
+  };
 }

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,7 +1,34 @@
 export type StopMode = { mode: "stop" | "be"; pct: number | null };
 
+export type EntryOrderType = "market" | "limit" | "stop" | "stop_limit";
+export type TimeInForce = "day" | "gtc" | "ioc" | "fok" | "opg" | "cls";
+export type OrderClass = "simple" | "bracket" | "oco" | "oto";
+export type OtoExitSide = "stop_loss" | "take_profit";
+
+export type TakeProfitDraft = {
+  limitPrice: number | null;
+};
+
+export type StopLossDraft = {
+  stopPrice: number | null;
+  limitPrice: number | null;
+};
+
+export type EntryOrderDraft = {
+  orderType: EntryOrderType;
+  timeInForce: TimeInForce;
+  orderClass: OrderClass;
+  extendedHours: boolean;
+  limitPrice: number | null;
+  stopPrice: number | null;
+  otoExitSide: OtoExitSide;
+  takeProfit: TakeProfitDraft | null;
+  stopLoss: StopLossDraft | null;
+};
+
 export type TrancheMode = {
   mode: "limit" | "runner";
+  allocationPct?: number | null;
   trail: number;
   trailUnit: "$" | "%";
   target: "1R" | "2R" | "3R" | "Manual";
@@ -14,6 +41,9 @@ export type Tranche = {
   stop: number;
   target?: number | null;
   status: "active" | "sold" | "canceled";
+  exitPrice?: number | null;
+  exitFilledAt?: string | null;
+  exitOrderType?: string | null;
   mode: "limit" | "runner";
   trail: number;
   trailUnit: "$" | "%";
@@ -23,16 +53,22 @@ export type Tranche = {
 
 export type OrderView = {
   id: string;
+  symbol: string;
+  side?: string | null;
   type: string;
   qty: number;
   origQty: number;
+  filledQty: number;
+  remainingQty: number;
   price: number;
   status: string;
   tranche: string;
   coveredTranches: string[];
   parentId?: string | null;
   brokerOrderId?: string | null;
+  cancelable: boolean;
   createdAt?: string | null;
+  updatedAt?: string | null;
   filledAt?: string | null;
   fillPrice?: number | null;
 };
@@ -51,7 +87,12 @@ export type SetupResponse = {
   sessionState: "regular_open" | "overnight" | "pre_market" | "after_hours" | "closed";
   quoteState: "live_quote" | "cached_quote" | "quote_unavailable";
   entryBasis: string;
-  stopReferenceDefault: string;
+  stopReferenceDefault: "lod" | "atr" | "manual";
+  lodIsValid: boolean;
+  atrIsValid: boolean;
+  lodStop: number;
+  atrStop: number;
+  manualStopWarning?: string | null;
   bid: number;
   ask: number;
   last: number;
@@ -75,8 +116,26 @@ export type SetupResponse = {
   perShareRisk: number;
   riskPct: number;
   accountEquity: number;
+  accountBuyingPower: number;
+  accountCash?: number | null;
+  equitySource: string;
+  sizingWarning?: string | null;
+  buyingPowerNote?: string | null;
   atrExtension: number;
   extFrom10Ma: number;
+};
+
+export type TradePreviewResponse = {
+  symbol: string;
+  entry: number;
+  finalStop: number;
+  perShareRisk: number;
+  shares: number;
+  dollarRisk: number;
+  sizingWarning?: string | null;
+  orderType?: EntryOrderType;
+  timeInForce?: TimeInForce;
+  orderClass?: OrderClass;
 };
 
 export type PositionView = {
@@ -98,9 +157,11 @@ export type OffHoursMode = "queue_for_open" | "extended_hours_limit";
 export type AccountView = {
   equity: number;
   buying_power: number;
+  cash?: number | null;
   risk_pct: number;
   mode: string;
   effective_mode: string;
+  equity_source: string;
   daily_realized_pnl: number;
   allow_live_trading: boolean;
   max_position_notional_pct: number;

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  typedRoutes: false
+  typedRoutes: false,
+  allowedDevOrigins: ["127.0.0.1", "localhost"]
 };
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:stable": "next dev",
+    "dev:fast": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -35,6 +35,8 @@ Object.defineProperty(globalThis, "fetch", {
           }
           : url.includes("/api/positions")
           ? []
+          : url.includes("/api/orders")
+            ? []
           : url.includes("/api/activity-log")
             ? []
             : {

--- a/scripts/dev/start-local.ps1
+++ b/scripts/dev/start-local.ps1
@@ -14,6 +14,7 @@ $ErrorActionPreference = "Stop"
 $repoRoot = Get-RepoRoot
 $backendDir = Join-Path $repoRoot "backend"
 $frontendDir = Join-Path $repoRoot "frontend"
+$frontendNextDir = Join-Path $frontendDir ".next"
 $backendOut = Join-Path $repoRoot "backend.out.log"
 $backendErr = Join-Path $repoRoot "backend.err.log"
 $frontendOut = Join-Path $repoRoot "frontend.out.log"
@@ -117,10 +118,14 @@ Invoke-RestMethod `
   -Body $accountBody `
   -WebSession $authSession | Out-Null
 
+if (Test-Path $frontendNextDir) {
+  cmd /c "rmdir /s /q ""$frontendNextDir""" | Out-Null
+}
+
 $frontendCmd = @(
   "set ""NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:$BackendPort""",
   "set ""NEXT_PUBLIC_WS_URL=ws://127.0.0.1:$BackendPort/ws/cockpit""",
-  "npm run dev -- --port $FrontendPort"
+  "npx next dev -p $FrontendPort"
 ) -join " && "
 
 Start-Process -FilePath "cmd.exe" `


### PR DESCRIPTION
## Summary
- merge the validated release-prep candidate onto a clean branch from `codex/integration-app`
- carry the current cockpit UI/state work into a committed, clean, integration-ready branch
- keep the hardened local startup path that clears stale `.next` and launches Next dev reliably

## Validation
- `npm run lint`
- `npm run test`
- `npm run build`
- `python -m ruff check backend/app`
- `python -m black --check backend/app`
- `python -m pytest -q backend/app/tests/test_api.py`
- browser QC on isolated stack `3040/8040`, including successful `MSFT` setup load

## Notes
- screenshot evidence captured locally during QC: `frontend/output/playwright/integration-promote-setup-loaded-3040.png`
- this targets `codex/integration-app`; it is not a `main` promotion PR
