### PR TITLE
Add hosted smoke readiness tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,26 @@ Validate hosted envs before deploy:
 .\scripts\dev\check-hosted-env.ps1 -EnvFile ".env"
 ```
 
+Hosted browser smoke:
+
+```powershell
+.\scripts\dev\run-hosted-smoke.ps1 `
+  -FrontendUrl "https://app.example.com" `
+  -BackendUrl "https://api.example.com" `
+  -EnvFile ".env.production.local"
+```
+
+For local validation of the hosted smoke wrapper, add explicit auth overrides:
+
+```powershell
+.\scripts\dev\run-hosted-smoke.ps1 `
+  -FrontendUrl "http://127.0.0.1:3094" `
+  -BackendUrl "http://127.0.0.1:8094" `
+  -EnvFile ".env.production.example" `
+  -AuthUsername "admin" `
+  -AuthPassword "change-me-admin"
+```
+
 More deployment detail lives in [docs/process/HOSTED_DEPLOYMENT.md](docs/process/HOSTED_DEPLOYMENT.md).
 
 ## Roadmap

--- a/docs/issues/2026-03-23-hosted-smoke-readiness.md
+++ b/docs/issues/2026-03-23-hosted-smoke-readiness.md
@@ -1,0 +1,34 @@
+# Hosted Smoke Readiness
+
+> Status: Open
+> Branch: `codex/feature-hosted-smoke-readiness`
+> Opened: 2026-03-23
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The repo now has stronger env validation and runtime preflight checks, but the hosted deployment path is still missing a single operator command that proves the deployed frontend and backend work together. The Render blueprint is also under-specified for production-like staging because it does not declare a health check or a persistent auth storage path.
+
+## Business value
+
+Hosted readiness should be operable, not theoretical. This tranche gives the repo a documented post-deploy smoke command, makes the Render blueprint safer to deploy, and codifies the current hosted tradeoffs in docs.
+
+## Scope
+
+- add a hosted smoke wrapper that reuses the existing browser smoke flow against arbitrary frontend/backend URLs
+- document the hosted post-deploy smoke path
+- harden `render.yaml` with an explicit health check and persistent auth disk contract
+- document the persistent-disk tradeoff for the current hosted auth model
+
+## Acceptance criteria
+
+- [ ] `scripts/dev/run-hosted-smoke.ps1` exists and can drive browser smoke against provided hosted URLs
+- [ ] hosted deployment docs include the smoke command and expected artifacts
+- [ ] `render.yaml` declares a health check path
+- [ ] `render.yaml` declares a persistent auth storage path for the current hosted auth model
+
+## Risks / constraints
+
+- the current hosted auth model still depends on file-backed auth storage; this tranche documents and stabilizes it but does not replace it with Postgres-backed auth
+- attaching a persistent disk on Render trades off zero-downtime deploys and horizontal scaling for durable auth state

--- a/docs/process/HOSTED_DEPLOYMENT.md
+++ b/docs/process/HOSTED_DEPLOYMENT.md
@@ -95,6 +95,52 @@ The hosted env check now rejects:
 - insecure auth cookie settings
 - missing live confirmation token when live trading is enabled
 
+## Hosted Smoke
+
+After the hosted backend and frontend are deployed, run the browser smoke against the real URLs:
+
+```powershell
+Copy-Item .env.production.example .env.production.local
+# Edit .env.production.local with the hosted admin credentials
+.\scripts\dev\run-hosted-smoke.ps1 `
+  -FrontendUrl "https://app.example.com" `
+  -BackendUrl "https://api.example.com" `
+  -EnvFile ".env.production.local"
+```
+
+For local validation of the wrapper against a non-hosted stack, you can override the auth credentials explicitly:
+
+```powershell
+.\scripts\dev\run-hosted-smoke.ps1 `
+  -FrontendUrl "http://127.0.0.1:3094" `
+  -BackendUrl "http://127.0.0.1:8094" `
+  -EnvFile ".env.production.example" `
+  -AuthUsername "admin" `
+  -AuthPassword "change-me-admin"
+```
+
+Expected artifacts:
+
+- `frontend/output/playwright/hosted-smoke.png`
+- `frontend/output/playwright/hosted-smoke.console.txt`
+- `frontend/output/playwright/hosted-smoke.network.txt`
+
+The hosted smoke reuses the same login and setup-load browser path as the local smoke flow, but points it at the hosted frontend/backend pair you provide.
+
+## Current Render Tradeoff
+
+The current Render blueprint keeps auth state on a persistent disk:
+
+- disk mount: `/var/lib/traders-cockpit/auth`
+- auth DB path: `/var/lib/traders-cockpit/auth/auth.db`
+
+This is the current hosted-safe compromise for durable auth sessions, but it has tradeoffs:
+
+- attached persistent disks limit scaling options
+- disk-backed auth on a single web service is not the long-term multi-instance design
+
+The follow-up production tranche should migrate hosted auth persistence to Postgres if multi-instance scaling becomes a real requirement.
+
 ## Promotion Path
 
 1. Deploy backend staging.

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,11 @@ services:
     runtime: docker
     dockerfilePath: ./backend/Dockerfile
     plan: starter
-    autoDeploy: true
+    autoDeployTrigger: checksPass
+    healthCheckPath: /health
+    disk:
+      name: auth
+      mountPath: /var/lib/traders-cockpit/auth
     envVars:
       - key: APP_ENV
         value: staging
@@ -18,6 +22,8 @@ services:
         value: none
       - key: AUTH_COOKIE_SECURE
         value: "true"
+      - key: AUTH_DB_PATH
+        value: /var/lib/traders-cockpit/auth/auth.db
       - key: ALLOW_SQLITE_FALLBACK
         value: "false"
       - key: BROKER_MODE

--- a/scripts/dev/run-hosted-smoke.ps1
+++ b/scripts/dev/run-hosted-smoke.ps1
@@ -1,0 +1,69 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$FrontendUrl,
+
+  [Parameter(Mandatory = $true)]
+  [string]$BackendUrl,
+
+  [string]$EnvFile = ".env.production.local",
+  [string]$SmokeLabel = "hosted-smoke",
+  [string]$Symbol = "MSFT",
+  [string]$AuthUsername,
+  [string]$AuthPassword
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "common.ps1")
+
+$repoRoot = Get-RepoRoot
+$profileEnv = Get-LocalProfileEnv -RepoRoot $repoRoot -EnvFile $EnvFile
+$frontendDir = Join-Path $repoRoot "frontend"
+$playwrightOutputDir = Join-Path $frontendDir "output\\playwright"
+
+$env:FRONTEND_URL = $FrontendUrl
+$env:BACKEND_URL = $BackendUrl.TrimEnd("/")
+$env:BROWSER_SMOKE_LABEL = $SmokeLabel
+$env:QC_SYMBOL = $Symbol.Trim().ToUpperInvariant()
+$env:QC_AUTH_USERNAME = if ($AuthUsername) {
+  $AuthUsername
+} else {
+  Get-ResolvedValue -EnvValues $profileEnv -Key "AUTH_ADMIN_USERNAME" -Default "admin"
+}
+$env:QC_AUTH_PASSWORD = if ($AuthPassword) {
+  $AuthPassword
+} else {
+  Get-ResolvedValue -EnvValues $profileEnv -Key "AUTH_ADMIN_PASSWORD" -Default "change-me-admin"
+}
+
+try {
+  Push-Location $repoRoot
+  try {
+    & (Join-Path $PSScriptRoot "check-hosted-env.ps1") -EnvFile $EnvFile
+  } finally {
+    Pop-Location
+  }
+
+  Push-Location $frontendDir
+  try {
+    node ..\scripts\dev\browser-smoke.mjs
+  } finally {
+    Pop-Location
+  }
+
+  foreach ($suffix in @("png", "console.txt", "network.txt")) {
+    $artifact = Join-Path $playwrightOutputDir "$SmokeLabel.$suffix"
+    if (-not (Test-Path $artifact)) {
+      throw "Expected hosted smoke artifact was not created: $artifact"
+    }
+  }
+
+  Write-Host "Hosted smoke completed successfully"
+  Write-Host "Artifacts: $playwrightOutputDir"
+} finally {
+  Remove-Item Env:FRONTEND_URL -ErrorAction SilentlyContinue
+  Remove-Item Env:BACKEND_URL -ErrorAction SilentlyContinue
+  Remove-Item Env:BROWSER_SMOKE_LABEL -ErrorAction SilentlyContinue
+  Remove-Item Env:QC_SYMBOL -ErrorAction SilentlyContinue
+  Remove-Item Env:QC_AUTH_USERNAME -ErrorAction SilentlyContinue
+  Remove-Item Env:QC_AUTH_PASSWORD -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- add a hosted smoke wrapper that reuses browser smoke against arbitrary frontend/backend URLs
- harden the Render blueprint with an explicit health check and persistent auth storage contract
- document the current hosted auth tradeoff and post-deploy smoke path

## Linked Issue
- docs/issues/2026-03-23-hosted-smoke-readiness.md

## Risks
- Render blueprint now declares a persistent disk for the current file-backed auth model, which trades off scaling flexibility for durable auth state
- hosted smoke depends on valid admin credentials in the provided env file or explicit overrides

## Known Gaps
- this tranche stabilizes the current disk-backed hosted auth model but does not replace it with Postgres-backed auth
- hosted smoke validates the deployed frontend/backend path but does not yet cover a full trade lifecycle on hosted infrastructure

## Env / Schema Changes
- Environment changes: none required, but hosted runs now assume `AUTH_DB_PATH=/var/lib/traders-cockpit/auth/auth.db` on Render
- Schema / migration changes: none
- README / `.env.example` updates: README and hosted deployment docs updated

## Validation
- [x] `python scripts/dev/check-secret-hygiene.py`
- [x] `python scripts/dev/check-config-contract.py`
- [x] `powershell -ExecutionPolicy Bypass -File scripts/dev/check-hosted-env.ps1 -EnvFile .env.production.example`
- [x] `powershell -ExecutionPolicy Bypass -File scripts/dev/start-local.ps1 -FrontendPort 3094 -FrontendProdPort 3194 -BackendPort 8094 -PostgresPort 55494 -RedisPort 56394`
- [x] `powershell -ExecutionPolicy Bypass -File scripts/dev/run-hosted-smoke.ps1 -FrontendUrl http://127.0.0.1:3094 -BackendUrl http://127.0.0.1:8094 -EnvFile .env.production.example -SmokeLabel hosted-smoke-local -AuthUsername admin -AuthPassword change-me-admin`

## QC Evidence
- Browser artifact: `frontend/output/playwright/hosted-smoke-local.png`
- Console artifact: `frontend/output/playwright/hosted-smoke-local.console.txt`
- Network artifact: `frontend/output/playwright/hosted-smoke-local.network.txt`

## Rollback
- Revert this PR merge to remove the hosted smoke wrapper and restore the prior Render blueprint
- If the Render disk contract is not acceptable for the target environment, revert the merge and keep using the existing manual hosted checks while replacing the auth persistence model in a follow-up tranche