### PR TITLE
Add broker adapter observability events

### DIFF
--- a/backend/app/adapters/broker.py
+++ b/backend/app/adapters/broker.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 import httpx
 
 from app.core.config import Settings
+from app.core.observability import log_event, request_log_fields
 
 
 @dataclass
@@ -247,6 +248,17 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         self._account_summary_cache: tuple[float, dict[str, float]] | None = None
         self._recent_orders_cache: tuple[float, int, list[dict]] | None = None
 
+    def _log_event(self, event: str, level: str = "info", **fields: object) -> None:
+        log_event(
+            event,
+            level=level,
+            **request_log_fields(
+                adapter="alpaca",
+                broker_mode=self.settings.broker_mode,
+                **fields,
+            ),
+        )
+
     def _client(self) -> httpx.Client:
         self._ensure_execution_allowed()
         return httpx.Client(
@@ -266,9 +278,30 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         if not self.settings.live_confirmation_token:
             raise ValueError("Live trading confirmation token is not configured")
 
-    def _fallback_or_raise(self, fallback_status: str, message: str) -> BrokerOrderResult:
+    def _fallback_or_raise(
+        self,
+        event_base: str,
+        fallback_status: str,
+        message: str,
+        **fields: object,
+    ) -> BrokerOrderResult:
         if self.settings.allow_controller_mock:
+            self._log_event(
+                f"{event_base}.fallback",
+                level="warning",
+                outcome="fallback",
+                fallback_status=fallback_status,
+                detail=message,
+                **fields,
+            )
             return BrokerOrderResult(None, fallback_status)
+        self._log_event(
+            f"{event_base}.failed",
+            level="error",
+            outcome="error",
+            detail=message,
+            **fields,
+        )
         raise ValueError(message)
 
     def _extract_http_error_message(self, prefix: str, exc: httpx.HTTPError) -> str:
@@ -307,7 +340,14 @@ class AlpacaBrokerAdapter(BrokerAdapter):
     def place_entry_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
-                "FILLED", "Alpaca paper credentials are missing for broker execution"
+                "broker.entry.submit",
+                "FILLED",
+                "Alpaca paper credentials are missing for broker execution",
+                symbol=order.symbol,
+                side=order.side,
+                order_type=order.order_type,
+                time_in_force=order.time_in_force,
+                order_class=order.order_class,
             )
         payload: dict[str, object] = {
             "symbol": order.symbol,
@@ -338,8 +378,26 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 data = response.json()
         except httpx.HTTPError as exc:
             return self._fallback_or_raise(
-                "FILLED", self._extract_http_error_message("Alpaca market order failed", exc)
+                "broker.entry.submit",
+                "FILLED",
+                self._extract_http_error_message("Alpaca market order failed", exc),
+                symbol=order.symbol,
+                side=order.side,
+                order_type=order.order_type,
+                time_in_force=order.time_in_force,
+                order_class=order.order_class,
             )
+        self._log_event(
+            "broker.entry.submit",
+            symbol=order.symbol,
+            side=order.side,
+            order_type=order.order_type,
+            time_in_force=order.time_in_force,
+            order_class=order.order_class,
+            broker_order_id=data.get("id"),
+            status=str(data.get("status", "accepted")).upper(),
+            outcome="success",
+        )
         return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper(), data)
 
     def place_market_order(
@@ -356,7 +414,13 @@ class AlpacaBrokerAdapter(BrokerAdapter):
     ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
-                "ACTIVE", "Alpaca paper credentials are missing for stop execution"
+                "broker.stop.submit",
+                "ACTIVE",
+                "Alpaca paper credentials are missing for stop execution",
+                symbol=symbol,
+                side=side,
+                qty=qty,
+                stop_price=stop_price,
             )
         result = self.place_entry_order(
             BrokerEntryOrder(
@@ -381,7 +445,14 @@ class AlpacaBrokerAdapter(BrokerAdapter):
     ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
-                "FILLED", "Alpaca paper credentials are missing for profit execution"
+                "broker.limit.submit",
+                "FILLED",
+                "Alpaca paper credentials are missing for profit execution",
+                symbol=symbol,
+                side=side,
+                qty=qty,
+                limit_price=limit_price,
+                time_in_force=time_in_force,
             )
         return self.place_entry_order(
             BrokerEntryOrder(
@@ -400,7 +471,14 @@ class AlpacaBrokerAdapter(BrokerAdapter):
     ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
-                "ACTIVE", "Alpaca paper credentials are missing for runner execution"
+                "broker.trailing.submit",
+                "ACTIVE",
+                "Alpaca paper credentials are missing for runner execution",
+                symbol=symbol,
+                side=side,
+                qty=qty,
+                trail=trail,
+                trail_unit=trail_unit,
             )
         payload = {
             "symbol": symbol,
@@ -420,14 +498,35 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 data = response.json()
         except httpx.HTTPError as exc:
             return self._fallback_or_raise(
-                "ACTIVE", self._extract_http_error_message("Alpaca trailing stop failed", exc)
+                "broker.trailing.submit",
+                "ACTIVE",
+                self._extract_http_error_message("Alpaca trailing stop failed", exc),
+                symbol=symbol,
+                side=side,
+                qty=qty,
+                trail=trail,
+                trail_unit=trail_unit,
             )
+        self._log_event(
+            "broker.trailing.submit",
+            symbol=symbol,
+            side=side,
+            qty=qty,
+            trail=trail,
+            trail_unit=trail_unit,
+            broker_order_id=data.get("id"),
+            status=str(data.get("status", "new")).upper(),
+            outcome="success",
+        )
         return BrokerOrderResult(data.get("id"), str(data.get("status", "new")).upper())
 
     def close_position(self, symbol: str) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
             return self._fallback_or_raise(
-                "FILLED", "Alpaca paper credentials are missing for flatten execution"
+                "broker.position.close",
+                "FILLED",
+                "Alpaca paper credentials are missing for flatten execution",
+                symbol=symbol,
             )
         try:
             with self._client() as client:
@@ -436,8 +535,18 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 data = response.json()
         except httpx.HTTPError as exc:
             return self._fallback_or_raise(
-                "FILLED", self._extract_http_error_message("Alpaca close position failed", exc)
+                "broker.position.close",
+                "FILLED",
+                self._extract_http_error_message("Alpaca close position failed", exc),
+                symbol=symbol,
             )
+        self._log_event(
+            "broker.position.close",
+            symbol=symbol,
+            broker_order_id=data.get("id"),
+            outcome="success",
+            status="FILLED",
+        )
         return BrokerOrderResult(data.get("id"), "FILLED")
 
     def wait_for_position(
@@ -445,28 +554,92 @@ class AlpacaBrokerAdapter(BrokerAdapter):
     ) -> int:
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.position.wait.fallback",
+                    level="warning",
+                    symbol=symbol,
+                    min_qty=min_qty,
+                    timeout_seconds=timeout_seconds,
+                    outcome="fallback",
+                )
                 return min_qty
-            raise ValueError("Alpaca paper credentials are missing for broker position checks")
+            message = "Alpaca paper credentials are missing for broker position checks"
+            self._log_event(
+                "broker.position.wait.failed",
+                level="error",
+                symbol=symbol,
+                min_qty=min_qty,
+                timeout_seconds=timeout_seconds,
+                outcome="error",
+                detail=message,
+            )
+            raise ValueError(message)
         import time
 
         end_time = time.monotonic() + timeout_seconds
         last_error: str | None = None
+        attempts = 0
         while time.monotonic() < end_time:
+            attempts += 1
             try:
                 with self._client() as client:
                     response = client.get(f"/v2/positions/{symbol}")
                     if response.status_code == 404:
+                        self._log_event(
+                            "broker.position.wait.retry",
+                            symbol=symbol,
+                            min_qty=min_qty,
+                            attempt=attempts,
+                            outcome="retry",
+                            detail="Broker position not available yet",
+                        )
                         time.sleep(0.5)
                         continue
                     response.raise_for_status()
                     data = response.json()
                 qty = int(float(data.get("qty", 0)))
                 if qty >= min_qty:
+                    self._log_event(
+                        "broker.position.wait.succeeded",
+                        symbol=symbol,
+                        min_qty=min_qty,
+                        qty=qty,
+                        attempts=attempts,
+                        outcome="success",
+                    )
                     return qty
                 last_error = f"Broker position quantity {qty} is below expected {min_qty}"
+                self._log_event(
+                    "broker.position.wait.retry",
+                    symbol=symbol,
+                    min_qty=min_qty,
+                    qty=qty,
+                    attempt=attempts,
+                    outcome="retry",
+                    detail=last_error,
+                )
             except httpx.HTTPError as exc:
                 last_error = self._extract_http_error_message("Alpaca position lookup failed", exc)
+                self._log_event(
+                    "broker.position.wait.retry",
+                    level="warning",
+                    symbol=symbol,
+                    min_qty=min_qty,
+                    attempt=attempts,
+                    outcome="retry",
+                    detail=last_error,
+                )
             time.sleep(0.5)
+        self._log_event(
+            "broker.position.wait.failed",
+            level="error",
+            symbol=symbol,
+            min_qty=min_qty,
+            attempts=attempts,
+            timeout_seconds=timeout_seconds,
+            outcome="error",
+            detail=last_error or f"Broker position for {symbol} is not available yet",
+        )
         raise ValueError(last_error or f"Broker position for {symbol} is not available yet")
 
     def cancel_order(self, broker_order_id: str) -> None:
@@ -474,20 +647,61 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.order.cancel.fallback",
+                    level="warning",
+                    broker_order_id=broker_order_id,
+                    outcome="fallback",
+                )
                 return
-            raise ValueError("Alpaca paper credentials are missing for broker order cancellation")
+            message = "Alpaca paper credentials are missing for broker order cancellation"
+            self._log_event(
+                "broker.order.cancel.failed",
+                level="error",
+                broker_order_id=broker_order_id,
+                outcome="error",
+                detail=message,
+            )
+            raise ValueError(message)
         try:
             with self._client() as client:
                 response = client.delete(f"/v2/orders/{broker_order_id}")
                 if response.status_code in {404, 422}:
+                    self._log_event(
+                        "broker.order.cancel",
+                        broker_order_id=broker_order_id,
+                        outcome="noop",
+                        status=response.status_code,
+                    )
                     return
                 response.raise_for_status()
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.order.cancel.fallback",
+                    level="warning",
+                    broker_order_id=broker_order_id,
+                    outcome="fallback",
+                    detail=self._extract_http_error_message(
+                        "Alpaca order cancellation failed", exc
+                    ),
+                )
                 return
