### PR TITLE
Add websocket observability correlation

### DIFF
--- a/backend/app/core/observability.py
+++ b/backend/app/core/observability.py
@@ -11,6 +11,7 @@ from fastapi import Request
 
 REQUEST_ID_HEADER = "X-Request-ID"
 _request_id_ctx: ContextVar[str | None] = ContextVar("request_id", default=None)
+_client_session_id_ctx: ContextVar[str | None] = ContextVar("client_session_id", default=None)
 logger = logging.getLogger("traders_cockpit")
 
 
@@ -23,18 +24,33 @@ def bind_request_id(request_id: str) -> Token[str | None]:
     return _request_id_ctx.set(request_id)
 
 
+def bind_client_session_id(client_session_id: str | None) -> Token[str | None]:
+    return _client_session_id_ctx.set(client_session_id)
+
+
 def reset_request_id(token: Token[str | None]) -> None:
     _request_id_ctx.reset(token)
+
+
+def reset_client_session_id(token: Token[str | None]) -> None:
+    _client_session_id_ctx.reset(token)
 
 
 def get_request_id() -> str | None:
     return _request_id_ctx.get()
 
 
+def get_client_session_id() -> str | None:
+    return _client_session_id_ctx.get()
+
+
 def request_log_fields(request: Request | None = None, **fields: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "request_id": get_request_id(),
     }
+    client_session_id = get_client_session_id()
+    if client_session_id is not None:
+        payload["client_session_id"] = client_session_id
     if request is not None:
         payload["method"] = request.method
         payload["path"] = request.url.path

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from contextlib import asynccontextmanager
 from time import perf_counter
+from uuid import uuid4
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi import Request
@@ -16,9 +17,11 @@ from app.api.routes_auth import router as auth_router
 from app.core.config import Settings
 from app.core.observability import (
     REQUEST_ID_HEADER,
+    bind_client_session_id,
     bind_request_id,
     log_event,
     request_log_fields,
+    reset_client_session_id,
     reset_request_id,
     resolve_request_id,
 )
@@ -142,11 +145,53 @@ def health_dependencies() -> JSONResponse:
 
 @app.websocket("/ws/cockpit")
 async def cockpit_ws(websocket: WebSocket) -> None:
+    websocket_id = uuid4().hex[:12]
+    client_session_id = (websocket.query_params.get("client_session_id") or "").strip() or None
+    connection_request_id = resolve_request_id(
+        websocket.query_params.get("request_id") or websocket.headers.get(REQUEST_ID_HEADER)
+    )
+    username: str | None = None
+    connected = False
+    connect_request_token = bind_request_id(connection_request_id)
+    connect_session_token = bind_client_session_id(client_session_id)
     try:
-        await require_websocket_session(websocket)
+        session = await require_websocket_session(websocket)
     except RuntimeError:
+        log_event(
+            "ws.auth.failed",
+            level="warning",
+            **request_log_fields(
+                path=websocket.url.path,
+                client_ip=websocket.client.host if websocket.client else None,
+                websocket_id=websocket_id,
+            ),
+        )
+        reset_client_session_id(connect_session_token)
+        reset_request_id(connect_request_token)
         return
-    await ws_manager.connect("cockpit", websocket)
+    username = str(session["user"]["username"])
+    log_event(
+        "ws.connect",
+        **request_log_fields(
+            path=websocket.url.path,
+            client_ip=websocket.client.host if websocket.client else None,
+            websocket_id=websocket_id,
+            username=username,
+            channel="cockpit",
+        ),
+    )
+    await ws_manager.connect(
+        "cockpit",
+        websocket,
+        metadata={
+            "websocket_id": websocket_id,
+            "username": username,
+            "client_session_id": client_session_id,
+        },
+    )
+    connected = True
+    reset_client_session_id(connect_session_token)
+    reset_request_id(connect_request_token)
     try:
         while True:
             raw = await websocket.receive_text()
@@ -154,9 +199,53 @@ async def cockpit_ws(websocket: WebSocket) -> None:
                 payload = json.loads(raw)
             except json.JSONDecodeError:
                 payload = {"action": "noop"}
