### PR TITLE
Fix browser QC terminal stop-state tolerance

### DIFF
--- a/docs/issues/2026-03-24-browser-qc-final-state-tolerance.md
+++ b/docs/issues/2026-03-24-browser-qc-final-state-tolerance.md
@@ -1,0 +1,39 @@
+# Browser QC Final Stop-State Tolerance
+
+> Status: Open
+> Branch: `codex/bugfix-browser-qc-final-state`
+> Opened: 2026-03-24
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The integration branch browser QC is failing in `scripts/dev/trade-flow-qc.mjs` even though the trade flow itself completes.
+
+The failing run ended with final stop statuses:
+
+- `["FILLED", "CANCELED", "CANCELED"]`
+
+That is a valid terminal paper-simulation outcome, but the QC script currently rejects it because the accepted final-state list is too narrow.
+
+## Scope
+
+- update the browser-QC trade-flow script to accept the additional valid terminal stop state
+- keep the fix limited to QC tolerance, not runtime trading behavior
+- rerun the real browser-QC harness locally against the patched branch
+
+## Acceptance criteria
+
+- [x] `scripts/dev/trade-flow-qc.mjs` accepts `["FILLED", "CANCELED", "CANCELED"]`
+- [x] local browser-QC passes on the patched branch
+- [ ] the fix is pushed in a dedicated `codex/bugfix-*` branch for merge into `codex/integration-app`
+
+## Risks / constraints
+
+- do not widen the accepted state set beyond what is justified by observed paper behavior
+- do not change backend trade semantics in this tranche
+- keep the change scoped so promotion can proceed once integration is green
+
+## Validation
+
+- `QC_FRONTEND_PORT=3142 QC_BACKEND_PORT=8142 python scripts/ci/run_browser_qc.py`

--- a/scripts/dev/trade-flow-qc.mjs
+++ b/scripts/dev/trade-flow-qc.mjs
@@ -220,6 +220,7 @@ try {
   const acceptableFinalStates = [
     JSON.stringify(["CANCELED", "CANCELED", "ACTIVE"]),
     JSON.stringify(["CANCELED", "CANCELED", "CANCELED"]),
+    JSON.stringify(["FILLED", "CANCELED", "CANCELED"]),
     JSON.stringify(["FILLED", "FILLED", "ACTIVE"]),
     JSON.stringify(["FILLED", "FILLED", "CANCELED"]),
     JSON.stringify(["FILLED", "FILLED", "FILLED"]),


### PR DESCRIPTION
## Summary
- accept the observed valid paper terminal stop state ['FILLED','CANCELED','CANCELED'] in trade-flow QC
- document the integration blocker in a scoped issue record
- keep the change limited to browser-QC tolerance only

## Validation
- QC_FRONTEND_PORT=3142 QC_BACKEND_PORT=8142 python scripts/ci/run_browser_qc.py
