### PR TITLE
Add sell-side order matrix support

### DIFF
--- a/backend/app/adapters/broker.py
+++ b/backend/app/adapters/broker.py
@@ -43,14 +43,24 @@ class BrokerAdapter:
             )
         )
 
-    def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
+    def place_stop_order(
+        self, symbol: str, qty: int, stop_price: float, side: str = "sell"
+    ) -> BrokerOrderResult:
         raise NotImplementedError
 
-    def place_limit_order(self, symbol: str, qty: int, limit_price: float) -> BrokerOrderResult:
+    def place_limit_order(
+        self,
+        symbol: str,
+        qty: int,
+        limit_price: float,
+        side: str = "sell",
+        time_in_force: str = "gtc",
+        extended_hours: bool = False,
+    ) -> BrokerOrderResult:
         raise NotImplementedError
 
     def place_trailing_stop(
-        self, symbol: str, qty: int, trail: float, trail_unit: str
+        self, symbol: str, qty: int, trail: float, trail_unit: str, side: str = "sell"
     ) -> BrokerOrderResult:
         raise NotImplementedError
 
@@ -100,14 +110,24 @@ class PaperBrokerAdapter(BrokerAdapter):
     def place_market_order(self, symbol: str, qty: int, side: str) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="FILLED")
 
-    def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
+    def place_stop_order(
+        self, symbol: str, qty: int, stop_price: float, side: str = "sell"
+    ) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="ACTIVE")
 
-    def place_limit_order(self, symbol: str, qty: int, limit_price: float) -> BrokerOrderResult:
+    def place_limit_order(
+        self,
+        symbol: str,
+        qty: int,
+        limit_price: float,
+        side: str = "sell",
+        time_in_force: str = "gtc",
+        extended_hours: bool = False,
+    ) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="FILLED")
 
     def place_trailing_stop(
-        self, symbol: str, qty: int, trail: float, trail_unit: str
+        self, symbol: str, qty: int, trail: float, trail_unit: str, side: str = "sell"
     ) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="ACTIVE")
 
@@ -251,7 +271,9 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             )
         )
 