-            if payload.get("action") == "subscribe_price":
-                with SessionLocal() as db:
-                    await service.publish_price_tick(db, str(payload.get("symbol", "")).upper())
+            action = str(payload.get("action") or "noop")
+            message_request_id = resolve_request_id(
+                payload.get("requestId") if isinstance(payload.get("requestId"), str) else None
+            )
+            message_client_session_id = (
+                str(payload.get("clientSessionId")).strip()
+                if payload.get("clientSessionId") not in (None, "")
+                else client_session_id
+            )
+            message_request_token = bind_request_id(message_request_id)
+            message_session_token = bind_client_session_id(message_client_session_id)
+            try:
+                log_event(
+                    "ws.message.received",
+                    **request_log_fields(
+                        path=websocket.url.path,
+                        client_ip=websocket.client.host if websocket.client else None,
+                        websocket_id=websocket_id,
+                        username=username,
+                        channel="cockpit",
+                        action=action,
+                        symbol=str(payload.get("symbol", "")).upper() or None,
+                    ),
+                )
+                if action == "subscribe_price":
+                    with SessionLocal() as db:
+                        await service.publish_price_tick(db, str(payload.get("symbol", "")).upper())
+            finally:
+                reset_client_session_id(message_session_token)
+                reset_request_id(message_request_token)
             await asyncio.sleep(0.05)
     except WebSocketDisconnect:
-        await ws_manager.disconnect("cockpit", websocket)
+        pass
+    finally:
+        if connected:
+            disconnect_token = bind_request_id(connection_request_id)
+            disconnect_session_token = bind_client_session_id(client_session_id)
+            log_event(
+                "ws.disconnect",
+                **request_log_fields(
+                    path=websocket.url.path,
+                    client_ip=websocket.client.host if websocket.client else None,
+                    websocket_id=websocket_id,
+                    username=username,
+                    channel="cockpit",
+                ),
+            )
+            reset_client_session_id(disconnect_session_token)
+            reset_request_id(disconnect_token)
+            await ws_manager.disconnect("cockpit", websocket)

--- a/backend/app/services/cockpit.py
+++ b/backend/app/services/cockpit.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from app.adapters.broker import AlpacaBrokerAdapter, BrokerEntryOrder, PaperBrokerAdapter
 from app.adapters.market_data import AlpacaPolygonMarketDataAdapter, SetupMarketData
 from app.core.config import Settings
