### PR TITLE
Add request ID observability foundation

### DIFF
--- a/backend/app/api/routes_auth.py
+++ b/backend/app/api/routes_auth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException, Request, Response
 
 from app.core.config import Settings
+from app.core.observability import log_event, request_log_fields
 from app.schemas.cockpit import LoginRequest, LoginResponse
 from app.services.auth import get_auth_store
 
@@ -16,7 +17,16 @@ def me(request: Request) -> LoginResponse:
     session_token = request.cookies.get(settings.auth_cookie_name)
     session = auth_store.resolve_session(session_token=session_token)
     if session is None:
+        log_event("auth.me.unauthenticated", level="warning", **request_log_fields(request))
         raise HTTPException(status_code=401, detail="Not authenticated")
+    log_event(
+        "auth.me",
+        **request_log_fields(
+            request,
+            username=str(session["user"]["username"]),
+            role=str(session["user"]["role"]),
+        ),
+    )
     return LoginResponse(
         username=str(session["user"]["username"]),
         role=str(session["user"]["role"]),
@@ -32,6 +42,15 @@ def login(payload: LoginRequest, request: Request, response: Response) -> LoginR
         ip_addr=ip_addr,
     )
     if not is_allowed:
+        log_event(
+            "auth.login.blocked",
+            level="warning",
+            **request_log_fields(
+                request,
+                username=payload.username,
+                retry_after_seconds=retry_after,
+            ),
+        )
         raise HTTPException(
             status_code=429,
             detail=f"Too many login attempts. Try again in {retry_after} seconds.",
@@ -44,10 +63,24 @@ def login(payload: LoginRequest, request: Request, response: Response) -> LoginR
             ip_addr=ip_addr,
         )
         if not is_allowed:
+            log_event(
+                "auth.login.blocked",
+                level="warning",
+                **request_log_fields(
+                    request,
+                    username=payload.username,
+                    retry_after_seconds=retry_after,
+                ),
+            )
             raise HTTPException(
                 status_code=429,
                 detail=f"Too many login attempts. Try again in {retry_after} seconds.",
             )
+        log_event(
+            "auth.login.failed",
+            level="warning",
+            **request_log_fields(request, username=payload.username),
+        )
         raise HTTPException(status_code=401, detail="Invalid credentials")
     auth_store.clear_login_failures(username=payload.username, ip_addr=ip_addr)
     session_token, session_data = auth_store.create_session(
@@ -62,6 +95,10 @@ def login(payload: LoginRequest, request: Request, response: Response) -> LoginR
         samesite=settings.auth_cookie_samesite,
         secure=settings.auth_cookie_secure,
     )
+    log_event(
+        "auth.login.succeeded",
+        **request_log_fields(request, username=user.username, role=user.role),
+    )
     return LoginResponse(
         username=user.username,
         role=user.role,
@@ -71,11 +108,21 @@ def login(payload: LoginRequest, request: Request, response: Response) -> LoginR
 
 @router.post("/logout")
 def logout(request: Request, response: Response) -> dict[str, bool]:
+    session = auth_store.resolve_session(
+        session_token=request.cookies.get(settings.auth_cookie_name)
+    )
     auth_store.revoke_session(session_token=request.cookies.get(settings.auth_cookie_name))
     response.delete_cookie(
         settings.auth_cookie_name,
         httponly=True,
         samesite=settings.auth_cookie_samesite,
         secure=settings.auth_cookie_secure,
+    )
+    log_event(
+        "auth.logout",
+        **request_log_fields(
+            request,
+            username=str(session["user"]["username"]) if session is not None else None,
+        ),
     )
     return {"ok": True}

--- a/backend/app/api/routes_positions.py
+++ b/backend/app/api/routes_positions.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from app.api.deps_auth import require_session
+from app.core.observability import log_event, request_log_fields
 from app.db.session import get_db
 from app.schemas.cockpit import OrderView, PositionView
 from app.services.cockpit import CockpitService
@@ -30,10 +31,37 @@ def build_router(service: CockpitService) -> APIRouter:
         return service.get_recent_orders(db)
 
     @router.delete("/orders/{broker_order_id}", response_model=OrderView)
-    def cancel_order(broker_order_id: str, db: Session = Depends(get_db)) -> OrderView:
+    def cancel_order(
+        broker_order_id: str,
+        request: Request,
+        db: Session = Depends(get_db),
+        session: dict = Depends(require_session),
+    ) -> OrderView:
         try:
-            return service.cancel_recent_order(db, broker_order_id)
+            response = service.cancel_recent_order(db, broker_order_id)
+            log_event(
+                "orders.cancel",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    broker_order_id=broker_order_id,
+                    symbol=response.symbol,
+                    outcome="success",
+                ),
+            )
+            return response
         except ValueError as exc:
+            log_event(
+                "orders.cancel",
+                level="warning",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    broker_order_id=broker_order_id,
+                    outcome="error",
+                    detail=str(exc),
+                ),
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return router

--- a/backend/app/api/routes_trade.py
+++ b/backend/app/api/routes_trade.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from app.api.deps_auth import require_session
+from app.core.observability import log_event, request_log_fields
 from app.db.session import get_db
 from app.schemas.cockpit import (
     MoveToBeRequest,
@@ -22,46 +23,221 @@ def build_router(service: CockpitService) -> APIRouter:
 
     @router.post("/preview", response_model=TradePreviewResponse)
     def preview(
-        payload: TradePreviewRequest, db: Session = Depends(get_db)
+        payload: TradePreviewRequest,
+        request: Request,
+        db: Session = Depends(get_db),
+        session: dict = Depends(require_session),
     ) -> TradePreviewResponse:
         try:
-            return service.preview_trade(db, payload)
+            response = service.preview_trade(db, payload)
+            log_event(
+                "trade.preview",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    side=payload.order.side,
+                    order_type=payload.order.orderType,
+                    time_in_force=payload.order.timeInForce,
+                    order_class=payload.order.orderClass,
+                    outcome="success",
+                ),
+            )
+            return response
         except ValueError as exc:
+            log_event(
+                "trade.preview",
+                level="warning",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    side=payload.order.side,
+                    order_type=payload.order.orderType,
+                    time_in_force=payload.order.timeInForce,
+                    order_class=payload.order.orderClass,
+                    outcome="error",
+                    detail=str(exc),
+                ),
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/enter", response_model=PositionView)
-    async def enter(payload: TradeEnterRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def enter(
+        payload: TradeEnterRequest,
+        request: Request,
+        db: Session = Depends(get_db),
+        session: dict = Depends(require_session),
+    ) -> PositionView:
         try:
-            return await service.enter_trade(db, payload)
+            response = await service.enter_trade(db, payload)
+            log_event(
+                "trade.enter",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    side=payload.order.side,
+                    order_type=payload.order.orderType,
+                    time_in_force=payload.order.timeInForce,
+                    order_class=payload.order.orderClass,
+                    phase=response.phase,
+                    outcome="success",
+                ),
+            )
+            return response
         except ValueError as exc:
+            log_event(
+                "trade.enter",
+                level="warning",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    side=payload.order.side,
+                    order_type=payload.order.orderType,
+                    time_in_force=payload.order.timeInForce,
+                    order_class=payload.order.orderClass,
+                    outcome="error",
+                    detail=str(exc),
+                ),
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/stops", response_model=PositionView)
-    async def stops(payload: StopsRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def stops(
+        payload: StopsRequest,
+        request: Request,
+        db: Session = Depends(get_db),
+        session: dict = Depends(require_session),
+    ) -> PositionView:
         try:
-            return await service.apply_stops(db, payload)
+            response = await service.apply_stops(db, payload)
+            log_event(
+                "trade.stops",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    stop_mode=payload.stopMode,
+                    outcome="success",
+                ),
+            )
+            return response
         except ValueError as exc:
+            log_event(
+                "trade.stops",
+                level="warning",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    stop_mode=payload.stopMode,
+                    outcome="error",
+                    detail=str(exc),
+                ),
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/profit", response_model=PositionView)
-    async def profit(payload: ProfitRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def profit(
+        payload: ProfitRequest,
+        request: Request,
+        db: Session = Depends(get_db),
+        session: dict = Depends(require_session),
+    ) -> PositionView:
         try:
-            return await service.execute_profit_plan(db, payload)
+            response = await service.execute_profit_plan(db, payload)
+            log_event(
+                "trade.profit",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    tranche_count=len(payload.trancheModes),
+                    outcome="success",
+                ),
+            )
+            return response
         except ValueError as exc:
+            log_event(
+                "trade.profit",
+                level="warning",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    tranche_count=len(payload.trancheModes),
+                    outcome="error",
+                    detail=str(exc),
+                ),
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/flatten", response_model=PositionView)
-    async def flatten(payload: MoveToBeRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def flatten(
+        payload: MoveToBeRequest,
+        request: Request,
+        db: Session = Depends(get_db),
+        session: dict = Depends(require_session),
+    ) -> PositionView:
         try:
-            return await service.flatten(db, payload.symbol)
+            response = await service.flatten(db, payload.symbol)
+            log_event(
+                "trade.flatten",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    outcome="success",
+                ),
+            )
+            return response
         except ValueError as exc:
+            log_event(
+                "trade.flatten",
+                level="warning",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    outcome="error",
+                    detail=str(exc),
+                ),
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/move_to_be", response_model=PositionView)
-    async def move_to_be(payload: MoveToBeRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def move_to_be(
+        payload: MoveToBeRequest,
+        request: Request,
+        db: Session = Depends(get_db),
+        session: dict = Depends(require_session),
+    ) -> PositionView:
         try:
-            return await service.move_to_be(db, payload.symbol)
+            response = await service.move_to_be(db, payload.symbol)
+            log_event(
+                "trade.move_to_be",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    outcome="success",
+                ),
+            )
+            return response
         except ValueError as exc:
+            log_event(
+                "trade.move_to_be",
+                level="warning",
+                **request_log_fields(
+                    request,
+                    username=str(session["user"]["username"]),
+                    symbol=payload.symbol.upper(),
+                    outcome="error",
+                    detail=str(exc),
+                ),
+            )
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return router

--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import logging
+from contextvars import ContextVar, Token
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from fastapi import Request
+
+REQUEST_ID_HEADER = "X-Request-ID"
+_request_id_ctx: ContextVar[str | None] = ContextVar("request_id", default=None)
+logger = logging.getLogger("traders_cockpit")
+
+
+def resolve_request_id(candidate: str | None) -> str:
+    value = (candidate or "").strip()
+    return value[:128] if value else uuid4().hex
+
+
+def bind_request_id(request_id: str) -> Token[str | None]:
+    return _request_id_ctx.set(request_id)
+
+
+def reset_request_id(token: Token[str | None]) -> None:
+    _request_id_ctx.reset(token)
+
+
+def get_request_id() -> str | None:
+    return _request_id_ctx.get()
+
+
+def request_log_fields(request: Request | None = None, **fields: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "request_id": get_request_id(),
+    }
+    if request is not None:
+        payload["method"] = request.method
+        payload["path"] = request.url.path
+        payload["client_ip"] = request.client.host if request.client else None
+    payload.update(fields)
+    return payload
+
+
+def log_event(event: str, level: str = "info", **fields: Any) -> None:
+    payload = {
+        "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "event": event,
+        **fields,
+    }
+    message = json.dumps(payload, default=str, sort_keys=True)
+    getattr(logger, level, logger.info)(message)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import asyncio
 import json
 from contextlib import asynccontextmanager
+from time import perf_counter
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -12,6 +14,14 @@ from app.api.deps_auth import require_websocket_session
 from app.api import routes_account, routes_market, routes_positions, routes_trade
 from app.api.routes_auth import router as auth_router
 from app.core.config import Settings
