### PR TITLE
Add hosted post-deploy smoke and support runbooks

### DIFF
--- a/docs/issues/2026-03-24-hosted-ops-smoke-and-runbooks.md
+++ b/docs/issues/2026-03-24-hosted-ops-smoke-and-runbooks.md
@@ -1,0 +1,49 @@
+# Hosted Post-Deploy Smoke and Support Runbooks
+
+> Status: Open
+> Branch: `codex/feature-hosted-ops-smoke`
+> Opened: 2026-03-24
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The repo now has local QC, CI browser QC, and a hosted smoke wrapper, but the hosted operational path is still incomplete:
+
+- there is no single post-deploy smoke command that validates health endpoints and browser entry flow against a hosted stack
+- the release checklist does not explicitly require hosted smoke evidence after deploy
+- support guidance for recurring operational failures is scattered and incomplete
+
+That leaves production follow-through weak even after CI is green.
+
+## Scope
+
+- add a post-deploy smoke runner for hosted frontend/backend URLs
+- document the post-deploy smoke flow and expected evidence
+- add a support runbook for the known operational failures:
+  - blank page
+  - setup not loading
+  - pending order not cancelable
+  - broker quote unavailable
+- wire the new hosted smoke evidence into the release/promotion docs
+
+## Acceptance criteria
+
+- [x] hosted smoke can be executed from one documented command
+- [x] hosted smoke checks backend health before browser flow
+- [x] hosted smoke produces browser artifacts in the standard Playwright output path
+- [x] release docs explicitly require hosted smoke evidence after deploy
+- [x] support runbook exists for the recurring operational failure cases
+
+## Risks / constraints
+
+- keep the change scoped to deployment/ops readiness
+- do not reshape the cockpit UI
+- keep hosted smoke compatible with the existing browser smoke/auth flow
+
+## Validation
+
+- `python scripts/dev/check-secret-hygiene.py`
+- `powershell -ExecutionPolicy Bypass -File scripts/dev/start-local.ps1 -FrontendPort 3122 -FrontendProdPort 3222 -BackendPort 8122 -PostgresPort 55522 -RedisPort 56422`
+- `powershell -ExecutionPolicy Bypass -File scripts/dev/run-hosted-smoke.ps1 -FrontendUrl http://127.0.0.1:3122 -BackendUrl http://127.0.0.1:8122 -EnvFile .env.production.example -AuthUsername admin -AuthPassword change-me-admin`
+- `powershell -ExecutionPolicy Bypass -File scripts/dev/stop-local.ps1 -FrontendPort 3122 -BackendPort 8122 -PostgresPort 55522 -RedisPort 56422`

--- a/docs/process/HOSTED_DEPLOYMENT.md
+++ b/docs/process/HOSTED_DEPLOYMENT.md
@@ -4,6 +4,11 @@ Hosted deployment is a trailing deliverable. Validate the local paper-trading pa
 
 Use `.env.production.example` as the public hosted config contract. Copy it to a private env file, fill in real values, and keep `.env.example` reserved for deterministic local development.
 
+Supporting docs:
+
+- [Post-Deploy Smoke](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit-hosted-ops/docs/process/POST_DEPLOY_SMOKE.md)
+- [Support Runbook](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit-hosted-ops/docs/process/SUPPORT_RUNBOOK.md)
+
 ## Recommended Topology
 
 - Frontend: Vercel
@@ -126,11 +131,12 @@ For local validation of the wrapper against a non-hosted stack, you can override
 
 Expected artifacts:
 
+- `frontend/output/playwright/hosted-smoke.health.json`
 - `frontend/output/playwright/hosted-smoke.png`
 - `frontend/output/playwright/hosted-smoke.console.txt`
 - `frontend/output/playwright/hosted-smoke.network.txt`
 
-The hosted smoke reuses the same login and setup-load browser path as the local smoke flow, but points it at the hosted frontend/backend pair you provide.
+The hosted smoke now validates the hosted env contract, checks `/health/live`, `/health/ready`, and `/health/deps`, writes a health artifact, and then reuses the same login and setup-load browser path as the local smoke flow against the hosted frontend/backend pair you provide.
 
 ## Hosted Auth Persistence
 
@@ -147,5 +153,6 @@ Local development can still use `AUTH_STORAGE_MODE=file` with `AUTH_DB_PATH`, bu
 2. Confirm `/health/live` and `/health/ready` both work.
 3. Configure frontend public envs.
 4. Deploy frontend preview/staging.