+from app.core.observability import get_request_id
 from app.models.entities import AccountSettingsEntity, OrderEntity, PositionEntity, TradeLogEntity
 from app.schemas.cockpit import (
     AccountSettingsUpdate,
@@ -1499,12 +1500,16 @@ class CockpitService:
         return LogEntry.model_validate(row, from_attributes=True)
 
     def _event(self, event_type: str, **payload: object) -> dict[str, object]:
-        return {
+        event: dict[str, object] = {
             "type": event_type,
             "version": "2026-03-21",
             "timestamp": utcnow().isoformat(),
             **payload,
         }
+        request_id = get_request_id()
+        if request_id:
+            event["requestId"] = request_id
+        return event
 
     def _next_order_id(self, db: Session) -> str:
         persisted_max = 0

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import httpx
 import pytest
 from sqlalchemy import select
+from starlette.websockets import WebSocketDisconnect
 
 db_path = Path(__file__).resolve().parent / "test.db"
 if db_path.exists():
@@ -230,6 +231,28 @@ def test_request_completion_logs_include_request_context(
     assert request_event["path"] == "/health"
     assert request_event["status"] == 200
     assert isinstance(request_event["duration_ms"], float | int)
+
+
+def test_websocket_auth_failure_logs_request_context(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    previous = deps_auth.settings.auth_require_login
+    deps_auth.settings.auth_require_login = True
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+    try:
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect(
+                "/ws/cockpit?request_id=req-ws-auth-fail&client_session_id=ws-client-auth-fail"
+            ) as websocket:
+                websocket.receive_text()
+    finally:
+        deps_auth.settings.auth_require_login = previous
+
+    events = structured_events(caplog)
+    auth_event = next(event for event in events if event.get("event") == "ws.auth.failed")
+    assert auth_event["request_id"] == "req-ws-auth-fail"
+    assert auth_event["client_session_id"] == "ws-client-auth-fail"
+    assert auth_event["path"] == "/ws/cockpit"
 
 
 def test_postgres_urls_normalize_to_psycopg_driver() -> None:
@@ -685,6 +708,75 @@ def test_trade_preview_logs_request_scoped_event(caplog: pytest.LogCaptureFixtur
     assert preview_event["symbol"] == "AAPL"
     assert preview_event["order_type"] == "limit"
     assert preview_event["outcome"] == "success"
+
+
+def test_websocket_subscribe_logs_lifecycle_and_propagates_request_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.INFO, logger="traders_cockpit")
+    client.put(
+        "/api/account/settings",
+        json={"equity": 1000000, "risk_pct": 0.2, "mode": "paper"},
+    )
+    setup = client.get("/api/setup/AAPL").json()
+    enter = client.post(
+        "/api/trade/enter",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "lod",
+            "stopPrice": setup["finalStop"],
+            "trancheCount": 3,
+            "trancheModes": tranche_modes(),
+            "order": simple_entry_order(orderType="market"),
+        },
+    )
+    assert enter.status_code == 200
+
+    with client.websocket_connect(
+        "/ws/cockpit?request_id=req-ws-connect-1&client_session_id=ws-client-1"
+    ) as websocket:
+        websocket.send_text(
+            json.dumps(
+                {
+                    "action": "subscribe_price",
+                    "symbol": "AAPL",
+                    "requestId": "req-ws-message-1",
+                    "clientSessionId": "ws-client-1",
+                }
+            )
+        )
+        payload = json.loads(websocket.receive_text())
+
+    assert payload["type"] == "price_update"
+    assert payload["symbol"] == "AAPL"
+    assert payload["requestId"] == "req-ws-message-1"
+
+    events = structured_events(caplog)
+    connect_event = next(event for event in events if event.get("event") == "ws.connect")
+    message_event = next(event for event in events if event.get("event") == "ws.message.received")
+    broadcast_event = next(
+        event
+        for event in events
+        if event.get("event") == "ws.broadcast"
+        and event.get("event_type") == "price_update"
+        and event.get("request_id") == "req-ws-message-1"
+    )
+    disconnect_event = next(event for event in events if event.get("event") == "ws.disconnect")
+
+    assert connect_event["request_id"] == "req-ws-connect-1"
+    assert connect_event["client_session_id"] == "ws-client-1"
+    assert connect_event["channel"] == "cockpit"
+    assert message_event["request_id"] == "req-ws-message-1"
+    assert message_event["client_session_id"] == "ws-client-1"
+    assert message_event["action"] == "subscribe_price"
+    assert message_event["symbol"] == "AAPL"
+    assert broadcast_event["request_id"] == "req-ws-message-1"
+    assert broadcast_event["client_session_id"] == "ws-client-1"
+    assert broadcast_event["event_type"] == "price_update"
+    assert broadcast_event["symbol"] == "AAPL"
+    assert disconnect_event["request_id"] == "req-ws-connect-1"
+    assert disconnect_event["client_session_id"] == "ws-client-1"
 
 
 def test_trade_lifecycle() -> None:

--- a/backend/app/ws/manager.py
+++ b/backend/app/ws/manager.py
@@ -10,12 +10,15 @@ from uuid import uuid4
 from fastapi import WebSocket
 from redis.asyncio import Redis
 
+from app.core.observability import log_event, request_log_fields
+
 
 class WebSocketManager:
     def __init__(
         self, redis_url: str | None = None, channel_prefix: str = "traders-cockpit"
     ) -> None:
         self.connections: dict[str, set[WebSocket]] = defaultdict(set)
+        self.connection_metadata: dict[WebSocket, dict[str, Any]] = {}
         self._lock = asyncio.Lock()
         self._redis_url = redis_url
         self._channel_prefix = channel_prefix
@@ -47,18 +50,32 @@ class WebSocketManager:
             await self._redis.aclose()
             self._redis = None
 
-    async def connect(self, channel: str, websocket: WebSocket) -> None:
+    async def connect(
+        self, channel: str, websocket: WebSocket, metadata: dict[str, Any] | None = None
+    ) -> None:
         await websocket.accept()
         async with self._lock:
             self.connections[channel].add(websocket)
+            self.connection_metadata[websocket] = dict(metadata or {})
 
     async def disconnect(self, channel: str, websocket: WebSocket) -> None:
         async with self._lock:
             if channel in self.connections:
                 self.connections[channel].discard(websocket)
+            self.connection_metadata.pop(websocket, None)
 
     async def broadcast(self, channel: str, message: dict[str, Any]) -> None:
-        await self._emit_local(channel, message)
+        delivered = await self._emit_local(channel, message)
+        log_event(
+            "ws.broadcast",
+            **request_log_fields(
+                channel=channel,
+                event_type=str(message.get("type", "unknown")),
+                symbol=message.get("symbol"),
+                listener_count=delivered,
+                redis_enabled=self._redis is not None,
+            ),
+        )
         if self._redis is None:
             return
         try:
@@ -73,6 +90,15 @@ class WebSocketManager:
                 ),
             )
         except Exception:
+            log_event(
+                "ws.redis.publish.failed",
+                level="warning",
+                **request_log_fields(
+                    channel=channel,
+                    event_type=str(message.get("type", "unknown")),
+                    symbol=message.get("symbol"),
+                ),
+            )
             return
 
     async def _subscriber_loop(self) -> None:
@@ -99,15 +125,32 @@ class WebSocketManager:
             with suppress(Exception):
                 await pubsub.aclose()
 
-    async def _emit_local(self, channel: str, message: dict[str, Any]) -> None:
+    async def _emit_local(self, channel: str, message: dict[str, Any]) -> int:
         encoded = json.dumps(message)
         async with self._lock:
             targets = list(self.connections.get(channel, set()))
+            metadata = {
+                websocket: dict(self.connection_metadata.get(websocket, {}))
+                for websocket in targets
+            }
         for websocket in targets:
             try:
                 await websocket.send_text(encoded)
             except Exception:
+                connection_metadata = metadata.get(websocket, {})
+                log_event(
+                    "ws.send.failed",
+                    level="warning",
+                    **request_log_fields(
+                        channel=channel,
+                        event_type=str(message.get("type", "unknown")),
+                        symbol=message.get("symbol"),
+                        websocket_id=connection_metadata.get("websocket_id"),
+                        username=connection_metadata.get("username"),
+                    ),
+                )
                 await self.disconnect(channel, websocket)
+        return len(targets)
 
     def _redis_channel(self, channel: str) -> str:
         return f"{self._channel_prefix}:events:{channel}"

--- a/docs/issues/2026-03-24-websocket-observability.md
+++ b/docs/issues/2026-03-24-websocket-observability.md
@@ -1,0 +1,51 @@
+# Websocket and Correlation Observability
+
+> Status: Open
+> Branch: `codex/feature-websocket-observability`
+> Opened: 2026-03-24
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+HTTP requests now have request IDs and the broker/market-data adapters emit structured events, but websocket traffic is still weakly correlated.
+
+That leaves two real support gaps:
+
+- websocket connect, disconnect, auth rejection, and publish flows are not consistently logged
+- browser-triggered websocket events are harder to correlate with the originating request/session/user than normal HTTP flows
+
+## Scope
+
+- add websocket connection lifecycle logs
+- add correlation identifiers for websocket sessions/messages
+- include request/session/user context where available
+- document the websocket observability contract
+- add backend tests for websocket lifecycle logging where practical
+
+## Acceptance criteria
+
+- [x] websocket connect/disconnect/auth-failure events emit structured logs
+- [x] websocket publish flow emits structured logs with a stable websocket/session correlation id
+- [x] websocket events include enough context to correlate with user/session activity
+- [x] observability docs include websocket event names and troubleshooting notes
+- [x] backend validation passes for the tranche
+
+## Risks / constraints
+
+- keep visible UI unchanged
+- do not log secrets, auth cookies, or full payloads unnecessarily
+- keep websocket logging useful without flooding logs on every heartbeat/no-op
+
+## Validation
+
+- `python -m ruff check backend/app`
+- `python -m black --check backend/app backend/alembic/versions`
+- `python -m pytest -q backend/app/tests/test_api.py`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+
+## Notes
+
+- Browser QC was intentionally skipped because this tranche does not change the visible cockpit UI.

--- a/docs/process/OBSERVABILITY.md
+++ b/docs/process/OBSERVABILITY.md
@@ -68,6 +68,13 @@ This app uses a simple request-scoped observability contract for API troubleshoo
 - `broker.session.lookup.failed`
 - `broker.account.lookup.fallback`
 - `broker.account.lookup.failed`
+- `ws.auth.failed`
+- `ws.connect`
+- `ws.message.received`
+- `ws.broadcast`
+- `ws.disconnect`
+- `ws.send.failed`
+- `ws.redis.publish.failed`
 
 ## Logging safety rules
 
@@ -85,4 +92,12 @@ This app uses a simple request-scoped observability contract for API troubleshoo
    - cancel issue -> `orders.cancel`
    - broker submission/lookup/cancel issue -> `broker.*`
    - setup quote or fallback issue -> `market_data.*`
+   - websocket connect/subscribe/publish issue -> `ws.*`
 4. If the request never reached the app, check reverse-proxy or platform logs for the same request id if they propagate it.
+
+## Websocket correlation
+
+- The cockpit websocket now sends a stable `client_session_id` on connect and on outbound subscription messages.
+- Websocket subscription messages also send a per-message `requestId`.
+- Server-side websocket logs and websocket-triggered broker/service logs inherit that `requestId` and `client_session_id` where applicable.
+- Server-originated websocket event payloads may include `requestId` so browser-side support captures can be correlated back to backend logs.

--- a/frontend/components/Cockpit.tsx
+++ b/frontend/components/Cockpit.tsx
@@ -86,6 +86,13 @@ const DEFAULT_LAYOUT_STATE: LayoutState = {
   rightRailTopPct: 46,
 };
 
+function createClientId(prefix: string): string {
+  const value = typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `${prefix}-${value}`;
+}
+
 function readStoredJson<T>(key: string, fallback: T): T {
   if (typeof window === "undefined") return fallback;
   try {
@@ -267,6 +274,8 @@ export function Cockpit() {
   const setupRequestSeqRef = useRef(0);
   const setupAbortRef = useRef<AbortController | null>(null);
   const wsHasOpenedRef = useRef(false);
+  const wsClientSessionIdRef = useRef(createClientId("ws"));
+  const wsMessageSeqRef = useRef(0);
   const activeSymbolRef = useRef("");
   const setupLoadedRef = useRef(false);
   const stopModeRef = useRef(3);
@@ -446,7 +455,15 @@ export function Cockpit() {
 
   const subscribePrice = useCallback((symbol: string) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ action: "subscribe_price", symbol }));
+      wsMessageSeqRef.current += 1;
+      wsRef.current.send(
+        JSON.stringify({
+          action: "subscribe_price",
+          symbol,
+          requestId: `${wsClientSessionIdRef.current}-${wsMessageSeqRef.current}`,
+          clientSessionId: wsClientSessionIdRef.current,
+        })
+      );
     }
   }, []);
 