-    def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
+    def place_stop_order(
+        self, symbol: str, qty: int, stop_price: float, side: str = "sell"
+    ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
                 "ACTIVE", "Alpaca paper credentials are missing for stop execution"
@@ -260,7 +282,7 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             BrokerEntryOrder(
                 symbol=symbol,
                 qty=qty,
-                side="sell",
+                side=side,
                 order_type="stop",
                 stop_price=stop_price,
                 time_in_force="gtc",
@@ -294,7 +316,7 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         )
 
     def place_trailing_stop(
-        self, symbol: str, qty: int, trail: float, trail_unit: str
+        self, symbol: str, qty: int, trail: float, trail_unit: str, side: str = "sell"
     ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
@@ -303,7 +325,7 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         payload = {
             "symbol": symbol,
             "qty": qty,
-            "side": "sell",
+            "side": side,
             "type": "trailing_stop",
             "time_in_force": "gtc",
         }

--- a/backend/app/schemas/cockpit.py
+++ b/backend/app/schemas/cockpit.py
@@ -11,6 +11,7 @@ class StopMode(BaseModel):
     pct: float | None = None
 
 
+EntrySide = Literal["buy", "sell"]
 EntryOrderType = Literal["market", "limit", "stop", "stop_limit"]
 TimeInForce = Literal["day", "gtc", "ioc", "fok", "opg", "cls"]
 OrderClass = Literal["simple", "bracket", "oco", "oto"]
@@ -27,6 +28,7 @@ class StopLossDraft(BaseModel):
 
 
 class EntryOrderDraft(BaseModel):
+    side: EntrySide = "buy"
     orderType: EntryOrderType = "limit"
     timeInForce: TimeInForce = "day"
     orderClass: OrderClass = "simple"

--- a/backend/app/services/cockpit.py
+++ b/backend/app/services/cockpit.py
@@ -134,8 +134,8 @@ class CockpitService:
         order = self._normalize_entry_order(payload.order, payload.entry, payload.stopPrice)
         self._validate_entry_order(order, setup.sessionState)
         preview_entry = self._preview_entry_price(payload.entry, order)
-        self._validate_stop(preview_entry, payload.stopPrice)
-        per_share_risk = round(preview_entry - payload.stopPrice, 2)
+        self._validate_stop(preview_entry, payload.stopPrice, order.side)
+        per_share_risk = self._risk_per_share(preview_entry, payload.stopPrice, order.side)
         shares = self._calculate_shares(
             setup.accountEquity,
             setup.accountBuyingPower,
@@ -148,7 +148,7 @@ class CockpitService:
             db,
             payload.symbol.upper(),
             "info",
-            f"Preview: {payload.symbol.upper()} buy {shares} sh {order.orderType.upper()} {order.timeInForce.upper()} @ {preview_entry:.2f} stop {payload.stopPrice:.2f}",
+            f"Preview: {payload.symbol.upper()} {order.side.upper()} {shares} sh {order.orderType.upper()} {order.timeInForce.upper()} @ {preview_entry:.2f} stop {payload.stopPrice:.2f}",
         )
         db.commit()
         return TradePreviewResponse(
@@ -170,14 +170,15 @@ class CockpitService:
         order = self._normalize_entry_order(payload.order, payload.entry, payload.stopPrice)
         self._validate_entry_order(order, setup.sessionState)
         preview_entry = self._preview_entry_price(payload.entry, order)
-        self._validate_stop(preview_entry, payload.stopPrice)
+        self._validate_stop(preview_entry, payload.stopPrice, order.side)
         self._validate_tranche_modes(payload.trancheCount, payload.trancheModes)
+        per_share_risk = self._risk_per_share(preview_entry, payload.stopPrice, order.side)
         shares = self._calculate_shares(
             setup.accountEquity,
             setup.accountBuyingPower,
             preview_entry,
             setup.riskPct,
-            round(preview_entry - payload.stopPrice, 2),
+            per_share_risk,
         )
         if shares <= 0:
             raise ValueError(
@@ -214,7 +215,7 @@ class CockpitService:
             entry_message = "Extended-hours limit order submitted."
         else:
             entry_message = (
-                f"Trade entered: Buy {shares} sh {symbol} {order_for_broker.order_type.upper()} "
+                f"Trade entered: {order_for_broker.side.upper()} {shares} sh {symbol} {order_for_broker.order_type.upper()} "
                 f"{order_for_broker.time_in_force.upper()} @ {preview_entry:.2f}"
             )
         tranches = [
@@ -312,7 +313,10 @@ class CockpitService:
         )
         self._validate_stop_mode(payload.stopMode, payload.stopModes)
         self._reject_duplicate_active_stops(db, position.symbol)
-        stop_range = round(position.entry_price - position.stop_price, 2)
+        position_side = self._position_side(position)
+        exit_side = self._exit_side(position_side)
+        direction = 1 if position_side == "buy" else -1
+        stop_range = abs(round(position.entry_price - position.stop_price, 2))
         current_tranches = deepcopy(position.tranches)
         for index, group in enumerate(self._stop_groups(current_tranches, payload.stopMode)):
             config = payload.stopModes[index]
@@ -320,12 +324,12 @@ class CockpitService:
             price = (
                 position.entry_price
                 if config.mode == "be"
-                else round(position.entry_price - stop_range * pct / 100.0, 2)
+                else round(position.entry_price - direction * stop_range * pct / 100.0, 2)
             )
-            self._validate_stop(position.entry_price, price)
+            self._validate_stop(position.entry_price, price, position_side)
             qty = sum(item["qty"] for item in group)
             covered = [item["id"] for item in group]
-            broker = self.broker.place_stop_order(position.symbol, qty, price)
+            broker = self.broker.place_stop_order(position.symbol, qty, price, side=exit_side)
             db.add(
                 OrderEntity(
                     order_id=self._next_order_id(db),
@@ -372,7 +376,9 @@ class CockpitService:
         self._ensure_profit_actionable(position)
         self._validate_tranche_modes(position.tranche_count, payload.trancheModes)
         tranches = deepcopy(position.tranches)
-        per_share_risk = round(position.entry_price - position.stop_price, 2)
+        position_side = self._position_side(position)
+        exit_side = self._exit_side(position_side)
+        per_share_risk = abs(round(position.entry_price - position.stop_price, 2))
         phase = position.phase
         executed_count = 0
         self._cancel_broker_exit_orders(db, position.symbol, {"STOP"})
@@ -382,11 +388,13 @@ class CockpitService:
             mode = payload.trancheModes[index]
             if mode.mode == "runner":
                 self._reject_duplicate_active_order(db, position.symbol, tranche["id"], "TRAIL")
-                runner_stop = self._trail_stop(position.live_price, mode.trail, mode.trailUnit)
+                runner_stop = self._trail_stop(
+                    position.live_price, mode.trail, mode.trailUnit, position_side
+                )
                 tranche["mode"] = "runner"
                 tranche["runnerStop"] = runner_stop
                 broker = self.broker.place_trailing_stop(
-                    position.symbol, tranche["qty"], mode.trail, mode.trailUnit
+                    position.symbol, tranche["qty"], mode.trail, mode.trailUnit, side=exit_side
                 )
                 db.add(
                     OrderEntity(
@@ -407,8 +415,12 @@ class CockpitService:
                 phase = "runner_only"
             else:
                 self._reject_duplicate_active_order(db, position.symbol, tranche["id"], "LMT")
-                target = self._resolve_target_price(position.entry_price, per_share_risk, mode)
-                broker = self.broker.place_limit_order(position.symbol, tranche["qty"], target)
+                target = self._resolve_target_price(
+                    position.entry_price, per_share_risk, mode, position_side
+                )
+                broker = self.broker.place_limit_order(
+                    position.symbol, tranche["qty"], target, side=exit_side
+                )
                 db.add(
                     OrderEntity(
                         order_id=self._next_order_id(db),
@@ -596,11 +608,16 @@ class CockpitService:
                 .where(OrderEntity.symbol == symbol.upper())
                 .order_by(OrderEntity.created_at.asc())
             ).all()
-        return [self._order_view(row) for row in rows]
+        position_side = self._position_side(position)
+        return [self._order_view(row, position_side=position_side) for row in rows]
 
     def get_recent_orders(self, db: Session, limit: int = 50) -> list[OrderView]:
         broker_orders_by_symbol = self._recent_broker_orders_by_symbol(limit=max(limit, 100))
         self._reconcile_all_positions(db, broker_orders_by_symbol)
+        position_side_by_symbol = {
+            position.symbol.upper(): self._position_side(position)
+            for position in db.scalars(select(PositionEntity)).all()
+        }
         try:
             broker_payloads = self.broker.list_recent_orders(limit=limit)
         except ValueError:
@@ -619,7 +636,13 @@ class CockpitService:
             broker_payload = broker_orders.get(row.broker_order_id or "")
             if broker_payload is not None:
                 seen_broker_ids.add(str(broker_payload.get("id")))
-            merged.append(self._order_view(row, broker_payload))
+            merged.append(
+                self._order_view(
+                    row,
+                    broker_payload,
+                    position_side=position_side_by_symbol.get(row.symbol.upper(), "buy"),
+                )
+            )
         for broker_order_id, broker_payload in broker_orders.items():
             if broker_order_id in seen_broker_ids:
                 continue
@@ -658,8 +681,13 @@ class CockpitService:
             )
         db.commit()
         local = local_orders[0] if local_orders else None
+        local_position = (
+            db.scalar(select(PositionEntity).where(PositionEntity.symbol == local.symbol))
+            if local is not None
+            else None
+        )
         return (
-            self._order_view(local, refreshed)
+            self._order_view(local, refreshed, position_side=self._position_side(local_position))
             if local is not None
             else self._broker_order_view(refreshed)
         )
@@ -807,7 +835,11 @@ class CockpitService:
             return None
         if position.phase == "entry_pending":
             return None
-        if position.live_price > order.price:
+        position_side = self._position_side(position)
+        if position_side == "sell":
+            if position.live_price < order.price:
+                return None
+        elif position.live_price > order.price:
             return None
         return {
             "status": "FILLED",
@@ -885,6 +917,27 @@ class CockpitService:
         if sold_count >= 1:
             return "P1_done"
         return "protected"
+
+    def _position_side(self, position: PositionEntity | PositionView | dict | None) -> str:
+        if position is None:
+            return "buy"
+        if isinstance(position, dict):
+            setup_snapshot = position.get("setup") or position.get("setup_snapshot") or {}
+        else:
+            setup_snapshot = getattr(position, "setup_snapshot", None) or getattr(
+                position, "setup", {}
+            )
+        if isinstance(setup_snapshot, dict):
+            entry_order = setup_snapshot.get("entryOrder")
+            if isinstance(entry_order, dict) and entry_order.get("side") == "sell":
+                return "sell"
+        return "buy"
+
+    def _exit_side(self, side: str) -> str:
+        return "buy" if side == "sell" else "sell"
+
+    def _risk_per_share(self, entry: float, stop_price: float, side: str) -> float:
+        return round((stop_price - entry) if side == "sell" else (entry - stop_price), 2)
 
     def _build_setup_response(
         self,
@@ -1071,18 +1124,22 @@ class CockpitService:
         return float(100 - base * index) if index == stop_mode - 1 else float(base)
 
     def _resolve_target_price(
-        self, entry: float, per_share_risk: float, mode: TrancheMode
+        self, entry: float, per_share_risk: float, mode: TrancheMode, side: str = "buy"
     ) -> float:
         if mode.target == "Manual" and mode.manualPrice is not None:
             return round(mode.manualPrice, 2)
         multiplier = {"1R": 1, "2R": 2, "3R": 3}[mode.target]
-        return round(entry + per_share_risk * multiplier, 2)
+        direction = -1 if side == "sell" else 1
+        return round(entry + direction * per_share_risk * multiplier, 2)
 
-    def _trail_stop(self, live_price: float, trail: float, trail_unit: str) -> float:
+    def _trail_stop(
+        self, live_price: float, trail: float, trail_unit: str, side: str = "buy"
+    ) -> float:
+        direction = -1 if side == "sell" else 1
         return (
-            round(live_price - trail, 2)
+            round(live_price - direction * trail, 2)
             if trail_unit == "$"
-            else round(live_price * (1 - trail / 100), 2)
+            else round(live_price * (1 - direction * trail / 100), 2)
         )
 
     def _reduce_stop_orders(self, db: Session, symbol: str, tranche_id: str, qty_sold: int) -> None:
@@ -1119,6 +1176,8 @@ class CockpitService:
         self, order: EntryOrderDraft, entry: float, protective_stop: float
     ) -> EntryOrderDraft:
         normalized = order.model_copy(deep=True)
+        direction = -1 if normalized.side == "sell" else 1
+        protective_risk = max(abs(entry - protective_stop), 0.01)
         if normalized.orderType in {"limit", "stop_limit"} and normalized.limitPrice is None:
             normalized.limitPrice = round(entry, 2)
         if normalized.orderType == "stop" and normalized.stopPrice is None:
@@ -1127,7 +1186,7 @@ class CockpitService:
             normalized.stopPrice = round(entry, 2)
         if normalized.orderClass in {"bracket", "oco"}:
             normalized.takeProfit = normalized.takeProfit or TakeProfitDraft(
-                limitPrice=round(entry + max(entry - protective_stop, 0.01), 2)
+                limitPrice=round(entry + direction * protective_risk, 2)
             )
             normalized.stopLoss = normalized.stopLoss or StopLossDraft(
                 stopPrice=protective_stop, limitPrice=None
@@ -1135,7 +1194,7 @@ class CockpitService:
         if normalized.orderClass == "oto":
             if normalized.otoExitSide == "take_profit":
                 normalized.takeProfit = normalized.takeProfit or TakeProfitDraft(
-                    limitPrice=round(entry + max(entry - protective_stop, 0.01), 2)
+                    limitPrice=round(entry + direction * protective_risk, 2)
                 )
                 normalized.stopLoss = None
             else:
@@ -1233,7 +1292,7 @@ class CockpitService:
         return BrokerEntryOrder(
             symbol=symbol,
             qty=shares,
-            side="buy",
+            side=order.side,
             order_type=order_type,
             time_in_force=tif,
             limit_price=limit_price,
@@ -1268,11 +1327,15 @@ class CockpitService:
             "stop_limit": "STPLMT",
         }[order.orderType]
 
-    def _validate_stop(self, entry: float, stop_price: float) -> None:
-        if stop_price >= entry:
-            raise ValueError("Stop price must be below entry")
-        if stop_price <= entry * 0.5:
-            raise ValueError("Stop price too far below entry")
+    def _validate_stop(self, entry: float, stop_price: float, side: str = "buy") -> None:
+        if side == "sell":
+            if stop_price <= entry:
+                raise ValueError("Stop price must be above entry for short positions")
+        else:
+            if stop_price >= entry:
+                raise ValueError("Stop price must be below entry")
+        if abs(stop_price - entry) >= entry * 0.5:
+            raise ValueError("Stop price is too far from entry")
 
     def _validate_stop_mode(self, stop_mode: int, stop_modes: list[StopMode]) -> None:
         if stop_mode not in {1, 2, 3}:
@@ -1497,7 +1560,12 @@ class CockpitService:
         next_seq = max(persisted_max, pending_max) + 1
         return f"ORD-{next_seq:04d}"
 
-    def _order_view(self, row: OrderEntity, broker_payload: dict | None = None) -> OrderView:
+    def _order_view(
+        self,
+        row: OrderEntity,
+        broker_payload: dict | None = None,
+        position_side: str = "buy",
+    ) -> OrderView:
         filled_qty = (
             self._broker_filled_qty(broker_payload)
             if broker_payload
@@ -1506,7 +1574,7 @@ class CockpitService:
         remaining_qty = self._broker_remaining_qty(
             broker_payload, row.qty, row.orig_qty, filled_qty
         )
-        side = self._broker_side(broker_payload) or self._local_order_side(row)
+        side = self._broker_side(broker_payload) or self._local_order_side(row, position_side)
         status = (
             str(broker_payload.get("status", row.status)).upper() if broker_payload else row.status
         )
@@ -1600,10 +1668,12 @@ class CockpitService:
 
     def _pnl(self, position: PositionView) -> float:
         entry = float(position.setup.get("entry", 0.0))
+        side = self._position_side(position)
+        direction = -1 if side == "sell" else 1
         active_shares = sum(
             tranche.qty for tranche in position.tranches if tranche.status == "active"
         )
-        return round((position.livePrice - entry) * active_shares, 2)
+        return round((position.livePrice - entry) * direction * active_shares, 2)
 
     def _broker_timestamp(self, payload: dict | None, key: str) -> datetime | None:
         if not payload:
@@ -1673,10 +1743,10 @@ class CockpitService:
         side = payload.get("side")
         return str(side).upper() if side else None
 
-    def _local_order_side(self, row: OrderEntity) -> str:
+    def _local_order_side(self, row: OrderEntity, position_side: str = "buy") -> str:
         if row.parent_id is None:
-            return "BUY"
-        return "SELL"
+            return position_side.upper()
+        return self._exit_side(position_side).upper()
 
     def _broker_order_cancelable(self, payload: dict | None) -> bool:
         if not payload:

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -97,6 +97,23 @@ def tranche_modes() -> list[dict]:
     ]
 
 
+def simple_entry_order(side: str = "buy", **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "side": side,
+        "orderType": "limit",
+        "timeInForce": "day",
+        "orderClass": "simple",
+        "extendedHours": False,
+        "limitPrice": None,
+        "stopPrice": None,
+        "otoExitSide": "stop_loss",
+        "takeProfit": None,
+        "stopLoss": None,
+    }
+    payload.update(overrides)
+    return payload
+
+
 def test_setup_endpoint_returns_contract() -> None:
     response = client.get("/api/setup/AAPL")
     assert response.status_code == 200
@@ -517,6 +534,107 @@ def test_trade_lifecycle() -> None:
         or order.get("parentId") == profit_state["rootOrderId"]
         for order in profit_state["orders"]
     )
+
+
+def test_preview_trade_supports_sell_side_and_rejects_invalid_short_stop() -> None:
+    client.put(
+        "/api/account/settings",
+        json={"equity": 1000000, "risk_pct": 0.2, "mode": "paper"},
+    )
+    setup = client.get("/api/setup/AAPL").json()
+    short_stop = round(max(setup["hod"], setup["entry"] + 1), 2)
+
+    preview = client.post(
+        "/api/trade/preview",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "manual",
+            "stopPrice": short_stop,
+            "riskPct": 0.2,
+            "order": simple_entry_order("sell", timeInForce="gtc", limitPrice=setup["entry"]),
+        },
+    )
+    assert preview.status_code == 200
+    payload = preview.json()
+    assert payload["perShareRisk"] == round(short_stop - setup["entry"], 2)
+    assert payload["shares"] > 0
+
+    invalid = client.post(
+        "/api/trade/preview",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "manual",
+            "stopPrice": round(setup["entry"] - 1, 2),
+            "riskPct": 0.2,
+            "order": simple_entry_order("sell", limitPrice=setup["entry"]),
+        },
+    )
+    assert invalid.status_code == 400
+    assert "above entry for short positions" in invalid.text
+
+
+def test_short_trade_uses_buy_to_cover_for_stops_and_profit_orders() -> None:
+    client.put(
+        "/api/account/settings",
+        json={"equity": 1000000, "risk_pct": 0.2, "mode": "paper"},
+    )
+    setup = client.get("/api/setup/AAPL").json()
+    short_stop = round(max(setup["hod"], setup["entry"] + 1), 2)
+
+    enter = client.post(
+        "/api/trade/enter",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "manual",
+            "stopPrice": short_stop,
+            "trancheCount": 3,
+            "trancheModes": tranche_modes(),
+            "order": simple_entry_order("sell", limitPrice=setup["entry"]),
+        },
+    )
+    assert enter.status_code == 200
+    position = enter.json()
+    assert position["phase"] == "trade_entered"
+    root_order = next(
+        order for order in position["orders"] if order["id"] == position["rootOrderId"]
+    )
+    assert root_order["side"] == "SELL"
+
+    stops = client.post(
+        "/api/trade/stops",
+        json={
+            "symbol": "AAPL",
+            "stopMode": 3,
+            "stopModes": [
+                {"mode": "stop", "pct": 33.0},
+                {"mode": "stop", "pct": 66.0},
+                {"mode": "stop", "pct": 100.0},
+            ],
+        },
+    )
+    assert stops.status_code == 200
+    protected = stops.json()
+    stop_orders = [order for order in protected["orders"] if order["type"] == "STOP"]
+    assert len(stop_orders) == 3
+    assert all(order["side"] == "BUY" for order in stop_orders)
+    assert all(order["price"] > protected["setup"]["entry"] for order in stop_orders)
+
+    profit = client.post(
+        "/api/trade/profit",
+        json={"symbol": "AAPL", "trancheModes": tranche_modes()},
+    )
+    assert profit.status_code == 200
+    profit_state = profit.json()
+    filled_limits = [
+        order
+        for order in profit_state["orders"]
+        if order["type"] == "LMT" and order.get("parentId") == profit_state["rootOrderId"]
+    ]
+    assert filled_limits
+    assert all(order["side"] == "BUY" for order in filled_limits)
 
 
 def test_three_stop_mode_defaults_to_33_33_34_when_pct_is_blank() -> None:

--- a/docs/issues/2026-03-23-order-engine-correctness-matrix.md
+++ b/docs/issues/2026-03-23-order-engine-correctness-matrix.md
@@ -1,0 +1,81 @@
+# Order Engine Correctness Matrix
+
+> Status: Open
+> Branch: `codex/feature-order-engine-matrix`
+> Opened: 2026-03-23
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The current order-entry and protection flow still has correctness gaps that block a real production claim:
+
+- order intent is still effectively long-only in parts of the backend path
+- `Type`, `TIF`, and `Class` do not map cleanly to the existing `3010` cockpit flow in every combination
+- `SIMPLE` and class-driven attached exits can still leak state into each other
+- the entry strip semantics and the stop/profit draft semantics are not decision-complete across the supported broker/session modes
+
+## Business value
+
+The production release can only be credible if entry behavior is deterministic and explainable across the supported matrix:
+
+- `broker`
+- `side`
+- `type`
+- `TIF`
+- `class`
+- `session`
+
+This tranche is meant to harden the order engine so the existing cockpit UI maps to correct behavior instead of relying on partial defaults and ad hoc resets.
+
+## Scope
+
+- audit the current order-entry path in backend and frontend
+- define and implement the supported order matrix for the existing cockpit UI
+- fix long/short, type/TIF/class, and stop/profit draft interactions
+- add backend and browser coverage for the supported matrix
+
+## Acceptance criteria
+
+- [x] `BUY` and `SELL` both map correctly end to end
+- [ ] `MARKET`, `LIMIT`, `STOP`, and `STOP_LIMIT` do not silently rewrite to another type
+- [ ] `SIMPLE` retains normal multi-leg stop/profit drafts until fill
+- [ ] `BRACKET`, `OTO`, and compatibility `OCO` constrain the stop/profit panels correctly without leaking back into `SIMPLE`
+- [ ] supported `type x TIF x class x broker x session` combinations are tested and blocked with explicit reasons when invalid
+
+## Risks / constraints
+
+- this tranche touches both backend lifecycle logic and visible cockpit behavior
+- visible UI changes require browser QC and refreshed cockpit baselines
+- the existing `3010` layout should stay intact while the underlying mapping is corrected
+
+## Progress
+
+- added explicit `side` to the shared order draft and backend schema
+- made backend entry, stop, profit, trailing-stop, cancel, and P&L paths side-aware for long and short flows
+- added `BUY / SELL` to the existing `3010` entry strip without changing the overall cockpit layout
+- corrected frontend stop/target/runner math, open-position unrealized P&L, and active-stop display to respect side
+- added backend coverage for sell-side preview validation and short exit-order routing
+- hardened `scripts/dev/run-qc.ps1` so browser smoke uses the correct backend/prod ports and fails on native command errors
+
+## Validation
+
+- `python -m ruff check backend\app`
+- `python -m black --check backend\app backend\alembic\versions`
+- `python -m pytest -q backend\app\tests\test_api.py`
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test`
+- `npm run build`
+- `powershell -ExecutionPolicy Bypass -File scripts\dev\run-qc.ps1 -StartStack -FrontendPort 3078 -FrontendProdPort 3178 -BackendPort 8078 -PostgresPort 55478 -RedisPort 56388`
+
+## Browser evidence
+
+- `frontend/output/playwright/dev-smoke-initial.png`
+- `frontend/output/playwright/prod-smoke.png`
+- `frontend/output/playwright/dev-smoke-final.png`
+- `frontend/output/playwright/baseline-idle.png`
+- `frontend/output/playwright/baseline-setup-loaded.png`
+- `frontend/output/playwright/baseline-trade-entered.png`
+- `frontend/output/playwright/baseline-protected.png`
+- `frontend/output/playwright/baseline-profit-flow.png`

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -955,6 +955,38 @@ select {
   gap: 4px;
 }
 
+.entry-side-toggle {
+  display: inline-flex;
+  min-height: 30px;
+  border: 1px solid var(--border2);
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--bg3);
+}
+
+.entry-side-btn {
+  min-width: 54px;
+  padding: 0 10px;
+  border: 0;
+  border-right: 1px solid var(--border2);
+  background: transparent;
+  color: var(--text2);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.entry-side-btn:last-child {
+  border-right: 0;
+}
+
+.entry-side-btn.active {
+  background: rgba(0, 199, 255, 0.12);
+  color: var(--cyan);
+}
+
 .entry-order-copy {
   font-family: "IBM Plex Mono", monospace;
   font-size: 10px;

--- a/frontend/components/Cockpit.tsx
+++ b/frontend/components/Cockpit.tsx
@@ -13,8 +13,8 @@ import { RunningPnlPanel } from "@/components/RunningPnlPanel";
 import { SetupPanel } from "@/components/SetupPanel";
 import { StopProtectionPanel } from "@/components/StopProtectionPanel";
 import { ApiError, api } from "@/lib/api";
-import { defaultAllocationPcts, defaultStopPcts, normalizeAllocationPcts, normalizeStopPcts } from "@/lib/cockpit-ui";
-import type { AccountView, AuthUser, EntryOrderDraft, LogEntry, OffHoursMode, OrderView, PositionView, SetupResponse, StopMode, TrancheMode } from "@/lib/types";
+import { defaultAllocationPcts, defaultStopPcts, entryDirection, normalizeAllocationPcts, normalizeStopPcts } from "@/lib/cockpit-ui";
+import type { AccountView, AuthUser, EntryOrderDraft, EntrySide, LogEntry, OffHoursMode, OrderView, PositionView, SetupResponse, StopMode, TrancheMode } from "@/lib/types";
 
 const DEFAULT_STOP_MODES: StopMode[] = [
   { mode: "stop", pct: 33.33 },
@@ -29,6 +29,7 @@ const DEFAULT_TRANCHE_MODES: TrancheMode[] = [
 ];
 
 const DEFAULT_ENTRY_ORDER: EntryOrderDraft = {
+  side: "buy",
   orderType: "limit",
   timeInForce: "day",
   orderClass: "simple",
@@ -106,10 +107,23 @@ function sanitizeLayoutState(layout: LayoutState): LayoutState {
   };
 }
 
-function effectiveStopPrice(setup: SetupResponse | null, stopRef: "lod" | "atr" | "manual", manualStop: number | null) {
+function effectiveStopPrice(
+  setup: SetupResponse | null,
+  stopRef: "lod" | "atr" | "manual",
+  manualStop: number | null,
+  side: EntrySide,
+  entryPrice: number,
+) {
   if (!setup) return 0;
   if (stopRef === "manual") return manualStop ?? 0;
-  return stopRef === "atr" ? setup.atrStop : setup.lodStop;
+  if (stopRef === "atr") {
+    const atrOffset = Number.isFinite(setup.atr14) ? setup.atr14 : 0;
+    const baseEntry = entryPrice > 0 ? entryPrice : setup.entry;
+    return side === "sell"
+      ? Number((baseEntry + atrOffset).toFixed(2))
+      : Number((baseEntry - atrOffset).toFixed(2));
+  }
+  return side === "sell" ? setup.hod : setup.lodStop;
 }
 
 function deriveSetupForSelection(
@@ -117,15 +131,20 @@ function deriveSetupForSelection(
   account: AccountView | null,
   stopRef: "lod" | "atr" | "manual",
   manualStop: number | null,
-  entryPrice: number
+  entryPrice: number,
+  side: EntrySide,
 ) {
   if (!setup) return null;
   const equity = account?.equity ?? setup.accountEquity;
   const buyingPower = account?.buying_power ?? setup.accountBuyingPower;
   const riskPct = account?.risk_pct ?? setup.riskPct;
-  const stopPrice = stopRef === "manual" ? manualStop : stopRef === "atr" ? setup.atrStop : setup.lodStop;
-  const validStop = typeof stopPrice === "number" && Number.isFinite(stopPrice) && stopPrice > 0 && stopPrice < entryPrice;
-  const perShareRisk = validStop ? Number((entryPrice - stopPrice).toFixed(2)) : 0;
+  const stopPrice = effectiveStopPrice(setup, stopRef, manualStop, side, entryPrice);
+  const direction = entryDirection(side);
+  const validStop = typeof stopPrice === "number"
+    && Number.isFinite(stopPrice)
+    && stopPrice > 0
+    && direction * (entryPrice - stopPrice) > 0;
+  const perShareRisk = validStop ? Number(Math.abs(entryPrice - stopPrice).toFixed(2)) : 0;
   const dollarRisk = Number((equity * (riskPct / 100)).toFixed(2));
   const maxNotionalCap = equity * ((account?.max_position_notional_pct ?? 100) / 100);
   const effectiveNotionalCap = Math.min(buyingPower, maxNotionalCap);
@@ -144,9 +163,14 @@ function deriveSetupForSelection(
     riskPct,
     accountEquity: equity,
     accountBuyingPower: buyingPower,
-    r1: perShareRisk > 0 ? Number((entryPrice + perShareRisk).toFixed(2)) : entryPrice,
-    r2: perShareRisk > 0 ? Number((entryPrice + perShareRisk * 2).toFixed(2)) : entryPrice,
-    r3: perShareRisk > 0 ? Number((entryPrice + perShareRisk * 3).toFixed(2)) : entryPrice
+    entryOrder: {
+      ...DEFAULT_ENTRY_ORDER,
+      ...(setup.entryOrder ?? {}),
+      side,
+    },
+    r1: perShareRisk > 0 ? Number((entryPrice + direction * perShareRisk).toFixed(2)) : entryPrice,
+    r2: perShareRisk > 0 ? Number((entryPrice + direction * perShareRisk * 2).toFixed(2)) : entryPrice,
+    r3: perShareRisk > 0 ? Number((entryPrice + direction * perShareRisk * 3).toFixed(2)) : entryPrice
   };
 }
 
@@ -171,9 +195,13 @@ function buildEntryOrderDraft(
   entryPrice: number,
   protectiveStop: number,
   trancheModes: TrancheMode[],
+  side: EntrySide,
 ): EntryOrderDraft {
+  const direction = entryDirection(side);
+  const perShareRisk = Number(Math.abs(entryPrice - protectiveStop).toFixed(2));
   const next = {
     ...current,
+    side,
     limitPrice: current.orderType === "limit" || current.orderType === "stop_limit" ? (current.limitPrice ?? entryPrice) : null,
     stopPrice: current.orderType === "stop" || current.orderType === "stop_limit" ? (current.stopPrice ?? entryPrice) : null,
   };
@@ -181,7 +209,11 @@ function buildEntryOrderDraft(
   const takeProfitLimit = primaryProfitMode
     ? primaryProfitMode.target === "Manual" && primaryProfitMode.manualPrice !== null
       ? primaryProfitMode.manualPrice
-      : null
+      : primaryProfitMode.target === "Manual"
+        ? null
+      : primaryProfitMode.mode === "runner"
+        ? null
+        : Number((entryPrice + direction * perShareRisk * { "1R": 1, "2R": 2, "3R": 3 }[primaryProfitMode.target]).toFixed(2))
     : null;
   if (next.orderClass === "bracket") {
     next.takeProfit = { limitPrice: takeProfitLimit };
@@ -253,19 +285,25 @@ export function Cockpit() {
     () => positions.find((position) => position.symbol === activeSymbol) ?? null,
     [positions, activeSymbol]
   );
+  const draftEntrySide = entryOrder.side;
   const effectiveSetup = useMemo(
-    () => deriveSetupForSelection(setup, account, stopRef, manualStop, entryPrice || setup?.entry || 0),
-    [account, entryPrice, manualStop, setup, stopRef]
+    () => deriveSetupForSelection(setup, account, stopRef, manualStop, entryPrice || setup?.entry || 0, draftEntrySide),
+    [account, draftEntrySide, entryPrice, manualStop, setup, stopRef]
+  );
+  const protectiveStopPrice = useMemo(
+    () => effectiveStopPrice(setup, stopRef, manualStop, draftEntrySide, entryPrice || setup?.entry || 0),
+    [draftEntrySide, entryPrice, manualStop, setup, stopRef]
   );
   const effectiveEntryOrder = useMemo(
     () =>
       buildEntryOrderDraft(
         entryOrder,
         entryPrice || effectiveSetup?.entry || 0,
-        effectiveStopPrice(setup, stopRef, manualStop),
+        protectiveStopPrice,
         trancheModes,
+        draftEntrySide,
       ),
-    [entryOrder, entryPrice, manualStop, setup, stopRef, effectiveSetup, trancheModes]
+    [draftEntrySide, effectiveSetup, entryOrder, entryPrice, protectiveStopPrice, trancheModes]
   );
   const attachedSummary = useMemo(
     () => ({
@@ -290,6 +328,7 @@ export function Cockpit() {
     : actionTickerMismatch
       ? `Wait for ${normalizedTicker} to finish loading before previewing or entering a trade.`
       : orderConfigDisabledReason ?? effectiveSetup?.sizingWarning ?? null;
+  const activeEntrySide = activePosition?.setup?.entryOrder?.side === "sell" ? "sell" : effectiveEntryOrder.side;
   const leftColumnCollapsed = panelCollapse.stopProtection && panelCollapse.profitTaking;
   const rightColumnCollapsed = panelCollapse.recentOrders && panelCollapse.runningPnl;
   const effectiveExecutionLeftPct = leftColumnCollapsed && !rightColumnCollapsed
@@ -419,6 +458,7 @@ export function Cockpit() {
       setManualStop(position.setup.stopReferenceDefault === "manual" ? null : position.setup.finalStop);
       setEntryOrder({
         ...DEFAULT_ENTRY_ORDER,
+        side: position.setup.entryOrder?.side === "sell" ? "sell" : "buy",
         limitPrice: position.setup.entry,
       });
       setOffHoursMode("queue_for_open");
@@ -680,6 +720,7 @@ export function Cockpit() {
     setManualStop(nextSetup.stopReferenceDefault === "manual" ? null : nextSetup.finalStop);
     setEntryOrder({
       ...DEFAULT_ENTRY_ORDER,
+      side: "buy",
       limitPrice: nextSetup.entry,
     });
     setActiveSymbol("");
@@ -738,6 +779,7 @@ export function Cockpit() {
         setManualStop(nextSetup.stopReferenceDefault === "manual" ? null : nextSetup.finalStop);
         setEntryOrder({
           ...DEFAULT_ENTRY_ORDER,
+          side: "buy",
           limitPrice: nextSetup.entry,
         });
         setStopModes(defaultStopModesFor(stopMode));
@@ -771,13 +813,13 @@ export function Cockpit() {
         symbol: activeLoadedTicker || ticker,
         entry: entryPrice,
         stopRef,
-        stopPrice: effectiveStopPrice(setup, stopRef, manualStop),
+        stopPrice: protectiveStopPrice,
         riskPct: account?.risk_pct ?? setup.riskPct,
         order: effectiveEntryOrder,
       });
       prependLog(
         "info",
-        `Preview: ${preview.symbol} buy ${preview.shares} sh @ ${preview.entry.toFixed(2)} stop ${preview.finalStop.toFixed(2)}`,
+        `Preview: ${preview.symbol} ${effectiveEntryOrder.side.toUpperCase()} ${preview.shares} sh @ ${preview.entry.toFixed(2)} stop ${preview.finalStop.toFixed(2)}`,
         preview.symbol
       );
       pulse("preview");
@@ -808,7 +850,7 @@ export function Cockpit() {
         symbol: activeLoadedTicker || ticker,
         entry: entryPrice,
         stopRef,
-        stopPrice: effectiveStopPrice(setup, stopRef, manualStop),
+        stopPrice: protectiveStopPrice,
         trancheCount,
         trancheModes: trancheModes.slice(0, trancheCount),
         offHoursMode: setup.sessionState === "regular_open" ? null : mode,
@@ -1095,6 +1137,7 @@ export function Cockpit() {
             entryPrice={entryPrice || effectiveSetup?.entry || 0}
             stopRef={stopRef}
             manualStop={manualStop}
+            displayStopPrice={protectiveStopPrice || null}
             order={effectiveEntryOrder}
             attachedSummary={attachedSummary}
             actionsDisabled={actionsDisabled}
@@ -1114,6 +1157,7 @@ export function Cockpit() {
               <StopProtectionPanel
                 setup={effectiveSetup}
                 phase={activePosition?.phase ?? null}
+                entrySide={activeEntrySide}
                 stopMode={stopMode}
                 stopModes={stopModes}
                 tranches={activePosition?.tranches ?? []}
@@ -1160,6 +1204,7 @@ export function Cockpit() {
               <ProfitTakingPanel
                 setup={effectiveSetup}
                 activePosition={activePosition}
+                entrySide={activeEntrySide}
                 trancheCount={trancheCount}
                 trancheModes={trancheModes}
                 executeFlashing={Boolean(flashState.profit)}

--- a/frontend/components/EntryPanel.tsx
+++ b/frontend/components/EntryPanel.tsx
@@ -1,5 +1,5 @@
 import { fp } from "@/lib/cockpit-ui";
-import type { EntryOrderDraft, EntryOrderType, OtoExitSide, OrderClass, SetupResponse, TimeInForce } from "@/lib/types";
+import type { EntryOrderDraft, EntryOrderType, EntrySide, OtoExitSide, OrderClass, SetupResponse, TimeInForce } from "@/lib/types";
 
 const ORDER_TYPE_OPTIONS: Array<{ value: EntryOrderType; label: string }> = [
   { value: "limit", label: "LIMIT" },
@@ -29,6 +29,11 @@ function tifAllowed(orderType: EntryOrderType, tif: TimeInForce) {
   return tif === "day" || tif === "gtc";
 }
 
+const SIDE_OPTIONS: Array<{ value: EntrySide; label: string }> = [
+  { value: "buy", label: "BUY" },
+  { value: "sell", label: "SELL" },
+];
+
 type Props = {
   ticker: string;
   setupLoadPending: boolean;
@@ -42,6 +47,7 @@ type Props = {
   entryPrice: number;
   stopRef: "lod" | "atr" | "manual";
   manualStop: number | null;
+  displayStopPrice: number | null;
   order: EntryOrderDraft;
   attachedSummary: { takeProfit: number | null; stopLoss: number | null };
   actionsDisabled?: boolean;
@@ -70,6 +76,7 @@ export function EntryPanel(props: Props) {
     entryPrice,
     stopRef,
     manualStop,
+    displayStopPrice,
     order,
     attachedSummary,
     actionsDisabled = false,
@@ -84,22 +91,30 @@ export function EntryPanel(props: Props) {
     onEnterTrade,
   } = props;
 
-  const stopPrice = stopRef === "manual" ? manualStop : stopRef === "atr" ? setup?.atrStop ?? null : setup?.lodStop ?? null;
+  const stopPrice = displayStopPrice;
   const cycleStopRef = () => {
     if (!setup) return;
+    const lodLikeValid = order.side === "sell" ? setup.hod > entryPrice : setup.lodStop < entryPrice;
+    const atrLikePrice = order.side === "sell"
+      ? Number((entryPrice + setup.atr14).toFixed(2))
+      : Number((entryPrice - setup.atr14).toFixed(2));
+    const atrLikeValid = atrLikePrice > 0 && (order.side === "sell" ? atrLikePrice > entryPrice : atrLikePrice < entryPrice);
     const availableRefs: Array<"lod" | "atr" | "manual"> = [
-      ...(setup.lodIsValid ? ["lod" as const] : []),
-      ...(setup.atrIsValid ? ["atr" as const] : []),
+      ...(lodLikeValid ? ["lod" as const] : []),
+      ...(atrLikeValid ? ["atr" as const] : []),
       "manual",
     ];
     const currentIndex = availableRefs.indexOf(stopRef);
     const nextRef = availableRefs[(currentIndex + 1 + availableRefs.length) % availableRefs.length] ?? "manual";
     onStopRefChange(nextRef);
   };
-  const stopRefLabel = stopRef === "lod" ? "LoD" : stopRef === "atr" ? "ATR" : "Manual";
+  const stopRefLabel = stopRef === "lod" ? (order.side === "sell" ? "HoD" : "LoD") : stopRef === "atr" ? "ATR" : "Manual";
   const showLimitInput = order.orderType === "limit" || order.orderType === "stop_limit";
   const showTriggerInput = order.orderType === "stop" || order.orderType === "stop_limit";
   const showAttachedSummary = order.orderClass !== "simple";
+  const entryFieldLabel = "Indicative";
+  const limitFieldLabel = "Order Price";
+  const triggerFieldLabel = "Trigger";
 
   return (
     <div className="panel entry-panel">
@@ -150,7 +165,22 @@ export function EntryPanel(props: Props) {
             </div>
             {setupLoadPending ? <div className="ticker-loading">SYNCING</div> : null}
             <div className="entry-order-field">
-              <span className="entry-order-label">Entry</span>
+              <span className="entry-order-label">Side</span>
+              <div className="entry-side-toggle" role="group" aria-label="Entry side">
+                {SIDE_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={`entry-side-btn ${order.side === option.value ? "active" : ""}`}
+                    onClick={() => onOrderChange({ ...order, side: option.value })}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="entry-order-field">
+              <span className="entry-order-label">{entryFieldLabel}</span>
               <input
                 id="heroEntry"
                 type="number"
@@ -163,9 +193,9 @@ export function EntryPanel(props: Props) {
                 Active stop:{" "}
                 {setup
                   ? stopRef === "lod"
-                    ? `LoD ${fp(setup.lodStop)}`
+                    ? `${order.side === "sell" ? "HoD" : "LoD"} ${fp(order.side === "sell" ? setup.hod : setup.lodStop)}`
                     : stopRef === "atr"
-                      ? `ATR ${fp(setup.atrStop)}`
+                      ? `ATR ${fp(stopPrice)}`
                       : manualStop !== null
                         ? `Manual ${fp(manualStop)}`
                         : "Manual required"
@@ -216,7 +246,7 @@ export function EntryPanel(props: Props) {
             </div>
             {showLimitInput ? (
               <div className="entry-order-field">
-                <span className="entry-order-label">Limit</span>
+                <span className="entry-order-label">{limitFieldLabel}</span>
                 <input
                   type="number"
                   inputMode="decimal"
@@ -233,7 +263,7 @@ export function EntryPanel(props: Props) {
             ) : null}
             {showTriggerInput ? (
               <div className="entry-order-field">
-                <span className="entry-order-label">Trigger</span>
+                <span className="entry-order-label">{triggerFieldLabel}</span>
                 <input
                   type="number"
                   inputMode="decimal"
@@ -260,7 +290,7 @@ export function EntryPanel(props: Props) {
           ) : (
             <>
               <div className="entry-row entry-row-labels">
-                <div className="entry-caption">Shares to Buy</div>
+                <div className="entry-caption">Shares</div>
                 <div className="entry-caption">Protective Stop</div>
                 <div className="entry-caption">Attached Exits</div>
               </div>

--- a/frontend/components/OpenPositionsList.tsx
+++ b/frontend/components/OpenPositionsList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PositionView } from "@/lib/types";
-import { activeShares, isActivePhase, signedMoney } from "@/lib/cockpit-ui";
+import { activeShares, entryDirection, entrySideFromSetup, isActivePhase, signedMoney } from "@/lib/cockpit-ui";
 
 type Props = {
   positions: PositionView[];
@@ -36,7 +36,7 @@ export function OpenPositionsList({ positions, activeSymbol, onSelect }: Props) 
             {openPositions.map((position) => {
               const live = position.livePrice || position.setup.entry;
               const activeQty = activeShares(position);
-              const pnl = (live - position.setup.entry) * activeQty;
+              const pnl = (live - position.setup.entry) * entryDirection(entrySideFromSetup(position.setup)) * activeQty;
               const stopEnabled = position.stopMode > 0;
               const isProfitEnabled = profitEnabled(position, activeSymbol);
               const isSelected = position.symbol === activeSymbol;

--- a/frontend/components/ProfitTakingPanel.tsx
+++ b/frontend/components/ProfitTakingPanel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { fp, splitShares, targetPrice, trailingStop } from "@/lib/cockpit-ui";
-import type { PositionView, SetupResponse, TrancheMode } from "@/lib/types";
+import type { EntrySide, PositionView, SetupResponse, TrancheMode } from "@/lib/types";
 
 type Props = {
   setup: SetupResponse | null;
   activePosition: PositionView | null;
+  entrySide: EntrySide;
   trancheCount: number;
   trancheModes: TrancheMode[];
   executeFlashing?: boolean;
@@ -20,6 +21,7 @@ export function ProfitTakingPanel(props: Props) {
   const {
     setup,
     activePosition,
+    entrySide,
     trancheCount,
     trancheModes,
     executeFlashing = false,
@@ -55,7 +57,9 @@ export function ProfitTakingPanel(props: Props) {
         <div className="section-label stop-plan-title">Exit Plan</div>
         <div className="exit-plan-content">
           {!plannedSetup ? null : trancheModes.slice(0, trancheCount).map((mode, index) => {
-            const price = mode.mode === "runner" ? trailingStop(activePosition?.livePrice ?? plannedSetup.last, mode) : targetPrice(plannedSetup, mode);
+            const price = mode.mode === "runner"
+              ? trailingStop(activePosition?.livePrice ?? plannedSetup.last, mode, entrySide)
+              : targetPrice(plannedSetup, mode, entrySide);
             const qty = plannedShares[index] ?? 0;
             return (
               <div className="exit-plan-line" key={`exit-${index}`}>

--- a/frontend/components/StopProtectionPanel.tsx
+++ b/frontend/components/StopProtectionPanel.tsx
@@ -1,9 +1,10 @@
 import { fp, stopPlanRows } from "@/lib/cockpit-ui";
-import type { OrderView, SetupResponse, StopMode, Tranche } from "@/lib/types";
+import type { EntrySide, OrderView, SetupResponse, StopMode, Tranche } from "@/lib/types";
 
 type Props = {
   setup: SetupResponse | null;
   phase: string | null;
+  entrySide: EntrySide;
   stopMode: number;
   stopModes: StopMode[];
   tranches: Tranche[];
@@ -24,6 +25,7 @@ export function StopProtectionPanel(props: Props) {
   const {
     setup,
     phase,
+    entrySide,
     stopMode,
     stopModes,
     tranches,
@@ -39,7 +41,7 @@ export function StopProtectionPanel(props: Props) {
     onMoveToBe,
     onFlatten
   } = props;
-  const rows = stopPlanRows(setup, tranches, stopMode, stopModes, orders);
+  const rows = stopPlanRows(setup, tranches, stopMode, stopModes, orders, entrySide);
   const hasSetup = Boolean(setup);
   const hasTrade = tranches.length > 0;
   const waitingForFill = phase === "entry_pending";

--- a/frontend/lib/cockpit-ui.ts
+++ b/frontend/lib/cockpit-ui.ts
@@ -1,4 +1,4 @@
-import type { OrderView, PositionView, SetupResponse, StopMode, Tranche, TrancheMode } from "@/lib/types";
+import type { EntrySide, OrderView, PositionView, SetupResponse, StopMode, Tranche, TrancheMode } from "@/lib/types";
 
 export const ACTIVE_PHASES = ["entry_pending", "trade_entered", "protected", "P1_done", "P2_done", "runner_only"] as const;
 
@@ -56,6 +56,14 @@ export function sessionStateLabel(value: string | null | undefined): string {
 
 export function phaseLabel(phase: string): string {
   return PHASE_LABELS[phase] ?? phase.replaceAll("_", " ").toUpperCase();
+}
+
+export function entrySideFromSetup(setup: SetupResponse | null | undefined): EntrySide {
+  return setup?.entryOrder?.side === "sell" ? "sell" : "buy";
+}
+
+export function entryDirection(side: EntrySide): 1 | -1 {
+  return side === "sell" ? -1 : 1;
 }
 
 export function defaultAllocationPcts(count: number): number[] {
@@ -165,17 +173,22 @@ export function normalizeStopPcts(
   });
 }
 
-export function targetPrice(setup: SetupResponse, mode: TrancheMode): number | null {
+export function targetPrice(
+  setup: SetupResponse,
+  mode: TrancheMode,
+  side: EntrySide = entrySideFromSetup(setup),
+): number | null {
   if (mode.mode === "runner") return null;
   if (mode.target === "Manual") return mode.manualPrice;
   const multiplier = { "1R": 1, "2R": 2, "3R": 3 }[mode.target];
-  return Number((setup.entry + setup.perShareRisk * multiplier).toFixed(2));
+  return Number((setup.entry + entryDirection(side) * setup.perShareRisk * multiplier).toFixed(2));
 }
 
-export function trailingStop(livePrice: number, mode: TrancheMode): number {
+export function trailingStop(livePrice: number, mode: TrancheMode, side: EntrySide = "buy"): number {
+  const direction = entryDirection(side);
   return mode.trailUnit === "$"
-    ? Number((livePrice - mode.trail).toFixed(2))
-    : Number((livePrice * (1 - mode.trail / 100)).toFixed(2));
+    ? Number((livePrice - direction * mode.trail).toFixed(2))
+    : Number((livePrice * (1 - direction * (mode.trail / 100))).toFixed(2));
 }
 
 export function stopGroups(tranches: Tranche[], stopMode: number): Tranche[][] {
@@ -202,9 +215,11 @@ export function stopPlanRows(
   tranches: Tranche[],
   stopMode: number,
   stopModes: StopMode[],
-  orders: OrderView[]
+  orders: OrderView[],
+  side: EntrySide = entrySideFromSetup(setup),
 ): Array<{ label: string; qty: number; price: number; pct: number; mode: StopMode["mode"]; status: string; coveredTranches: string[] }> {
   if (!setup) return [];
+  const direction = entryDirection(side);
   const modeCount = stopMode || 3;
   const stopOrders = orders
     .filter((order) => order.type === "STOP")
@@ -245,14 +260,16 @@ export function stopPlanRows(
         trailUnit: "$" as const,
         label: `Tranche ${index + 1}`
       }));
-  const range = setup.entry - setup.finalStop;
+  const range = Math.abs(setup.entry - setup.finalStop);
   return stopGroups(previewTranches, modeCount).map((group, index) => {
     const config = stopModes[index] ?? { mode: "stop", pct: null };
     const autoPct = index === modeCount - 1
       ? 100 - Math.floor(100 / modeCount) * index
       : Math.floor(100 / modeCount);
     const pct = config.mode === "be" ? 0 : (config.pct ?? autoPct);
-    const price = config.mode === "be" ? setup.entry : Number((setup.entry - range * pct / 100).toFixed(2));
+    const price = config.mode === "be"
+      ? setup.entry
+      : Number((setup.entry - direction * range * pct / 100).toFixed(2));
     const qty = group.reduce((sum, tranche) => sum + tranche.qty, 0);
     const activeOrder = orders.find(
       (order) =>
@@ -303,6 +320,8 @@ export type RunningPnlSummary = {
 export function runningPnlSummary(position: PositionView | null, setup: SetupResponse | null): RunningPnlSummary | null {
   if (!position || !setup || position.phase === "entry_pending") return null;
   const entry = setup.entry;
+  const side = entrySideFromSetup(setup);
+  const direction = entryDirection(side);
   const totalShares = position.tranches.reduce((sum, tranche) => sum + tranche.qty, 0);
   const activeTranches = position.tranches.filter((tranche) => tranche.status === "active");
   const closedTranches = position.tranches.filter((tranche) => tranche.status === "sold");
@@ -318,7 +337,9 @@ export function runningPnlSummary(position: PositionView | null, setup: SetupRes
         return rightTime.localeCompare(leftTime);
       })[0];
     const exitPrice = tranche.exitPrice ?? fillOrder?.fillPrice ?? tranche.target ?? null;
-    const pnl = exitPrice !== null ? Number(((exitPrice - entry) * tranche.qty).toFixed(2)) : 0;
+    const pnl = exitPrice !== null
+      ? Number((((exitPrice - entry) * direction) * tranche.qty).toFixed(2))
+      : 0;
     const exitOrderType = tranche.exitOrderType ?? fillOrder?.type ?? null;
     const label = exitOrderType === "STOP"
       ? `Stop hit · ${tranche.id}`
@@ -335,9 +356,12 @@ export function runningPnlSummary(position: PositionView | null, setup: SetupRes
   });
 
   const realizedPnl = Number(filledLegs.reduce((sum, leg) => sum + leg.pnl, 0).toFixed(2));
-  const unrealizedPnl = Number(((position.livePrice - entry) * remainingShares).toFixed(2));
+  const unrealizedPnl = Number((((position.livePrice - entry) * direction) * remainingShares).toFixed(2));
   const openRisk = Number(
-    activeTranches.reduce((sum, tranche) => sum + Math.max(0, (entry - tranche.stop) * tranche.qty), 0).toFixed(2)
+    activeTranches.reduce(
+      (sum, tranche) => sum + Math.max(0, ((entry - tranche.stop) * direction) * tranche.qty),
+      0,
+    ).toFixed(2)
   );
 
   return {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -1,5 +1,6 @@
 export type StopMode = { mode: "stop" | "be"; pct: number | null };
 
+export type EntrySide = "buy" | "sell";
 export type EntryOrderType = "market" | "limit" | "stop" | "stop_limit";
 export type TimeInForce = "day" | "gtc" | "ioc" | "fok" | "opg" | "cls";
 export type OrderClass = "simple" | "bracket" | "oco" | "oto";
@@ -15,6 +16,7 @@ export type StopLossDraft = {
 };
 
 export type EntryOrderDraft = {
+  side: EntrySide;
   orderType: EntryOrderType;
   timeInForce: TimeInForce;
   orderClass: OrderClass;
@@ -123,6 +125,7 @@ export type SetupResponse = {
   buyingPowerNote?: string | null;
   atrExtension: number;
   extFrom10Ma: number;
+  entryOrder?: EntryOrderDraft;
 };
 
 export type TradePreviewResponse = {

--- a/scripts/dev/run-qc.ps1
+++ b/scripts/dev/run-qc.ps1
@@ -25,6 +25,14 @@ $profileEnv = Get-LocalProfileEnv -RepoRoot $repoRoot -EnvFile $EnvFile -Persona
 $qcAuthUsername = Get-ResolvedValue -EnvValues $profileEnv -Key "AUTH_ADMIN_USERNAME" -Default "admin"
 $qcAuthPassword = Get-ResolvedValue -EnvValues $profileEnv -Key "AUTH_ADMIN_PASSWORD" -Default "change-me-admin"
 
+function Assert-LastExitCode {
+  param([Parameter(Mandatory = $true)][string]$Description)
+
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Description failed with exit code $LASTEXITCODE."
+  }
+}
+
 function Reset-FrontendNextCache {
   if (Test-Path $frontendNextDir) {
     cmd /c "rmdir /s /q ""$frontendNextDir""" | Out-Null
@@ -80,8 +88,12 @@ function Invoke-BrowserSmoke {
   )
 
   $env:FRONTEND_URL = $Url
+  $env:BACKEND_URL = "http://127.0.0.1:$BackendPort"
+  $env:NEXT_PUBLIC_API_BASE_URL = $env:BACKEND_URL
+  $env:NEXT_PUBLIC_WS_URL = "ws://127.0.0.1:$BackendPort/ws/cockpit"
   $env:BROWSER_SMOKE_LABEL = $Label
   node ..\scripts\dev\browser-smoke.mjs
+  Assert-LastExitCode -Description "Browser smoke ($Label)"
 
   foreach ($suffix in @("png", "console.txt", "network.txt")) {
     $artifact = Join-Path $playwrightOutputDir "$Label.$suffix"
@@ -109,6 +121,7 @@ if ($PersonalPaper) {
 Push-Location $backendDir
 try {
   python -m pytest -q
+  Assert-LastExitCode -Description "Backend pytest"
 } finally {
   Pop-Location
 }
@@ -118,8 +131,11 @@ try {
   $env:QC_AUTH_USERNAME = $qcAuthUsername
   $env:QC_AUTH_PASSWORD = $qcAuthPassword
   npm run lint
+  Assert-LastExitCode -Description "Frontend lint"
   npm run typecheck
+  Assert-LastExitCode -Description "Frontend typecheck"
   npm run test
+  Assert-LastExitCode -Description "Frontend test"
 
   Invoke-BrowserSmoke -Url "http://127.0.0.1:$FrontendPort" -Label "dev-smoke-initial"
 
@@ -129,6 +145,7 @@ try {
   $env:NEXT_PUBLIC_API_BASE_URL = "http://127.0.0.1:$BackendPort"
   $env:NEXT_PUBLIC_WS_URL = "ws://127.0.0.1:$BackendPort/ws/cockpit"
   npm run build
+  Assert-LastExitCode -Description "Frontend build"
 
   Start-FrontendProd -Port $FrontendProdPort
   Invoke-BrowserSmoke -Url "http://127.0.0.1:$FrontendProdPort" -Label "prod-smoke"
@@ -141,7 +158,9 @@ try {
   $env:FRONTEND_URL = "http://127.0.0.1:$FrontendPort"
   $env:BACKEND_URL = "http://127.0.0.1:$BackendPort"
   node ..\scripts\dev\fidelity-baselines.mjs
+  Assert-LastExitCode -Description "Fidelity baselines"
   node ..\scripts\dev\trade-flow-qc.mjs
+  Assert-LastExitCode -Description "Trade flow QC"
   foreach ($artifactName in @("baseline-idle.png", "baseline-setup-loaded.png", "baseline-trade-entered.png", "baseline-protected.png", "baseline-profit-flow.png")) {
     $artifact = Join-Path $playwrightOutputDir $artifactName
     if (-not (Test-Path $artifact)) {


### PR DESCRIPTION
## Summary
- add explicit buy/sell side handling end to end for the cockpit order draft and broker paths
- make stop, profit, trailing, and running P&L math side-aware without changing the existing 3010 cockpit layout
- harden scripts/dev/run-qc.ps1 so browser smoke targets the correct backend/prod ports and fails on native command errors

## Validation
- python -m ruff check backend/app
- python -m black --check backend/app backend/alembic/versions
- python -m pytest -q backend/app/tests/test_api.py
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- powershell -ExecutionPolicy Bypass -File scripts/dev/run-qc.ps1 -StartStack -FrontendPort 3078 -FrontendProdPort 3178 -BackendPort 8078 -PostgresPort 55478 -RedisPort 56388

## Evidence
- frontend/output/playwright/dev-smoke-initial.png
- frontend/output/playwright/prod-smoke.png
- frontend/output/playwright/dev-smoke-final.png
- frontend/output/playwright/baseline-idle.png
- frontend/output/playwright/baseline-setup-loaded.png
- frontend/output/playwright/baseline-trade-entered.png
- frontend/output/playwright/baseline-protected.png
- frontend/output/playwright/baseline-profit-flow.png

## Known gaps
- this tranche closes explicit sell-side support, but the broader type/TIF/class matrix is still open in the linked issue doc
- trade-flow QC still logs a warning while toggling pre-protection stop-mode preview counts; the screenshots and flow complete successfully, but that preview-path behavior still needs tightening in a later tranche