-5. Run browser smoke against hosted URLs.
-6. Promote only after hosted smoke passes.
+5. Run hosted post-deploy smoke against the real URLs.
+6. Link the smoke artifacts in the release handoff or promotion PR.
+7. Promote only after hosted smoke passes.

--- a/docs/process/POST_DEPLOY_SMOKE.md
+++ b/docs/process/POST_DEPLOY_SMOKE.md
@@ -1,0 +1,55 @@
+# Post-Deploy Smoke
+
+Use this after a hosted staging or production deploy. The goal is to prove that the deployed backend is alive, ready, dependency-clean, and that the hosted cockpit still completes the baseline login and setup-load browser path.
+
+## Command
+
+```powershell
+.\scripts\dev\run-hosted-smoke.ps1 `
+  -FrontendUrl "https://app.example.com" `
+  -BackendUrl "https://api.example.com" `
+  -EnvFile ".env.production.local"
+```
+
+For local validation of the wrapper against a disposable local stack, you may override the auth credentials explicitly:
+
+```powershell
+.\scripts\dev\run-hosted-smoke.ps1 `
+  -FrontendUrl "http://127.0.0.1:3092" `
+  -BackendUrl "http://127.0.0.1:8092" `
+  -EnvFile ".env.production.example" `
+  -AuthUsername "admin" `
+  -AuthPassword "change-me-admin"
+```
+
+## What it checks
+
+1. Validates the hosted env file with `check-hosted-env.ps1`.
+2. Calls backend health endpoints:
+   - `/health/live`
+   - `/health/ready`
+   - `/health/deps`
+3. Fails immediately if any health endpoint is non-200 or reports `status != ok`.
+4. Runs the hosted browser smoke against the provided frontend/backend URLs.
+
+## Required evidence
+
+The smoke is not complete unless all of these artifacts exist in `frontend/output/playwright/`:
+
+- `<label>.health.json`
+- `<label>.png`
+- `<label>.console.txt`
+- `<label>.network.txt`
+
+The default label is `hosted-smoke`, so the default artifact set is:
+
+- `frontend/output/playwright/hosted-smoke.health.json`
+- `frontend/output/playwright/hosted-smoke.png`
+- `frontend/output/playwright/hosted-smoke.console.txt`
+- `frontend/output/playwright/hosted-smoke.network.txt`
+
+## Promotion use
+
+- Required for hosted staging before opening a production promotion PR.
+- Required again after production deploy as post-merge verification evidence.
+- Link the resulting artifact set from the promotion PR or the release handoff.

--- a/docs/process/RELEASE_PROMOTION_CHECKLIST.md
+++ b/docs/process/RELEASE_PROMOTION_CHECKLIST.md
@@ -20,6 +20,7 @@ Use this checklist before opening or merging a promotion PR from `codex/integrat
 - browser QC evidence exists for visible UI changes
 - the five cockpit baseline screenshots are refreshed for cockpit-state work
 - production-facing UI work is promoted only after browser QC evidence is attached on the integration candidate
+- if the target is a hosted environment, post-deploy smoke evidence exists or is explicitly scheduled as the first post-merge verification step
 
 ## Release review questions
 
@@ -28,6 +29,7 @@ Use this checklist before opening or merging a promotion PR from `codex/integrat
 - are all schema or env changes reflected in docs
 - are any live-trading controls still safely gated
 - can this release be rolled back by reverting the promotion merge
+- is there a hosted smoke plan with frontend URL, backend URL, env file, and artifact destination
 
 ## After merge to `main`
 
@@ -44,5 +46,6 @@ Use this checklist before opening or merging a promotion PR from `codex/integrat
 
 - verify the promoted `main` commit is the same commit reviewed in the promotion PR
 - rerun the post-merge smoke or hosted-health checks required for the target environment
+- for hosted targets, rerun `.\scripts\dev\run-hosted-smoke.ps1` and retain `hosted-smoke.health.json`, screenshot, console, and network artifacts
 - confirm baseline artifacts and validation notes are still linked from the promotion PR
 - record any first-24-hour monitoring follow-up in `docs/handoffs/`

--- a/docs/process/STAGING_RELEASE_PLAYBOOK.md
+++ b/docs/process/STAGING_RELEASE_PLAYBOOK.md
@@ -7,6 +7,7 @@ Use this when `codex/integration-app` is being prepared for promotion into `main
 - feature work merged into `codex/integration-app`
 - open regressions or intentional deferrals documented in the promotion PR
 - env and schema changes reflected in `.env.example`, README, and migration docs
