### PR TITLE
Add pending order cancel QC

### DIFF
--- a/backend/app/adapters/broker.py
+++ b/backend/app/adapters/broker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 import httpx
@@ -30,6 +31,7 @@ class BrokerEntryOrder:
     take_profit_limit_price: float | None = None
     stop_loss_stop_price: float | None = None
     stop_loss_limit_price: float | None = None
+    reference_price: float | None = None
 
 
 class BrokerAdapter:
@@ -89,10 +91,78 @@ class BrokerAdapter:
 
 
 class PaperBrokerAdapter(BrokerAdapter):
+    def __init__(self) -> None:
+        self._orders: dict[str, dict] = {}
+
+    def _next_broker_order_id(self) -> str:
+        return f"paper-{uuid4().hex[:12]}"
+
+    def _timestamp(self) -> str:
+        return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+    def _store_pending_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
+        broker_order_id = self._next_broker_order_id()
+        now = self._timestamp()
+        payload = {
+            "id": broker_order_id,
+            "client_order_id": broker_order_id,
+            "symbol": order.symbol,
+            "qty": str(order.qty),
+            "filled_qty": "0",
+            "side": order.side,
+            "type": order.order_type,
+            "time_in_force": order.time_in_force,
+            "order_class": order.order_class,
+            "limit_price": order.limit_price,
+            "stop_price": order.stop_price,
+            "extended_hours": order.extended_hours,
+            "status": "accepted",
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._orders[broker_order_id] = payload
+        return BrokerOrderResult(broker_order_id=broker_order_id, status="PENDING", payload=payload)
+
+    def _paper_entry_fills_immediately(self, order: BrokerEntryOrder) -> bool:
+        if order.order_class != "simple":
+            return False
+        if order.order_type == "market":
+            return True
+        if order.order_type == "limit":
+            if order.limit_price is None or order.reference_price is None:
+                return False
+            if order.side == "sell":
+                return order.limit_price <= order.reference_price
+            return order.limit_price >= order.reference_price
+        return False
+
     def place_entry_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
+        if self._paper_entry_fills_immediately(order):
+            return BrokerOrderResult(
+                broker_order_id=None,
+                status="FILLED",
+                payload={
+                    "symbol": order.symbol,
+                    "qty": str(order.qty),
+                    "side": order.side,
+                    "type": order.order_type,
+                    "time_in_force": order.time_in_force,
+                    "order_class": order.order_class,
+                    "limit_price": order.limit_price,
+                    "stop_price": order.stop_price,
+                    "extended_hours": order.extended_hours,
+                    "status": "filled",
+                },
+            )
+        if order.order_type in {"limit", "stop", "stop_limit"} or order.order_class in {
+            "bracket",
+            "oco",
+            "oto",
+        }:
+            return self._store_pending_order(order)
         return BrokerOrderResult(
             broker_order_id=None,
-            status="ACTIVE" if order.order_class in {"bracket", "oco", "oto"} else "FILLED",
+            status="FILLED",
             payload={
                 "symbol": order.symbol,
                 "qty": str(order.qty),
@@ -103,7 +173,7 @@ class PaperBrokerAdapter(BrokerAdapter):
                 "limit_price": order.limit_price,
                 "stop_price": order.stop_price,
                 "extended_hours": order.extended_hours,
-                "status": "accepted",
+                "status": "filled",
             },
         )
 
@@ -140,13 +210,23 @@ class PaperBrokerAdapter(BrokerAdapter):
         return min_qty
 
     def cancel_order(self, broker_order_id: str) -> None:
+        payload = self._orders.get(broker_order_id)
+        if payload is not None:
+            payload["status"] = "canceled"
+            payload["updated_at"] = self._timestamp()
         return None
 
     def list_recent_orders(self, limit: int = 50) -> list[dict]:
-        return []
+        rows = sorted(
+            self._orders.values(),
+            key=lambda payload: payload.get("updated_at") or payload.get("created_at") or "",
+            reverse=True,
+        )
+        return [dict(order) for order in rows[:limit]]
 
     def get_order(self, broker_order_id: str) -> dict | None:
-        return None
+        payload = self._orders.get(broker_order_id)
+        return dict(payload) if payload is not None else None
 
     def get_session_state(self) -> str:
         return "regular_open"

--- a/backend/app/services/cockpit.py
+++ b/backend/app/services/cockpit.py
@@ -193,7 +193,13 @@ class CockpitService:
         broker_status = "PENDING"
         root_order_type = self._local_entry_order_type(order)
         order_for_broker = self._build_broker_entry_order(
-            symbol, shares, order, payload.offHoursMode, session_state, enforce_alpaca_offhours
+            symbol,
+            shares,
+            order,
+            payload.offHoursMode,
+            session_state,
+            enforce_alpaca_offhours,
+            setup.last,
         )
         broker = self.broker.place_entry_order(order_for_broker)
         broker_status = broker.status or "PENDING"
@@ -1227,6 +1233,7 @@ class CockpitService:
         off_hours_mode: str | None,
         session_state: str,
         enforce_alpaca_offhours: bool,
+        reference_price: float,
     ) -> BrokerEntryOrder:
         extended_hours = False
         order_type = order.orderType