+            self._log_event(
+                "broker.order.cancel.failed",
+                level="error",
+                broker_order_id=broker_order_id,
+                outcome="error",
+                detail=self._extract_http_error_message("Alpaca order cancellation failed", exc),
+            )
             raise ValueError(
                 self._extract_http_error_message("Alpaca order cancellation failed", exc)
             ) from exc
+        self._log_event(
+            "broker.order.cancel",
+            broker_order_id=broker_order_id,
+            outcome="success",
+        )
 
     def list_recent_orders(self, limit: int = 50) -> list[dict]:
         import time
@@ -499,8 +713,22 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 return [dict(order) for order in cached_payload[:limit]]
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.orders.recent.fallback",
+                    level="warning",
+                    limit=limit,
+                    outcome="fallback",
+                )
                 return []
-            raise ValueError("Alpaca paper credentials are missing for broker order lookup")
+            message = "Alpaca paper credentials are missing for broker order lookup"
+            self._log_event(
+                "broker.orders.recent.failed",
+                level="error",
+                limit=limit,
+                outcome="error",
+                detail=message,
+            )
+            raise ValueError(message)
         try:
             with self._client() as client:
                 response = client.get(
@@ -510,7 +738,23 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 payload = response.json()
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.orders.recent.fallback",
+                    level="warning",
+                    limit=limit,
+                    outcome="fallback",
+                    detail=self._extract_http_error_message(
+                        "Alpaca recent orders lookup failed", exc
+                    ),
+                )
                 return []
