### PR TITLE
Harden release process docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,17 @@ Describe the change in 2-5 lines.
 - Risk 1:
 - Risk 2:
 
+## Known Gaps
+
+- Gap 1:
+- Gap 2:
+
+## Env / Schema Changes
+
+- Environment changes:
+- Schema / migration changes:
+- README / `.env.example` updates:
+
 ## Validation
 
 - [ ] Frontend lint, test, and build
@@ -27,7 +38,7 @@ Validation notes:
 
 ## QC Evidence
 
-If visible UI changed, note where evidence was captured:
+If visible UI changed, note where evidence was captured. Include the browser artifact paths or links used for review:
 
 - `output/...`
 - `frontend/test-results/...`
@@ -38,6 +49,14 @@ If visible UI changed, note where evidence was captured:
 - [ ] Linked issue or repo issue record is included
 - [ ] Required checks are green
 - [ ] Risks and rollback path are documented
+- [ ] Browser QC evidence is attached for production-facing UI work
+- [ ] Env/schema notes are complete
+- [ ] Known gaps are listed explicitly
+
+## Rollback
+
+- Revert strategy:
+- Operational follow-up after revert:
 
 ## Follow-Up
 

--- a/docs/handoffs/2026-03-23-release-board.md
+++ b/docs/handoffs/2026-03-23-release-board.md
@@ -1,0 +1,19 @@
+# Release Board
+
+Use this board to track the current promotion program from feature branches through staging and into `main`.
+
+| Tranche | Branch | PR | Validation | Decision / Notes |
+| --- | --- | --- | --- | --- |
+| Release prep consolidation | `codex/feature-release-prep` | merged via integration | local lint/test/build, backend Ruff/Black/pytest, browser QC on isolated stack | prepared the clean candidate before integration promotion |
+| Integration promotion candidate | `codex/feature-integration-promote-release-prep` | [#10](https://github.com/Melvinroy/traders-cockpit/pull/10) | frontend CI green, backend CI initially blocked on Black | merged into `codex/integration-app` after blocker fix |
+| Integration Black blocker | `codex/bugfix-integration-black-ci` | folded into PR #10 head | backend Ruff, Black check, pytest | documented blocker; actual delivery path was the integration-promotion branch |
+| Staged QC hardening | `codex/bugfix-qc-stable-symbol` | [#11](https://github.com/Melvinroy/traders-cockpit/pull/11) | `run-qc.ps1 -StartStack` on deterministic paper stack, refreshed Playwright artifacts | merged into `codex/integration-app` |
+| Promotion to `main` | `codex/integration-app` | [#12](https://github.com/Melvinroy/traders-cockpit/pull/12) | promotion PR includes validation, known gaps, env/schema notes, rollback | open |
+
+## Merge Sequence
+
+1. Implement and validate on a dedicated `codex/*` branch.
+2. Merge into `codex/integration-app`.
+3. Run staged QC on integration and refresh required browser artifacts.
+4. Open the promotion PR from `codex/integration-app` to `main`.
+5. After merge to `main`, close linked issue docs and prune merged branches.

--- a/docs/issues/2026-03-23-release-process-hardening.md
+++ b/docs/issues/2026-03-23-release-process-hardening.md
@@ -1,0 +1,38 @@
+# Release Process Hardening
+
+> Status: Open
+> Branch: `codex/refactor-release-process-hardening`
+> Opened: 2026-03-23
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The repository already has staging and promotion docs, but the release path still depends too much on convention and recent memory. Reviewers can miss screenshot evidence, env/schema drift, rollback detail, or the exact merge sequence because those requirements are spread across multiple files and not enforced consistently in the PR template.
+
+## Business value
+
+Production promotion should be boring. The repo needs one durable release-program record, one visible handoff board, and one consistent PR/checklist contract so staged work reaches `main` with the same evidence every time.
+
+## Scope
+
+- add a standing repo issue doc for the production-readiness program
+- add a simple release board under `docs/handoffs/`
+- tighten the PR template with screenshot, env/schema, known-gap, and rollback sections
+- make the merge sequence explicit in process docs
+- strengthen the release checklist with clean-worktree and post-merge verification requirements
+- restate that production-facing work must land through `codex/integration-app` with browser QC evidence
+
+## Acceptance criteria
+
+- [ ] release-program issue doc exists and links to the release board
+- [ ] release board exists under `docs/handoffs/`
+- [ ] PR template requires screenshot evidence, env/schema notes, known gaps, and rollback
+- [ ] release checklist includes clean-worktree and post-merge verification guidance
+- [ ] merge sequence is explicitly documented as feature -> `codex/integration-app` -> `main`
+- [ ] process docs explicitly require browser QC evidence for production-facing UI work
+
+## Risks / constraints
+
+- avoid duplicating process guidance without clarifying the single source of truth
+- keep the docs lightweight enough that they are used, not ignored

--- a/docs/process/RELEASE_PROMOTION_CHECKLIST.md
+++ b/docs/process/RELEASE_PROMOTION_CHECKLIST.md
@@ -5,9 +5,11 @@ Use this checklist before opening or merging a promotion PR from `codex/integrat
 ## Before the promotion PR
 
 - all intended feature PRs into `codex/integration-app` are merged
+- local worktree is clean before promotion work begins
 - no unrelated local changes remain
 - the branch is rebased or merged up to the latest remote integration state
 - open follow-up risks are documented in the promotion PR
+- promotion PR includes explicit known gaps, env/schema notes, QC evidence, and rollback steps
 
 ## Required validation
 
@@ -16,9 +18,12 @@ Use this checklist before opening or merging a promotion PR from `codex/integrat
 - local backend `pytest -q` passed if backend changed
 - local frontend `npm run lint`, `npm run test`, and `npm run build` passed if frontend changed
 - browser QC evidence exists for visible UI changes
+- the five cockpit baseline screenshots are refreshed for cockpit-state work
+- production-facing UI work is promoted only after browser QC evidence is attached on the integration candidate
 
 ## Release review questions
 
+- does this release follow the merge sequence `codex/* -> codex/integration-app -> main`
 - does this promotion contain only staged, reviewed work
 - are all schema or env changes reflected in docs
 - are any live-trading controls still safely gated
@@ -26,6 +31,7 @@ Use this checklist before opening or merging a promotion PR from `codex/integrat
 
 ## After merge to `main`
 
+- confirm CI and deployment/host checks for the promoted revision
 - confirm the merge commit is present on `main`
 - update the linked `docs/issues/*.md` record to `Status: Closed`
 - record the closing promotion commit in that issue doc
@@ -33,3 +39,10 @@ Use this checklist before opening or merging a promotion PR from `codex/integrat
 - prune stale local and remote tracking refs if needed
 - tag the release if a versioned cut is needed
 - document any operational follow-up in `docs/handoffs/` or the merged PR
+
+## Post-Merge Verification
+
+- verify the promoted `main` commit is the same commit reviewed in the promotion PR
+- rerun the post-merge smoke or hosted-health checks required for the target environment
+- confirm baseline artifacts and validation notes are still linked from the promotion PR
+- record any first-24-hour monitoring follow-up in `docs/handoffs/`

--- a/docs/process/STAGING_RELEASE_PLAYBOOK.md
+++ b/docs/process/STAGING_RELEASE_PLAYBOOK.md
@@ -36,6 +36,15 @@ The following files must exist after QC:
 - validate on integration before opening the promotion PR
 - promote only from `codex/integration-app` into `main`
 - if rollback is needed, revert the promotion merge rather than rewriting history
+- production-facing UI work must include browser QC evidence on the integration branch before promotion
+
+## Merge Sequence
+
+1. Merge a dedicated `codex/*` branch into `codex/integration-app`.
+2. Run staged validation on `codex/integration-app`.
+3. Refresh required browser artifacts for any visible cockpit changes.
+4. Open the promotion PR from `codex/integration-app` to `main`.
+5. After merge to `main`, close linked issue docs and prune merged branches.
 
 ## PR Summary Template
 
@@ -46,3 +55,4 @@ State:
 - env/schema changes
 - remaining known gaps
 - rollback plan
+- where screenshot/browser QC evidence is attached


### PR DESCRIPTION
## Summary
- add a standing release-process hardening issue record and release board
- tighten the PR template with known-gap, env/schema, browser-QC, and rollback sections
- strengthen promotion/staging docs with clean-worktree, merge-sequence, and post-merge verification guidance

## Linked Issue
- docs/issues/2026-03-23-release-process-hardening.md

## Risks
- documentation-only change

## Known Gaps
- this does not yet enforce the new sections in CI; it documents and standardizes them

## Env / Schema Changes
- Environment changes: none
- Schema / migration changes: none
- README / .env.example updates: none

## Validation
- [x] Docs reviewed locally

## QC Evidence
- Documentation-only change; no browser QC required

## Rollback
- Revert the merge commit for this docs tranche