+- hosted target URLs and credentials prepared when the release will be deployed beyond local staging
 
 ## Required Commands
 
@@ -20,6 +21,15 @@ If Docker-based verification is needed:
 docker compose up --build
 ```
 
+If the target environment is hosted staging or production, run post-deploy smoke after deploy:
+
+```powershell
+.\scripts\dev\run-hosted-smoke.ps1 `
+  -FrontendUrl "https://app.example.com" `
+  -BackendUrl "https://api.example.com" `
+  -EnvFile ".env.production.local"
+```
+
 ## Required Browser Artifacts
 
 The following files must exist after QC:
@@ -30,6 +40,13 @@ The following files must exist after QC:
 - `frontend/output/playwright/baseline-protected.png`
 - `frontend/output/playwright/baseline-profit-flow.png`
 
+For hosted deploys, also require:
+
+- `frontend/output/playwright/hosted-smoke.health.json`
+- `frontend/output/playwright/hosted-smoke.png`
+- `frontend/output/playwright/hosted-smoke.console.txt`
+- `frontend/output/playwright/hosted-smoke.network.txt`
+
 ## Promotion Notes
 
 - merge feature branches into `codex/integration-app` first
@@ -37,6 +54,7 @@ The following files must exist after QC:
 - promote only from `codex/integration-app` into `main`
 - if rollback is needed, revert the promotion merge rather than rewriting history
 - production-facing UI work must include browser QC evidence on the integration branch before promotion
+- hosted releases require post-deploy smoke evidence before they are considered complete
 
 ## Merge Sequence
 

--- a/docs/process/SUPPORT_RUNBOOK.md
+++ b/docs/process/SUPPORT_RUNBOOK.md
@@ -1,0 +1,117 @@
+# Support Runbook
+
+Use this when a deployed cockpit is reachable but a core operator flow is failing. The first step for every case is to capture the current hosted smoke artifacts before changing anything.
+
+## Blank page
+
+Symptoms:
+
+- frontend loads a white or nearly empty page
+- browser console shows chunk or runtime failures
+- `/health/ready` is healthy but the UI shell does not render correctly
+
+Checks:
+
+1. Open the browser console and review the latest `<label>.console.txt` artifact.
+2. Confirm the frontend build matches the promoted commit.
+3. Confirm `NEXT_PUBLIC_API_BASE_URL` and `NEXT_PUBLIC_WS_URL` are set to the deployed backend.
+4. Check the latest network artifact for failing `/_next/` assets or `500` frontend document requests.
+
+Likely causes:
+
+- stale or partial frontend deploy
+- broken Next build artifact
+- wrong public backend or websocket URL
+
+Recovery:
+
+1. Redeploy the frontend from the promoted commit.
+2. Re-run hosted smoke.
+3. If the failure persists, revert the promotion merge and redeploy the last known-good frontend build.
+
+## Setup not loading
+
+Symptoms:
+
+- login works
+- cockpit shell renders
+- entering a ticker leaves setup panels empty or stuck in an idle state
+
+Checks:
+
+1. Confirm `hosted-smoke.health.json` reports `ready` and `deps` as `ok`.
+2. Inspect `<label>.network.txt` for failing setup, market, or websocket requests.
+3. Confirm backend `CORS_ORIGINS` includes the deployed frontend origin.
+4. Confirm provider credentials and broker mode are present in the hosted env.
+
+Likely causes:
+
+- backend readiness is degraded
+- CORS mismatch
+- broker/quote provider outage or missing credentials
+- websocket endpoint mismatch
+
+Recovery:
+
+1. Fix env drift first, especially CORS and public URL settings.
+2. Re-run hosted smoke after redeploying backend config.
+3. If provider dependencies are unhealthy, keep the deploy in paper-safe mode and document the incident in the release handoff.
+
+## Pending order not cancelable
+
+Symptoms:
+
+- recent orders show a cancel action
+- cancel returns an error or the order remains pending
+- browser QC previously passed, but live operator cancel is failing now
+
+Checks:
+
+1. Confirm backend health is still `ok`.
+2. Inspect backend logs for broker cancel failures and request IDs.
+3. Confirm the pending order still exists in the broker-backed order source.
+4. Review the latest browser network artifact for the cancel request status code.
+
+Likely causes:
+
+- broker-side order already changed state
+- stale local order reconciliation
+- runtime/backend deploy drift between frontend and backend revisions
+
+Recovery:
+
+1. Refresh recent orders from broker truth before retrying.
+2. If broker truth shows the order is already closed, let reconciliation clear it.
+3. If broker truth still shows pending, retry cancel once with the same request ID trail captured in logs.
+4. If reconciliation is broken, revert to the last known-good backend deploy.
+
+## Broker quote unavailable
+
+Symptoms:
+
+- setup loads partially but quote-driven values are missing or stale
+- fallback copy appears repeatedly
+- setup or preview actions degrade around quote-dependent math
+
+Checks:
+
+1. Inspect `/health/deps` for broker/provider dependency status.
+2. Confirm market-data credentials are present and valid.
+3. Review backend logs for broker quote lookup failures or fallback events.
+4. Check whether the system is already using fallback technicals intentionally.
+
+Likely causes:
+
+- provider outage
+- credential rotation drift
+- rate limiting or network failure to the quote source
+
+Recovery:
+
+1. Restore credential/config health first.
+2. If the provider is degraded, keep the app in paper-safe behavior and communicate that quotes are in fallback mode.
+3. Re-run hosted smoke after the dependency returns to `ok`.
+
+## Escalation rule
+
+If any one of these flows fails and cannot be recovered by config correction or redeploy of the promoted commit, revert the promotion merge and record the incident in `docs/handoffs/`.