+            self._log_event(
+                "broker.orders.recent.failed",
+                level="error",
+                limit=limit,
+                outcome="error",
+                detail=self._extract_http_error_message("Alpaca recent orders lookup failed", exc),
+            )
             raise ValueError(
                 self._extract_http_error_message("Alpaca recent orders lookup failed", exc)
             ) from exc
@@ -523,18 +767,51 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return None
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.order.lookup.fallback",
+                    level="warning",
+                    broker_order_id=broker_order_id,
+                    outcome="fallback",
+                )
                 return None
-            raise ValueError("Alpaca paper credentials are missing for broker order lookup")
+            message = "Alpaca paper credentials are missing for broker order lookup"
+            self._log_event(
+                "broker.order.lookup.failed",
+                level="error",
+                broker_order_id=broker_order_id,
+                outcome="error",
+                detail=message,
+            )
+            raise ValueError(message)
         try:
             with self._client() as client:
                 response = client.get(f"/v2/orders/{broker_order_id}")
                 if response.status_code == 404:
+                    self._log_event(
+                        "broker.order.lookup",
+                        broker_order_id=broker_order_id,
+                        outcome="not_found",
+                    )
                     return None
                 response.raise_for_status()
                 payload = response.json()
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.order.lookup.fallback",
+                    level="warning",
+                    broker_order_id=broker_order_id,
+                    outcome="fallback",
+                    detail=self._extract_http_error_message("Alpaca order lookup failed", exc),
+                )
                 return None