@@ -604,13 +621,25 @@ export function Cockpit() {
 
     const connect = () => {
       if (disposed) return;
-      const ws = new WebSocket(wsUrl);
+      const connectUrl = new URL(wsUrl);
+      connectUrl.searchParams.set("client_session_id", wsClientSessionIdRef.current);
+      wsMessageSeqRef.current += 1;
+      connectUrl.searchParams.set("request_id", `${wsClientSessionIdRef.current}-${wsMessageSeqRef.current}`);
+      const ws = new WebSocket(connectUrl.toString());
       wsRef.current = ws;
       ws.onopen = () => {
         reconnectDelay = 1000;
         setRuntimeError(null);
         if (activeSymbolRef.current) {
-          ws.send(JSON.stringify({ action: "subscribe_price", symbol: activeSymbolRef.current }));
+          wsMessageSeqRef.current += 1;
+          ws.send(
+            JSON.stringify({
+              action: "subscribe_price",
+              symbol: activeSymbolRef.current,
+              requestId: `${wsClientSessionIdRef.current}-${wsMessageSeqRef.current}`,
+              clientSessionId: wsClientSessionIdRef.current,
+            })
+          );
         }
         if (wsHasOpenedRef.current) {
           void hydrate({ autoSelectFirst: Boolean(activeSymbolRef.current) });


### PR DESCRIPTION
## Summary
- add websocket connection, auth-failure, message, broadcast, and disconnect structured logs
- propagate websocket equestId and client_session_id through backend observability context
- include websocket request ids in server-originated websocket event payloads
- add backend coverage for websocket auth failure and subscribe/broadcast lifecycle logging

## Validation
- python -m ruff check backend/app
- python -m black --check backend/app backend/alembic/versions
- python -m pytest -q backend/app/tests/test_api.py
- 
pm run lint
- 
pm run test
- 
pm run build

## UI / Browser QC
- No visible UI changes in this tranche
- Browser QC intentionally skipped

## Notes
- websocket-triggered broker/service logs now inherit both equest_id and client_session_id context where available
- the frontend websocket client now emits per-connection and per-message correlation ids without changing visible behavior