--- a/scripts/dev/run-hosted-smoke.ps1
+++ b/scripts/dev/run-hosted-smoke.ps1
@@ -19,6 +19,7 @@ $repoRoot = Get-RepoRoot
 $profileEnv = Get-LocalProfileEnv -RepoRoot $repoRoot -EnvFile $EnvFile
 $frontendDir = Join-Path $repoRoot "frontend"
 $playwrightOutputDir = Join-Path $frontendDir "output\\playwright"
+$healthArtifact = Join-Path $playwrightOutputDir "$SmokeLabel.health.json"
 
 $env:FRONTEND_URL = $FrontendUrl
 $env:BACKEND_URL = $BackendUrl.TrimEnd("/")
@@ -35,12 +36,119 @@ $env:QC_AUTH_PASSWORD = if ($AuthPassword) {
   Get-ResolvedValue -EnvValues $profileEnv -Key "AUTH_ADMIN_PASSWORD" -Default "change-me-admin"
 }
 
+function Read-HttpErrorBody {
+  param($Exception)
+
+  if ($null -eq $Exception.Response) {
+    return ""
+  }
+
+  try {
+    $stream = $Exception.Response.GetResponseStream()
+    if ($null -eq $stream) {
+      return ""
+    }
+    $reader = New-Object System.IO.StreamReader($stream)
+    try {
+      return $reader.ReadToEnd()
+    } finally {
+      $reader.Dispose()
+    }
+  } catch {
+    return ""
+  }
+}
+
+function Invoke-HostedHealthCheck {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$Url,
+    [Parameter(Mandatory = $true)][string]$ExpectedKind
+  )
+
+  $requestId = "hosted-smoke-$Name-" + [Guid]::NewGuid().ToString("N").Substring(0, 8)
+  $bodyText = ""
+  $statusCode = 0
+
+  try {
+    $response = Invoke-WebRequest -UseBasicParsing -Uri $Url -Headers @{ "X-Request-ID" = $requestId } -TimeoutSec 10
+    $statusCode = [int]$response.StatusCode
+    $bodyText = $response.Content
+  } catch {
+    if ($_.Exception.Response) {
+      $statusCode = [int]$_.Exception.Response.StatusCode
+      $bodyText = Read-HttpErrorBody -Exception $_.Exception
+    } else {
+      throw
+    }
+  }
+
+  $payload = $null
+  if ($bodyText) {
+    try {
+      $payload = $bodyText | ConvertFrom-Json
+    } catch {
+      $payload = [ordered]@{ raw = $bodyText }
+    }
+  }
+
+  $issues = @()
+  if ($statusCode -ne 200) {
+    $issues += "expected HTTP 200 but received $statusCode"
+  }
+  if ($null -eq $payload) {
+    $issues += "missing JSON payload"
+  } else {
+    if ($payload.PSObject.Properties.Name -contains "kind" -and $payload.kind -ne $ExpectedKind) {
+      $issues += "expected payload kind '$ExpectedKind' but received '$($payload.kind)'"
+    }
+    if ($payload.PSObject.Properties.Name -contains "status" -and $payload.status -ne "ok") {
+      $issues += "expected payload status 'ok' but received '$($payload.status)'"
+    }
+  }
+
+  return [ordered]@{
+    name = $Name
+    url = $Url
+    requestId = $requestId
+    statusCode = $statusCode
+    ok = ($issues.Count -eq 0)
+    issues = $issues
+    payload = $payload
+  }
+}
+
 try {
+  New-Item -ItemType Directory -Force -Path $playwrightOutputDir | Out-Null
+
   Push-Location $repoRoot
   try {
     & (Join-Path $PSScriptRoot "check-hosted-env.ps1") -EnvFile $EnvFile
   } finally {
     Pop-Location
+  }
+
+  $backendBaseUrl = $env:BACKEND_URL
+  $healthChecks = @(
+    Invoke-HostedHealthCheck -Name "live" -Url "$backendBaseUrl/health/live" -ExpectedKind "live"
+    Invoke-HostedHealthCheck -Name "ready" -Url "$backendBaseUrl/health/ready" -ExpectedKind "ready"
+    Invoke-HostedHealthCheck -Name "deps" -Url "$backendBaseUrl/health/deps" -ExpectedKind "deps"
+  )
+  $healthReport = [ordered]@{
+    label = $SmokeLabel
+    checkedAt = (Get-Date).ToString("o")
+    frontendUrl = $FrontendUrl
+    backendUrl = $backendBaseUrl
+    checks = $healthChecks
+  }
+  $healthReport | ConvertTo-Json -Depth 20 | Set-Content -Path $healthArtifact -Encoding UTF8
+
+  $failedChecks = @($healthChecks | Where-Object { -not $_.ok })
+  if ($failedChecks.Count -gt 0) {
+    $failureSummary = ($failedChecks | ForEach-Object {
+      "$($_.name): $($_.issues -join '; ')"
+    }) -join "`n"
+    throw "Hosted smoke health checks failed.`n$failureSummary"
   }
 
   Push-Location $frontendDir
@@ -50,7 +158,7 @@ try {
     Pop-Location
   }
 
-  foreach ($suffix in @("png", "console.txt", "network.txt")) {
+  foreach ($suffix in @("health.json", "png", "console.txt", "network.txt")) {
     $artifact = Join-Path $playwrightOutputDir "$SmokeLabel.$suffix"
     if (-not (Test-Path $artifact)) {
       throw "Expected hosted smoke artifact was not created: $artifact"


### PR DESCRIPTION
## Summary
- add hosted smoke health checks and a machine-readable health artifact
- document post-deploy smoke and operator recovery runbooks
- require hosted smoke evidence in hosted release/promotion docs

## Issue
- docs/issues/2026-03-24-hosted-ops-smoke-and-runbooks.md

## Validation
- python scripts/dev/check-secret-hygiene.py
- powershell -ExecutionPolicy Bypass -File scripts/dev/start-local.ps1 -FrontendPort 3122 -FrontendProdPort 3222 -BackendPort 8122 -PostgresPort 55522 -RedisPort 56422
- powershell -ExecutionPolicy Bypass -File scripts/dev/run-hosted-smoke.ps1 -FrontendUrl http://127.0.0.1:3122 -BackendUrl http://127.0.0.1:8122 -EnvFile .env.production.example -AuthUsername admin -AuthPassword change-me-admin
- powershell -ExecutionPolicy Bypass -File scripts/dev/stop-local.ps1 -FrontendPort 3122 -BackendPort 8122 -PostgresPort 55522 -RedisPort 56422

## Evidence
- frontend/output/playwright/hosted-smoke.health.json
- frontend/output/playwright/hosted-smoke.png
- frontend/output/playwright/hosted-smoke.console.txt
- frontend/output/playwright/hosted-smoke.network.txt

## Known gaps
- this tranche does not add provider-specific hosted dashboards or alerting
- browser smoke still validates the baseline login/setup-load path, not a full live hosted trade lifecycle

## Rollback
- revert this PR merge from codex/integration-app