+            self._log_event(
+                "broker.order.lookup.failed",
+                level="error",
+                broker_order_id=broker_order_id,
+                outcome="error",
+                detail=self._extract_http_error_message("Alpaca order lookup failed", exc),
+            )
             raise ValueError(
                 self._extract_http_error_message("Alpaca order lookup failed", exc)
             ) from exc
@@ -543,8 +820,20 @@ class AlpacaBrokerAdapter(BrokerAdapter):
     def get_session_state(self) -> str:
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.session.lookup.fallback",
+                    level="warning",
+                    outcome="fallback",
+                )
                 return "regular_open"
-            raise ValueError("Alpaca paper credentials are missing for broker clock checks")
+            message = "Alpaca paper credentials are missing for broker clock checks"
+            self._log_event(
+                "broker.session.lookup.failed",
+                level="error",
+                outcome="error",
+                detail=message,
+            )
+            raise ValueError(message)
         try:
             with self._client() as client:
                 response = client.get("/v2/clock")
@@ -556,7 +845,21 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return self._session_state_from_timestamp(timestamp or datetime.now(UTC))
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.session.lookup.fallback",
+                    level="warning",
+                    outcome="fallback",
+                    detail=self._extract_http_error_message(
+                        "Alpaca market clock lookup failed", exc
+                    ),
+                )
                 return "regular_open"
+            self._log_event(
+                "broker.session.lookup.failed",
+                level="error",
+                outcome="error",
+                detail=self._extract_http_error_message("Alpaca market clock lookup failed", exc),
+            )
             raise ValueError(
                 self._extract_http_error_message("Alpaca market clock lookup failed", exc)
             ) from exc
@@ -571,8 +874,20 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 return dict(payload)
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.account.lookup.fallback",
+                    level="warning",
+                    outcome="fallback",
+                )
                 return None
-            raise ValueError("Alpaca paper credentials are missing for broker account lookup")
+            message = "Alpaca paper credentials are missing for broker account lookup"
+            self._log_event(
+                "broker.account.lookup.failed",
+                level="error",
+                outcome="error",
+                detail=message,
+            )
+            raise ValueError(message)
         try:
             with self._client() as client:
                 response = client.get("/v2/account")
@@ -580,7 +895,19 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 payload = response.json()
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
+                self._log_event(
+                    "broker.account.lookup.fallback",
+                    level="warning",
+                    outcome="fallback",
+                    detail=self._extract_http_error_message("Alpaca account lookup failed", exc),
+                )
                 return None
+            self._log_event(
+                "broker.account.lookup.failed",
+                level="error",
+                outcome="error",
+                detail=self._extract_http_error_message("Alpaca account lookup failed", exc),
+            )
             raise ValueError(
                 self._extract_http_error_message("Alpaca account lookup failed", exc)
             ) from exc