+from app.core.observability import (
+    REQUEST_ID_HEADER,
+    bind_request_id,
+    log_event,
+    request_log_fields,
+    reset_request_id,
+    resolve_request_id,
+)
 from app.core.startup_preflight import (
     build_dependency_report,
     build_liveness_report,
@@ -55,6 +65,41 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def request_id_middleware(request: Request, call_next):
+    request_id = resolve_request_id(request.headers.get(REQUEST_ID_HEADER))
+    token = bind_request_id(request_id)
+    request.state.request_id = request_id
+    started = perf_counter()
+    try:
+        response = await call_next(request)
+    except Exception:
+        duration_ms = round((perf_counter() - started) * 1000, 2)
+        log_event(
+            "http.request.failed",
+            level="error",
+            **request_log_fields(
+                request,
+                status=500,
+                duration_ms=duration_ms,
+            ),
+        )
+        raise
+    response.headers[REQUEST_ID_HEADER] = request_id
+    duration_ms = round((perf_counter() - started) * 1000, 2)
+    log_event(
+        "http.request.completed",
+        **request_log_fields(
+            request,
+            status=response.status_code,
+            duration_ms=duration_ms,
+        ),
+    )
+    reset_request_id(token)
+    return response
+
 
 app.include_router(auth_router)
 app.include_router(routes_account.build_router(service))

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 import os
 from pathlib import Path
 
@@ -34,6 +36,7 @@ from app.models.entities import (  # noqa: E402
 from app.schemas.cockpit import TrancheMode  # noqa: E402
 from app.services.auth import FAILED_LOGIN_LIMIT, get_auth_store  # noqa: E402
 from app.core.config import Settings, _normalize_database_url  # noqa: E402
+from app.core.observability import REQUEST_ID_HEADER  # noqa: E402
 from app.api import deps_auth  # noqa: E402
 from app import main as main_module  # noqa: E402
 
@@ -114,6 +117,18 @@ def simple_entry_order(side: str = "buy", **overrides: object) -> dict[str, obje
     return payload
 
 
+def structured_events(caplog: pytest.LogCaptureFixture) -> list[dict]:
+    events: list[dict] = []
+    for record in caplog.records:
+        if record.name != "traders_cockpit":
+            continue
+        try:
+            events.append(json.loads(record.getMessage()))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
 def test_setup_endpoint_returns_contract() -> None:
     response = client.get("/api/setup/AAPL")
     assert response.status_code == 200
@@ -180,6 +195,36 @@ def test_health_ready_returns_503_when_readiness_fails(monkeypatch: pytest.Monke
 
     assert response.status_code == 503
     assert response.json()["status"] == "error"
+
+
+def test_request_id_header_is_generated_and_reused() -> None:
+    generated = client.get("/health")
+    assert generated.status_code == 200
+    generated_request_id = generated.headers.get(REQUEST_ID_HEADER)
+    assert generated_request_id
+
+    echoed = client.get("/health", headers={REQUEST_ID_HEADER: "req-health-123"})
+    assert echoed.status_code == 200
+    assert echoed.headers.get(REQUEST_ID_HEADER) == "req-health-123"
+
+
+def test_request_completion_logs_include_request_context(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+
+    response = client.get("/health", headers={REQUEST_ID_HEADER: "req-health-log-1"})
+
+    assert response.status_code == 200
+    events = structured_events(caplog)
+    request_event = next(
+        event for event in events if event.get("event") == "http.request.completed"
+    )
+    assert request_event["request_id"] == "req-health-log-1"
+    assert request_event["method"] == "GET"
+    assert request_event["path"] == "/health"
+    assert request_event["status"] == 200
+    assert isinstance(request_event["duration_ms"], float | int)
 
 
 def test_postgres_urls_normalize_to_psycopg_driver() -> None:
@@ -392,6 +437,24 @@ def test_login_creates_session_and_me_resolves_user() -> None:
     assert after.status_code == 401
 
 
+def test_auth_login_failure_logs_request_scoped_event(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+
+    response = client.post(
+        "/api/auth/login",
+        headers={REQUEST_ID_HEADER: "req-auth-fail-1"},
+        json={"username": "admin", "password": "wrong-password"},
+    )
+
+    assert response.status_code == 401
+    assert response.headers.get(REQUEST_ID_HEADER) == "req-auth-fail-1"
+    events = structured_events(caplog)
+    login_failure = next(event for event in events if event.get("event") == "auth.login.failed")
+    assert login_failure["request_id"] == "req-auth-fail-1"
+    assert login_failure["username"] == "admin"
+    assert "password" not in json.dumps(login_failure)
+
+
 def test_login_rate_limits_repeated_failures() -> None:
     for _ in range(FAILED_LOGIN_LIMIT):
         failed = client.post(
@@ -467,6 +530,33 @@ def test_sensitive_routes_require_session_when_auth_is_enabled() -> None:
     finally:
         deps_auth.settings.auth_require_login = previous
         client.post("/api/auth/logout")
+
+
+def test_trade_preview_logs_request_scoped_event(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+
+    setup = client.get("/api/setup/AAPL").json()
+    response = client.post(
+        "/api/trade/preview",
+        headers={REQUEST_ID_HEADER: "req-preview-1"},
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "lod",
+            "stopPrice": setup["finalStop"],
+            "riskPct": 1,
+            "order": simple_entry_order(limitPrice=setup["entry"]),
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get(REQUEST_ID_HEADER) == "req-preview-1"
+    events = structured_events(caplog)
+    preview_event = next(event for event in events if event.get("event") == "trade.preview")
+    assert preview_event["request_id"] == "req-preview-1"
+    assert preview_event["symbol"] == "AAPL"
+    assert preview_event["order_type"] == "limit"
+    assert preview_event["outcome"] == "success"
 
 
 def test_trade_lifecycle() -> None:
@@ -1236,6 +1326,71 @@ def test_recent_orders_merge_broker_state_and_cancel() -> None:
             assert local.status == "CANCELED"
     finally:
         service.broker.list_recent_orders = original_list_recent_orders
+        service.broker.get_order = original_get_order
+        service.broker.cancel_order = original_cancel_order
+
+
+def test_cancel_recent_order_logs_request_scoped_event(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with SessionLocal() as db:
+        db.add(
+            OrderEntity(
+                order_id="ORD-9201",
+                broker_order_id="broker-log-1",
+                symbol="AAPL",
+                type="LMT",
+                qty=10,
+                orig_qty=10,
+                price=101.25,
+                status="PENDING",
+                tranche_label="AAPL",
+                covered_tranches=[],
+                parent_id=None,
+            )
+        )
+        db.commit()
+
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+    original_get_order = service.broker.get_order
+    original_cancel_order = service.broker.cancel_order
+
+    def fake_get_order(broker_order_id: str):
+        if broker_order_id != "broker-log-1":
+            return None
+        return {
+            "id": "broker-log-1",
+            "client_order_id": "client-log-1",
+            "symbol": "AAPL",
+            "side": "buy",
+            "type": "limit",
+            "qty": "10",
+            "filled_qty": "0",
+            "limit_price": "101.25",
+            "status": "accepted",
+            "created_at": "2026-03-22T10:00:00Z",
+            "updated_at": "2026-03-22T10:00:05Z",
+        }
+
+    def fake_cancel_order(_broker_order_id: str):
+        return None
+
+    service.broker.get_order = fake_get_order
+    service.broker.cancel_order = fake_cancel_order
+    try:
+        response = client.delete(
+            "/api/orders/broker-log-1",
+            headers={REQUEST_ID_HEADER: "req-cancel-1"},
+        )
+        assert response.status_code == 200
+        assert response.headers.get(REQUEST_ID_HEADER) == "req-cancel-1"
+        events = structured_events(caplog)
+        cancel_event = next(event for event in events if event.get("event") == "orders.cancel")
+        assert cancel_event["request_id"] == "req-cancel-1"
+        assert cancel_event["broker_order_id"] == "broker-log-1"
+        assert cancel_event["symbol"] == "AAPL"
+        assert cancel_event["outcome"] == "success"
+    finally:
         service.broker.get_order = original_get_order
         service.broker.cancel_order = original_cancel_order
 

--- a/docs/issues/2026-03-24-request-id-observability.md
+++ b/docs/issues/2026-03-24-request-id-observability.md
@@ -1,0 +1,59 @@
+# Request ID and Structured Logging Foundation
+
+> Status: Open
+> Branch: `codex/feature-request-id-observability`
+> Opened: 2026-03-24
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The app has health checks and browser QC, but operational traces are still weak:
+
+- API responses do not expose a stable request identifier for support/debugging
+- server logs are not structured around request context
+- auth, preview, enter, stop, profit, flatten, and cancel actions do not emit a consistent machine-readable log shape
+- broker/runtime failures are harder to correlate across frontend, API, and backend logs than they should be
+
+That makes production triage slower than necessary, especially for intermittent failures and user-reported issues.
+
+## Business value
+
+- support can ask for a request id and trace a failure quickly
+- staging/production logs become much easier to search and group
+- auth and trade actions get an auditable operational trail without relying on ad hoc prints
+- this lays the groundwork for later correlation IDs across broker submissions and UI support runbooks
+
+## Scope
+
+- add request-id middleware for HTTP requests
+- return a stable request-id header on API responses
+- emit structured logs for auth and core trade/order actions
+- include request id, method, path, status, latency, and key domain fields where appropriate
+- keep the visible cockpit UI unchanged
+
+## Acceptance criteria
+
+- [x] every HTTP response includes a request-id header
+- [x] request ids are reused from inbound headers when provided, otherwise generated server-side
+- [x] request completion logs include request id, method, path, status, and duration
+- [x] auth login/logout failures and successes emit structured logs
+- [x] preview, enter, stops, profit, flatten, and order-cancel emit structured logs with request id
+- [x] backend tests cover request-id propagation and response headers
+- [x] repo docs capture the logging contract and troubleshooting usage
+
+## Risks / constraints
+
+- do not change the current cockpit layout or frontend behavior beyond optional response-header consumption
+- avoid logging secrets, session tokens, or raw credentials
+- keep the log shape simple JSON-like key/value output that works with default container/platform logs
+
+## Validation
+
+- `python -m ruff check backend/app`
+- `python -m black --check backend/app backend/alembic/versions`
+- `python -m pytest -q backend/app/tests/test_api.py`
+
+## Notes
+
+- Browser QC was intentionally skipped because this tranche does not change visible UI behavior.

--- a/docs/process/OBSERVABILITY.md
+++ b/docs/process/OBSERVABILITY.md
@@ -1,0 +1,59 @@
+# Observability Contract
+
+This app uses a simple request-scoped observability contract for API troubleshooting.
+
+## Request IDs
+
+- Every HTTP response includes the `X-Request-ID` header.
+- If a request already includes `X-Request-ID`, the backend reuses it.
+- If no request id is provided, the backend generates one server-side.
+- Browser, API, proxy, and support tooling should preserve the same request id when possible.
+
+## Structured backend logs
+
+- Structured backend events are emitted through the `traders_cockpit` logger.
+- Each event is a single JSON line.
+- Common fields:
+  - `ts`
+  - `event`
+  - `request_id`
+  - `method`
+  - `path`
+  - `client_ip`
+- HTTP completion events also include:
+  - `status`
+  - `duration_ms`
+
+## Core event names
+
+- `http.request.completed`
+- `http.request.failed`
+- `auth.me`
+- `auth.me.unauthenticated`
+- `auth.login.succeeded`
+- `auth.login.failed`
+- `auth.login.blocked`
+- `auth.logout`
+- `trade.preview`
+- `trade.enter`
+- `trade.stops`
+- `trade.profit`
+- `trade.flatten`
+- `trade.move_to_be`
+- `orders.cancel`
+
+## Logging safety rules
+
+- Do not log passwords, session cookies, or raw auth tokens.
+- Do not log broker secrets or environment secrets.
+- Prefer stable identifiers such as username, symbol, broker order id, and request id.
+
+## Troubleshooting usage
+
+1. Capture the `X-Request-ID` value from the failing browser/API response.
+2. Search backend logs for that request id.
+3. Correlate the request with the matching structured event:
+   - auth issue -> `auth.*`
+   - trade preview/entry/stops/profit/flatten -> `trade.*`
+   - cancel issue -> `orders.cancel`
+4. If the request never reached the app, check reverse-proxy or platform logs for the same request id if they propagate it.


### PR DESCRIPTION
## Summary
- add HTTP request-id middleware and X-Request-ID response propagation
- add structured backend logging for auth, trade, and order-cancel flows
- document the observability contract and add backend coverage for request-id propagation and logging

## Validation
- python -m ruff check backend/app
- python -m black --check backend/app backend/alembic/versions
- python -m pytest -q backend/app/tests/test_api.py

## UI / Browser QC
- No visible UI changes in this tranche
- Browser QC intentionally skipped

## Notes
- Request completion logs now retain the request id on successful responses
- Structured logs intentionally avoid secrets, passwords, session cookies, and tokens