@@ -1259,6 +1266,7 @@ class CockpitService:
             take_profit_limit_price=take_profit.limitPrice if take_profit else None,
             stop_loss_stop_price=stop_loss.stopPrice if stop_loss else None,
             stop_loss_limit_price=stop_loss.limitPrice if stop_loss else None,
+            reference_price=reference_price,
         )
 
     def _entry_should_start_filled(

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -536,6 +536,53 @@ def test_trade_lifecycle() -> None:
     )
 
 
+def test_paper_limit_entry_stays_pending_and_can_be_canceled() -> None:
+    client.put(
+        "/api/account/settings",
+        json={"equity": 1000000, "risk_pct": 0.2, "mode": "paper"},
+    )
+    setup = client.get("/api/setup/AAPL").json()
+    pending_limit = round((setup["entry"] + setup["finalStop"]) / 2, 2)
+
+    enter = client.post(
+        "/api/trade/enter",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "lod",
+            "stopPrice": setup["finalStop"],
+            "trancheCount": 3,
+            "trancheModes": tranche_modes(),
+            "order": simple_entry_order(limitPrice=pending_limit),
+        },
+    )
+    assert enter.status_code == 200
+    position = enter.json()
+    assert position["phase"] == "entry_pending"
+    root_order = next(order for order in position["orders"] if order["tranche"] == "AAPL")
+    assert root_order["status"] == "PENDING"
+    assert root_order["cancelable"] is True
+    assert root_order["brokerOrderId"]
+
+    recent_orders = client.get("/api/orders")
+    assert recent_orders.status_code == 200
+    assert any(
+        order["brokerOrderId"] == root_order["brokerOrderId"] for order in recent_orders.json()
+    )
+
+    cancel = client.delete(f"/api/orders/{root_order['brokerOrderId']}")
+    assert cancel.status_code == 200
+    canceled_order = cancel.json()
+    assert canceled_order["status"] == "CANCELED"
+
+    positions = client.get("/api/positions")
+    assert positions.status_code == 200
+    closed_position = next(
+        position for position in positions.json() if position["symbol"] == "AAPL"
+    )
+    assert closed_position["phase"] == "closed"
+
+
 def test_preview_trade_supports_sell_side_and_rejects_invalid_short_stop() -> None:
     client.put(
         "/api/account/settings",

--- a/docs/issues/2026-03-23-pending-order-cancel-qc.md
+++ b/docs/issues/2026-03-23-pending-order-cancel-qc.md
@@ -1,0 +1,72 @@
+# Pending Order Cancel QC
+
+> Status: Open
+> Branch: `codex/feature-pending-cancel-qc`
+> Opened: 2026-03-23
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The cockpit previously had a real regression where pending orders could be canceled through the backend, but the browser flow failed or looked broken because the frontend/runtime path was not being exercised by automated QC.
+
+Current browser smoke covers shell load and the standard trade flow, but it does not explicitly prove that:
+
+- a deterministic pending entry order can be created
+- the cancel action is visible and usable in `Recent Orders`
+- canceling the pending order updates the row state correctly in the browser
+
+## Business value
+
+- locking the cancel path into QC prevents a repeat of a previously user-visible failure
+- production readiness needs a deterministic browser-level cancel regression check, not just API confidence
+- canceling a pending order is a core recovery action in paper and live trading workflows
+
+## Scope
+
+- add a deterministic browser QC path for pending-order cancel
+- ensure the path uses a reliably pending order configuration instead of a likely-to-fill order
+- verify browser-visible state transitions in `Recent Orders`
+- add targeted backend coverage if the cancel path lacks current regression protection
+- keep the existing cockpit layout intact
+
+## Acceptance criteria
+
+- [x] browser QC creates a pending order deterministically
+- [x] the `Cancel` action is visible for that order in `Recent Orders`
+- [x] invoking cancel changes the order state to `CANCELED` in the browser
+- [x] automated coverage would fail if the cancel path regressed again
+- [x] validation evidence is captured in the repo artifact path
+
+## Risks / constraints
+
+- this must use paper-mode-safe order construction only
+- the path should avoid mutating unrelated existing positions
+- the fix should stay scoped to cancel regression coverage and deterministic pending-order setup
+
+## Validation
+
+- Backend: `python -m ruff check backend\app`
+- Backend: `python -m black --check backend\app backend\alembic\versions`
+- Backend: `python -m pytest -q backend\app\tests\test_api.py`
+- Frontend: `npm run lint`
+- Frontend: `npm run typecheck`
+- Frontend: `npm run test`
+- Frontend: `npm run build`
+- Browser QC: `powershell -ExecutionPolicy Bypass -File scripts\dev\run-qc.ps1 -FrontendPort 3098 -FrontendProdPort 3198 -BackendPort 8098 -PostgresPort 55498 -RedisPort 56408`
+
+## Evidence
+
+- Pending cancel artifact: `frontend/output/playwright/pending-cancel-flow.png`
+- Baselines refreshed:
+  - `frontend/output/playwright/baseline-idle.png`
+  - `frontend/output/playwright/baseline-setup-loaded.png`
+  - `frontend/output/playwright/baseline-trade-entered.png`
+  - `frontend/output/playwright/baseline-protected.png`
+  - `frontend/output/playwright/baseline-profit-flow.png`
+
+## Notes
+
+- The local paper broker now supports realistic pending entry orders for non-marketable simple limits and for advanced entry classes, with synthetic broker ids so browser cancel coverage exercises the same order-management path as the cockpit UI.
+- `scripts/dev/run-qc.ps1` now includes the deterministic pending cancel browser flow.
+- `scripts/dev\fidelity-baselines.mjs` was updated to use explicit ready-state waits instead of `networkidle`, which is not stable on the polling cockpit UI.

--- a/frontend/components/EntryPanel.tsx
+++ b/frontend/components/EntryPanel.tsx
@@ -211,6 +211,7 @@ export function EntryPanel(props: Props) {
             <div className={`entry-order-field ${typeIssue ? "entry-order-field-invalid" : ""}`}>
               <span className="entry-order-label">Type</span>
               <select
+                id="entryOrderType"
                 className="entry-select"
                 aria-invalid={Boolean(typeIssue)}
                 title={typeIssue ?? undefined}
@@ -227,6 +228,7 @@ export function EntryPanel(props: Props) {
             <div className={`entry-order-field ${tifIssue ? "entry-order-field-invalid" : ""}`}>
               <span className="entry-order-label">TIF</span>
               <select
+                id="entryTimeInForce"
                 className="entry-select"
                 aria-invalid={Boolean(tifIssue)}
                 title={tifIssue ?? undefined}
@@ -243,6 +245,7 @@ export function EntryPanel(props: Props) {
             <div className={`entry-order-field ${classIssue ? "entry-order-field-invalid" : ""}`}>
               <span className="entry-order-label">Class</span>
               <select
+                id="entryOrderClass"
                 className="entry-select"
                 aria-invalid={Boolean(classIssue)}
                 title={classIssue ?? undefined}
@@ -260,6 +263,7 @@ export function EntryPanel(props: Props) {
               <div className={`entry-order-field ${limitIssue ? "entry-order-field-invalid" : ""}`}>
                 <span className="entry-order-label">{limitFieldLabel}</span>
                 <input
+                  id="entryLimitPrice"
                   type="number"
                   inputMode="decimal"
                   value={order.limitPrice ?? ""}
@@ -279,6 +283,7 @@ export function EntryPanel(props: Props) {
               <div className={`entry-order-field ${triggerIssue ? "entry-order-field-invalid" : ""}`}>
                 <span className="entry-order-label">{triggerFieldLabel}</span>
                 <input
+                  id="entryStopPrice"
                   type="number"
                   inputMode="decimal"
                   value={order.stopPrice ?? ""}

--- a/scripts/dev/fidelity-baselines.mjs
+++ b/scripts/dev/fidelity-baselines.mjs
@@ -1,15 +1,17 @@
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const frontendUrl = process.env.FRONTEND_URL || "http://127.0.0.1:3010";
 const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8010";
-const outputDir = path.resolve(process.cwd(), "output", "playwright");
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..", "..");
+const outputDir = path.join(repoRoot, "frontend", "output", "playwright");
 const qcSymbol = (process.env.QC_SYMBOL || "MSFT").trim().toUpperCase() || "MSFT";
 const require = createRequire(import.meta.url);
 const playwrightEntry = require.resolve("playwright", {
-  paths: [process.cwd(), path.resolve(process.cwd(), "frontend")]
+  paths: [repoRoot, path.join(repoRoot, "frontend")]
 });
 const playwrightModule = await import(pathToFileURL(playwrightEntry).href);
 const { chromium } = playwrightModule.default ?? playwrightModule;
@@ -101,7 +103,7 @@ try {
   await fs.mkdir(outputDir, { recursive: true });
   await seedAuthSession(page);
 
-  const response = await page.goto(frontendUrl, { waitUntil: "networkidle" });
+  const response = await page.goto(frontendUrl, { waitUntil: "load" });
   if (!response || response.status() >= 400) {
     throw new Error(`Frontend root failed to load for baseline capture at ${frontendUrl}.`);
   }
@@ -119,9 +121,10 @@ try {
   await page.getByText("SETUP LOADED").waitFor({ timeout: 15000 });
   await page.screenshot({ path: path.join(outputDir, "baseline-setup-loaded.png"), fullPage: true });
 
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "load" });
   await ensureCockpitReady(page);
-  await page.waitForTimeout(1500);
+  await page.locator(".state-display").waitFor({ timeout: 15000 });
+  await page.waitForTimeout(1000);
   const phaseText = (await page.locator(".state-display").textContent())?.trim() || "unknown";
   await page.screenshot({ path: path.join(outputDir, `baseline-${safeName(phaseText)}.png`), fullPage: true });
 } finally {

--- a/scripts/dev/pending-cancel-qc.mjs
+++ b/scripts/dev/pending-cancel-qc.mjs
@@ -1,0 +1,188 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import path from "node:path";
+
+const frontendUrl = process.env.FRONTEND_URL || "http://127.0.0.1:3010";
+const backendUrl = process.env.BACKEND_URL || "http://127.0.0.1:8010";
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..", "..");
+const outputDir = path.join(repoRoot, "frontend", "output", "playwright");
+const authUsername = process.env.QC_AUTH_USERNAME || "admin";
+const authPassword = process.env.QC_AUTH_PASSWORD || "change-me-admin";
+const require = createRequire(import.meta.url);
+const playwrightEntry = require.resolve("playwright", {
+  paths: [repoRoot, path.join(repoRoot, "frontend")],
+});
+const playwrightModule = await import(pathToFileURL(playwrightEntry).href);
+const { chromium } = playwrightModule.default ?? playwrightModule;
+
+async function launchBrowser() {
+  try {
+    return await chromium.launch({ channel: "chrome", headless: true });
+  } catch {
+    return chromium.launch({ headless: true });
+  }
+}
+
+async function loginBackend() {
+  const response = await fetch(`${backendUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: authUsername, password: authPassword }),
+  });
+  if (!response.ok) {
+    throw new Error(`Unable to authenticate against ${backendUrl}`);
+  }
+  const cookie = response.headers.get("set-cookie");
+  if (!cookie) {
+    throw new Error("Missing auth cookie from backend login.");
+  }
+  return cookie.split(";")[0];
+}
+
+async function seedAuthSession(page) {
+  const cookiePair = await loginBackend();
+  const separator = cookiePair.indexOf("=");
+  const cookieName = cookiePair.slice(0, separator);
+  const cookieValue = cookiePair.slice(separator + 1);
+  const frontend = new URL(frontendUrl);
+  await page.context().addCookies([
+    {
+      name: cookieName,
+      value: cookieValue,
+      domain: frontend.hostname,
+      path: "/",
+      httpOnly: true,
+      sameSite: "Lax",
+    },
+  ]);
+  return cookiePair;
+}
+
+async function clearActiveState() {
+  const authCookie = await loginBackend();
+  const positionsResponse = await fetch(`${backendUrl}/api/positions`, {
+    headers: { Cookie: authCookie },
+  });
+  if (!positionsResponse.ok) {
+    throw new Error(`Unable to read positions from ${backendUrl}`);
+  }
+  const positions = await positionsResponse.json();
+  for (const position of positions) {
+    if (position.phase === "closed") continue;
+    await fetch(`${backendUrl}/api/trade/flatten`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: authCookie },
+      body: JSON.stringify({ symbol: position.symbol }),
+    });
+  }
+
+  const ordersResponse = await fetch(`${backendUrl}/api/orders`, {
+    headers: { Cookie: authCookie },
+  });
+  if (!ordersResponse.ok) {
+    throw new Error(`Unable to read recent orders from ${backendUrl}`);
+  }
+  const recentOrders = await ordersResponse.json();
+  for (const order of recentOrders) {
+    if (!order.cancelable || !order.brokerOrderId) continue;
+    await fetch(`${backendUrl}/api/orders/${order.brokerOrderId}`, {
+      method: "DELETE",
+      headers: { Cookie: authCookie },
+    });
+  }
+
+  await fetch(`${backendUrl}/api/activity-log`, {
+    method: "DELETE",
+    headers: { Cookie: authCookie },
+  });
+}
+
+async function loadSetup(page, symbol = "MSFT") {
+  const symbolInput = page.locator("#tickerInput");
+  await symbolInput.waitFor({ state: "visible", timeout: 15000 });
+  await symbolInput.fill(symbol);
+  await page.waitForFunction(
+    (value) => {
+      const input = document.querySelector("#tickerInput");
+      return input instanceof HTMLInputElement && input.value === value;
+    },
+    symbol,
+    { timeout: 5000 },
+  );
+  await symbolInput.press("Enter");
+}
+
+function pendingLimitFrom(entryText, stopText) {
+  const entry = Number(entryText);
+  const stop = Number(stopText);
+  if (!Number.isFinite(entry) || entry <= 0 || !Number.isFinite(stop) || stop <= 0) {
+    throw new Error(`Unable to derive pending limit from entry=${entryText} stop=${stopText}`);
+  }
+  const midpoint = Number((((entry + stop) / 2)).toFixed(2));
+  if (midpoint <= stop) {
+    return Number((stop + 0.1).toFixed(2));
+  }
+  return midpoint;
+}
+
+const browser = await launchBrowser();
+const page = await browser.newPage({ viewport: { width: 1440, height: 1200 } });
+
+try {
+  await fs.mkdir(outputDir, { recursive: true });
+  await clearActiveState();
+  await seedAuthSession(page);
+
+  const response = await page.goto(frontendUrl, { waitUntil: "load" });
+  if (!response || response.status() >= 400) {
+    throw new Error(`Frontend root failed to load for pending cancel QC at ${frontendUrl}.`);
+  }
+
+  await page.getByText("Setup Parameters").waitFor({ timeout: 30000 });
+  await loadSetup(page, "MSFT");
+  await page.locator(".state-display").filter({ hasText: "SETUP LOADED" }).waitFor({ timeout: 15000 });
+
+  await page.locator("#entryOrderType").selectOption("limit");
+  await page.locator("#entryTimeInForce").selectOption("day");
+  await page.locator("#entryOrderClass").selectOption("simple");
+
+  const entryValue = await page.locator("#heroEntry").inputValue();
+  const stopValue = await page.locator(".hero-stop-price").textContent();
+  const pendingLimit = pendingLimitFrom(entryValue, stopValue ?? "");
+  await page.locator("#entryLimitPrice").fill(String(pendingLimit));
+
+  await page.getByRole("button", { name: /\u2197 ENTER TRADE|ENTER TRADE/ }).click();
+  await page.locator(".state-display").filter({ hasText: "ENTRY SUBMITTED" }).waitFor({ timeout: 15000 });
+
+  await page.getByRole("button", { name: "Open / Working", exact: true }).click();
+  const cancelButton = page.locator(".orders-cancel-btn").first();
+  await cancelButton.waitFor({ state: "visible", timeout: 15000 });
+  const pendingRow = cancelButton.locator("xpath=ancestor::tr[1]");
+  const brokerOrderId = await pendingRow.getAttribute("title");
+  if (!brokerOrderId) {
+    throw new Error("Pending order row is missing broker order id.");
+  }
+
+  await cancelButton.click();
+  await page.waitForTimeout(500);
+
+  await page.getByRole("button", { name: "All", exact: true }).click();
+  const canceledRow = page.locator(`tr[title="${brokerOrderId}"]`).first();
+  await canceledRow.waitFor({ state: "visible", timeout: 15000 });
+  await page.waitForFunction(
+    (orderId) => {
+      const row = document.querySelector(`tr[title="${orderId}"]`);
+      return row?.textContent?.includes("CANCELED") ?? false;
+    },
+    brokerOrderId,
+    { timeout: 15000 },
+  );
+
+  await page.screenshot({ path: path.join(outputDir, "pending-cancel-flow.png"), fullPage: true });
+} finally {
+  await browser.close();
+}
+
+console.log(`Pending cancel QC captured in ${outputDir}`);

--- a/scripts/dev/run-qc.ps1
+++ b/scripts/dev/run-qc.ps1
@@ -63,7 +63,10 @@ function Start-FrontendDev {
 function Start-FrontendProd {
   param([int]$Port)
 
-  Assert-PortFree -Port $Port -Purpose "Frontend production server"
+  if ($null -ne (Get-PortListener -Port $Port)) {
+    Stop-PortListenerProcess -Port $Port
+    Wait-ForPortClosed -Port $Port
+  }
 
   $frontendCmd = @(
     "set ""NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:$BackendPort""",
@@ -157,11 +160,13 @@ try {
   Invoke-BrowserSmoke -Url "http://127.0.0.1:$FrontendPort" -Label "dev-smoke-final"
   $env:FRONTEND_URL = "http://127.0.0.1:$FrontendPort"
   $env:BACKEND_URL = "http://127.0.0.1:$BackendPort"
+  node ..\scripts\dev\pending-cancel-qc.mjs
+  Assert-LastExitCode -Description "Pending cancel QC"
   node ..\scripts\dev\fidelity-baselines.mjs
   Assert-LastExitCode -Description "Fidelity baselines"
   node ..\scripts\dev\trade-flow-qc.mjs
   Assert-LastExitCode -Description "Trade flow QC"
-  foreach ($artifactName in @("baseline-idle.png", "baseline-setup-loaded.png", "baseline-trade-entered.png", "baseline-protected.png", "baseline-profit-flow.png")) {
+  foreach ($artifactName in @("pending-cancel-flow.png", "baseline-idle.png", "baseline-setup-loaded.png", "baseline-trade-entered.png", "baseline-protected.png", "baseline-profit-flow.png")) {
     $artifact = Join-Path $playwrightOutputDir $artifactName
     if (-not (Test-Path $artifact)) {
       throw "Expected fidelity artifact was not created: $artifact"

--- a/scripts/dev/start-local.ps1
+++ b/scripts/dev/start-local.ps1
@@ -34,7 +34,10 @@ Push-Location $repoRoot
 try {
   $env:POSTGRES_HOST_PORT = "$PostgresPort"
   $env:REDIS_HOST_PORT = "$RedisPort"
-  docker compose up -d postgres redis
+  cmd /c "docker compose up -d postgres redis"
+  if ($LASTEXITCODE -ne 0) {
+    throw "docker compose up failed with exit code $LASTEXITCODE."
+  }
 } finally {
   Remove-Item Env:POSTGRES_HOST_PORT -ErrorAction SilentlyContinue
   Remove-Item Env:REDIS_HOST_PORT -ErrorAction SilentlyContinue
@@ -48,7 +51,7 @@ try {
   $env:POSTGRES_HOST_PORT = "$PostgresPort"
   $env:REDIS_HOST_PORT = "$RedisPort"
   Wait-ForCommandSuccess -Description "postgres readiness" -ScriptBlock {
-    docker compose exec -T postgres pg_isready -U traders_cockpit -d traders_cockpit
+    cmd /c "docker compose exec -T postgres pg_isready -U traders_cockpit -d traders_cockpit"
   }
 } finally {
   Remove-Item Env:POSTGRES_HOST_PORT -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- add deterministic browser QC for creating and canceling a pending paper entry order
- make the paper broker keep non-marketable entry orders pending with synthetic broker ids so the cockpit cancel path is exercised end to end
- wire the new pending-cancel flow into \\scripts/dev/run-qc.ps1\\ and harden the baseline/startup scripts used by the QC wrapper

## Validation
- python -m ruff check backend/app
- python -m black --check backend/app backend/alembic/versions
- python -m pytest -q backend/app/tests/test_api.py
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- powershell -ExecutionPolicy Bypass -File scripts/dev/run-qc.ps1 -FrontendPort 3098 -FrontendProdPort 3198 -BackendPort 8098 -PostgresPort 55498 -RedisPort 56408

## Evidence
- frontend/output/playwright/pending-cancel-flow.png
- frontend/output/playwright/baseline-idle.png
- frontend/output/playwright/baseline-setup-loaded.png
- frontend/output/playwright/baseline-trade-entered.png
- frontend/output/playwright/baseline-protected.png
- frontend/output/playwright/baseline-profit-flow.png

## Known gaps
- none in this tranche; scope stays on deterministic pending-order cancel coverage and the small QC harness fixes required to make the wrapper stable