--- a/backend/app/adapters/market_data.py
+++ b/backend/app/adapters/market_data.py
@@ -9,6 +9,7 @@ import time
 import httpx
 
 from app.core.config import Settings
+from app.core.observability import log_event, request_log_fields
 
 MOCK_MARKET_DATA: dict[str, dict[str, float]] = {
     "AAPL": {
@@ -100,6 +101,17 @@ class AlpacaPolygonMarketDataAdapter:
         self._market_tz = ZoneInfo("America/New_York")
         self._setup_cache: dict[str, tuple[float, SetupMarketData]] = {}
 
+    def _log_event(self, event: str, level: str = "info", **fields: object) -> None:
+        log_event(
+            event,
+            level=level,
+            **request_log_fields(
+                provider="alpaca_market_data",
+                broker_mode=self.settings.broker_mode,
+                **fields,
+            ),
+        )
+
     def _data_client(self) -> httpx.Client:
         return httpx.Client(
             base_url=self.settings.alpaca_data_base_url,
@@ -122,7 +134,23 @@ class AlpacaPolygonMarketDataAdapter:
 
     def _fail_or_fallback(self, symbol: str, reason: str, message: str) -> SetupMarketData:
         if self.settings.allow_controller_mock:
+            self._log_event(
+                "market_data.setup.fallback",
+                level="warning",
+                symbol=symbol.upper(),
+                reason=reason,
+                outcome="fallback",
+                detail=message,
+            )
             return self.fallback.get_setup_data(symbol, fallback_reason=reason)
+        self._log_event(
+            "market_data.setup.failed",
+            level="error",
+            symbol=symbol.upper(),
+            reason=reason,
+            outcome="error",
+            detail=message,
+        )
         raise ValueError(message)
 
     def _parse_quote_timestamp(self, raw: str | None) -> datetime | None:

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -5,6 +5,7 @@ import logging
 import os
 from pathlib import Path
 
+import httpx
 import pytest
 from sqlalchemy import select
 
@@ -22,8 +23,8 @@ os.environ["AUTH_REQUIRE_LOGIN"] = "false"
 
 from fastapi.testclient import TestClient  # noqa: E402
 
-from app.adapters.broker import AlpacaBrokerAdapter  # noqa: E402
-from app.adapters.market_data import SetupMarketData  # noqa: E402
+from app.adapters.broker import AlpacaBrokerAdapter, BrokerEntryOrder  # noqa: E402
+from app.adapters.market_data import AlpacaPolygonMarketDataAdapter, SetupMarketData  # noqa: E402
 from app.db.base import Base  # noqa: E402
 from app.db.session import SessionLocal, engine  # noqa: E402
 from app.main import app, service  # noqa: E402
@@ -36,7 +37,11 @@ from app.models.entities import (  # noqa: E402
 from app.schemas.cockpit import TrancheMode  # noqa: E402
 from app.services.auth import FAILED_LOGIN_LIMIT, get_auth_store  # noqa: E402
 from app.core.config import Settings, _normalize_database_url  # noqa: E402
-from app.core.observability import REQUEST_ID_HEADER  # noqa: E402
+from app.core.observability import (  # noqa: E402
+    REQUEST_ID_HEADER,
+    bind_request_id,
+    reset_request_id,
+)
 from app.api import deps_auth  # noqa: E402
 from app import main as main_module  # noqa: E402
 
@@ -263,6 +268,129 @@ def test_alpaca_market_order_fails_loudly_without_mock_fallback(
     adapter = AlpacaBrokerAdapter(Settings.from_env())
     with pytest.raises(ValueError, match="credentials are missing"):
         adapter.place_market_order("MSFT", 10, "buy")
+
+
+def test_alpaca_entry_fallback_logs_structured_event(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("BROKER_MODE", "alpaca_paper")
+    monkeypatch.setenv("ALLOW_CONTROLLER_MOCK", "true")
+    monkeypatch.delenv("ALPACA_API_KEY_ID", raising=False)
+    monkeypatch.delenv("ALPACA_API_SECRET_KEY", raising=False)
+
+    adapter = AlpacaBrokerAdapter(Settings.from_env())
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+    token = bind_request_id("req-broker-fallback-1")
+    try:
+        result = adapter.place_entry_order(
+            BrokerEntryOrder(
+                symbol="MSFT",
+                qty=10,
+                side="buy",
+                order_type="limit",
+                time_in_force="day",
+                limit_price=380.5,
+            )
+        )
+    finally:
+        reset_request_id(token)
+
+    assert result.status == "FILLED"
+    events = structured_events(caplog)
+    fallback_event = next(
+        event for event in events if event.get("event") == "broker.entry.submit.fallback"
+    )
+    assert fallback_event["request_id"] == "req-broker-fallback-1"
+    assert fallback_event["symbol"] == "MSFT"
+    assert fallback_event["order_type"] == "limit"
+    assert fallback_event["fallback_status"] == "FILLED"
+    assert fallback_event["outcome"] == "fallback"
+
+
+def test_market_data_fallback_logs_structured_event(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("BROKER_MODE", "alpaca_paper")
+    monkeypatch.setenv("ALLOW_CONTROLLER_MOCK", "true")
+    monkeypatch.delenv("ALPACA_API_KEY_ID", raising=False)
+    monkeypatch.delenv("ALPACA_API_SECRET_KEY", raising=False)
+
+    adapter = AlpacaPolygonMarketDataAdapter(Settings.from_env())
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+    token = bind_request_id("req-market-fallback-1")
+    try:
+        payload = adapter.get_setup_data("MSFT")
+    finally:
+        reset_request_id(token)
+
+    assert payload.provider == "mock"
+    events = structured_events(caplog)
+    fallback_event = next(
+        event for event in events if event.get("event") == "market_data.setup.fallback"
+    )
+    assert fallback_event["request_id"] == "req-market-fallback-1"
+    assert fallback_event["symbol"] == "MSFT"
+    assert fallback_event["reason"] == "alpaca_credentials_missing"
+    assert fallback_event["outcome"] == "fallback"
+
+
+def test_wait_for_position_logs_retry_and_success(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import time
+
+    monkeypatch.setenv("BROKER_MODE", "alpaca_paper")
+    monkeypatch.setenv("ALLOW_CONTROLLER_MOCK", "false")
+    monkeypatch.setenv("ALPACA_API_KEY_ID", "paper-key")
+    monkeypatch.setenv("ALPACA_API_SECRET_KEY", "paper-secret")
+
+    adapter = AlpacaBrokerAdapter(Settings.from_env())
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    responses = [
+        httpx.Response(404, request=httpx.Request("GET", "https://example.test/v2/positions/MSFT")),
+        httpx.Response(
+            200,
+            request=httpx.Request("GET", "https://example.test/v2/positions/MSFT"),
+            json={"qty": "5"},
+        ),
+    ]
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, _url: str):
+            return responses.pop(0)
+
+    monkeypatch.setattr(adapter, "_client", lambda: FakeClient())
+    token = bind_request_id("req-wait-1")
+    try:
+        qty = adapter.wait_for_position("MSFT", min_qty=5, timeout_seconds=1.0)
+    finally:
+        reset_request_id(token)
+
+    assert qty == 5
+    events = structured_events(caplog)
+    retry_event = next(
+        event for event in events if event.get("event") == "broker.position.wait.retry"
+    )
+    success_event = next(
+        event for event in events if event.get("event") == "broker.position.wait.succeeded"
+    )
+    assert retry_event["request_id"] == "req-wait-1"
+    assert retry_event["symbol"] == "MSFT"
+    assert retry_event["attempt"] == 1
+    assert retry_event["outcome"] == "retry"
+    assert success_event["request_id"] == "req-wait-1"
+    assert success_event["symbol"] == "MSFT"
+    assert success_event["qty"] == 5
+    assert success_event["attempts"] == 2
+    assert success_event["outcome"] == "success"
 
 
 def test_setup_fails_loudly_when_real_quote_is_unavailable() -> None:

--- a/docs/issues/2026-03-24-broker-adapter-observability.md
+++ b/docs/issues/2026-03-24-broker-adapter-observability.md
@@ -1,0 +1,50 @@
+# Broker Adapter Observability
+
+> Status: Open
+> Branch: `codex/feature-broker-adapter-observability`
+> Opened: 2026-03-24
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+Request-scoped logging now exists at the API layer, but broker-facing and market-data adapter failures still disappear into generic errors too easily.
+
+That leaves four operational blind spots:
+
+- quote/setup fallback reasons are not structured in logs
+- broker order submit failures are not emitted as structured events
+- broker cancel failures and broker lookup fallbacks are not emitted as structured events
+- retry-driven flows such as waiting for broker position fill are not easy to trace
+
+## Scope
+
+- add structured logs in broker adapters for submit, cancel, lookup, and retry/fallback paths
+- add structured logs in market-data adapter for setup/quote fallback paths
+- extend observability docs with broker and market-data event names
+- add backend tests for broker fallback/retry log behavior
+
+## Acceptance criteria
+
+- [x] broker submit failures emit structured events
+- [x] broker cancel failures and fallback/no-op paths emit structured events
+- [x] market-data setup fallback emits structured events
+- [x] broker wait/retry flow emits structured retry and success/failure events
+- [x] backend tests cover fallback and retry log behavior
+- [x] observability docs include the new event names
+
+## Risks / constraints
+
+- keep UI unchanged
+- do not log secrets, raw credentials, or full auth cookies
+- keep retry logging useful without becoming excessively noisy
+
+## Validation
+
+- `python -m ruff check backend/app`
+- `python -m black --check backend/app backend/alembic/versions`
+- `python -m pytest -q backend/app/tests/test_api.py`
+
+## Notes
+
+- Browser QC was intentionally skipped because this tranche has no visible UI change.

--- a/docs/process/OBSERVABILITY.md
+++ b/docs/process/OBSERVABILITY.md
@@ -41,6 +41,33 @@ This app uses a simple request-scoped observability contract for API troubleshoo
 - `trade.flatten`
 - `trade.move_to_be`
 - `orders.cancel`
+- `market_data.setup.fallback`
+- `market_data.setup.failed`
+- `broker.entry.submit`
+- `broker.entry.submit.fallback`
+- `broker.entry.submit.failed`
+- `broker.trailing.submit`
+- `broker.trailing.submit.fallback`
+- `broker.trailing.submit.failed`
+- `broker.position.wait.retry`
+- `broker.position.wait.succeeded`
+- `broker.position.wait.failed`
+- `broker.position.wait.fallback`
+- `broker.position.close`
+- `broker.position.close.fallback`
+- `broker.position.close.failed`
+- `broker.order.cancel`
+- `broker.order.cancel.fallback`
+- `broker.order.cancel.failed`
+- `broker.orders.recent.fallback`
+- `broker.orders.recent.failed`
+- `broker.order.lookup`
+- `broker.order.lookup.fallback`
+- `broker.order.lookup.failed`
+- `broker.session.lookup.fallback`
+- `broker.session.lookup.failed`
+- `broker.account.lookup.fallback`
+- `broker.account.lookup.failed`
 
 ## Logging safety rules
 
@@ -56,4 +83,6 @@ This app uses a simple request-scoped observability contract for API troubleshoo
    - auth issue -> `auth.*`
    - trade preview/entry/stops/profit/flatten -> `trade.*`
    - cancel issue -> `orders.cancel`
+   - broker submission/lookup/cancel issue -> `broker.*`
+   - setup quote or fallback issue -> `market_data.*`
 4. If the request never reached the app, check reverse-proxy or platform logs for the same request id if they propagate it.


### PR DESCRIPTION
## Summary
- add structured broker-adapter logs for submit, cancel, lookup, fallback, and retry paths
- add market-data setup fallback logs for real quote/setup failures
- extend backend tests for broker fallback and wait-retry observability
- document the new broker and market-data event names

## Validation
- python -m ruff check backend/app
- python -m black --check backend/app backend/alembic/versions
- python -m pytest -q backend/app/tests/test_api.py

## UI / Browser QC
- No visible UI changes in this tranche
- Browser QC intentionally skipped

## Notes
- request-scoped broker logs now inherit equest_id from the existing observability context
- retry logging is focused on meaningful broker wait transitions, not every internal poll branch