### PR TITLE
feat: harden broker-truth reconciliation backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,16 +7,20 @@ AUTH_SESSION_TTL_HOURS=24
 AUTH_COOKIE_NAME=traders_cockpit_session
 AUTH_COOKIE_SAMESITE=lax
 AUTH_COOKIE_SECURE=false
+AUTH_REQUIRE_CSRF=false
+AUTH_CSRF_COOKIE_NAME=traders_cockpit_csrf
+AUTH_CSRF_HEADER_NAME=X-CSRF-Token
 AUTH_DB_PATH=./data/auth.db
 AUTH_SEED_USERS=true
 AUTH_ADMIN_USERNAME=admin
-AUTH_ADMIN_PASSWORD=admin123!
+AUTH_ADMIN_PASSWORD=change-me-admin
 AUTH_TRADER_USERNAME=trader
-AUTH_TRADER_PASSWORD=trader123!
+AUTH_TRADER_PASSWORD=change-me-trader
 
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8010
 NEXT_PUBLIC_WS_URL=ws://127.0.0.1:8010/ws/cockpit
 CORS_ORIGINS=http://127.0.0.1:3010,http://localhost:3010
+TRUSTED_ORIGINS=http://127.0.0.1:3010,http://localhost:3010
 
 DATABASE_URL=postgresql://traders_cockpit:traders_cockpit@127.0.0.1:55432/traders_cockpit
 REDIS_URL=redis://127.0.0.1:56379/0
@@ -24,12 +28,18 @@ REDIS_CHANNEL_PREFIX=traders-cockpit
 ALLOW_SQLITE_FALLBACK=false
 SQLITE_FALLBACK_URL=sqlite:///./data/traders_cockpit.db
 
-# Use BROKER_MODE=paper plus ALLOW_CONTROLLER_MOCK=true for deterministic tests and QC.
+# Use BROKER_MODE=paper or BROKER_MODE=sim_paper plus ALLOW_CONTROLLER_MOCK=true for deterministic tests and QC.
 # Use .env.personal-paper.local plus the Docker-local personal-paper scripts for real Alpaca paper trading.
 BROKER_MODE=paper
 ALLOW_LIVE_TRADING=false
 ALLOW_CONTROLLER_MOCK=true
 LIVE_CONFIRMATION_TOKEN=
+TRADING_ENABLED=true
+DISABLED_SYMBOLS=
+MAX_QUOTE_AGE_SECONDS=15
+RECONCILE_FAST_INTERVAL_SECONDS=3
+RECONCILE_SLOW_INTERVAL_SECONDS=20
+MAX_RECONCILE_AGE_SECONDS=45
 
 ALPACA_API_KEY_ID=
 ALPACA_API_SECRET_KEY=
@@ -51,3 +61,4 @@ MAX_OPEN_POSITIONS=6
 OPS_API_KEY=
 OPS_ADMIN_API_KEY=
 OPS_SIGNING_SECRET=
+WEBHOOK_SECRET_HEADER_NAME=X-Webhook-Secret

--- a/README.md
+++ b/README.md
@@ -49,7 +49,28 @@ See:
 
 ### Recommended Local Bootstrap
 
-For real local Alpaca paper trading, Docker + localhost is the canonical runtime:
+For day-to-day prototyping, use the hybrid local path:
+
+```powershell
+Copy-Item .env.personal-paper.example .env.personal-paper.local
+.\scripts\dev\start-hybrid-local-personal-paper.ps1
+```
+
+This starts:
+
+- Frontend locally on `3010`
+- Backend locally on `8010`
+- PostgreSQL in Docker on `55432`
+- Redis in Docker on `56379`
+
+Why this is the default development path:
+
+- much faster frontend/backend iteration
+- real Alpaca paper quote and execution path
+- same local Postgres/Redis persistence model
+- no full Docker image rebuild on each code change
+
+Use the full Docker-local path as the slower validation/signoff runtime:
 
 ```powershell
 Copy-Item .env.personal-paper.example .env.personal-paper.local
@@ -88,10 +109,22 @@ To stop the Docker-local personal-paper stack:
 .\scripts\dev\stop-docker-local-personal-paper.ps1
 ```
 
+To stop the hybrid local personal-paper stack:
+
+```powershell
+.\scripts\dev\stop-hybrid-local-personal-paper.ps1
+```
+
 To run the real Docker-local paper smoke flow:
 
 ```powershell
 .\scripts\dev\run-docker-local-paper-smoke.ps1 -StartStack -Build
+```
+
+To run the fast hybrid-local paper smoke flow:
+
+```powershell
+.\scripts\dev\run-hybrid-local-paper-smoke.ps1 -StartStack
 ```
 
 To validate and QC the script-driven personal-paper profile explicitly:
@@ -155,7 +188,7 @@ Copy `.env.example` to `.env` at the repo root and fill only the values you need
 Important defaults:
 
 - paper mode first for deterministic tests
-- Docker-local personal-paper mode is the primary runtime for real usage; hosted deploys come after local validation
+- hybrid local personal-paper mode is the primary development runtime; Docker-local personal-paper is the validation/signoff runtime
 - live mode disabled unless explicitly allowed
 - local session auth enabled by default
 - staged/hosted deployments should use `AUTH_COOKIE_SAMESITE=none` and `AUTH_COOKIE_SECURE=true` so the hosted frontend can authenticate against a separate backend origin

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ docker compose --env-file .env up --build -d
 | **Backend API** | http://127.0.0.1:8000 |
 | **API Docs (Swagger)** | http://127.0.0.1:8000/docs |
 
-Default login: `admin` / `admin123!`
+Default login: `admin` / `change-me-admin`
 
 ---
 
@@ -224,6 +224,8 @@ User Browser
 - `app/adapters/broker.py` — `PaperBrokerAdapter` (sim) and `AlpacaBrokerAdapter` (real execution)
 - `app/adapters/market_data.py` — Alpaca/Polygon quotes with deterministic fallback
 - `app/ws/manager.py` — Redis pub/sub fanout with single-process fallback
+- `scripts/dev/rebuild_position_projections.py` — rebuild projection payloads from current backend state
+- `scripts/dev/check_broker_paper_drift.py` — compare local broker-paper state with broker order truth and emit a pass/fail summary
 
 See [`docs/architecture/OVERVIEW.md`](docs/architecture/OVERVIEW.md) for a full breakdown.
 
@@ -276,7 +278,7 @@ Copy `.env.example` to `.env` and set the values you need. Most have safe defaul
 |---|---|---|
 | `AUTH_REQUIRE_LOGIN` | `true` | Enforce login before access |
 | `AUTH_ADMIN_USERNAME` | `admin` | Admin account username |
-| `AUTH_ADMIN_PASSWORD` | `admin123!` | **Change this in production** |
+| `AUTH_ADMIN_PASSWORD` | `change-me-admin` | **Change this in production** |
 | `AUTH_TRADER_USERNAME` | `trader` | Trader account username |
 | `AUTH_SESSION_TTL_HOURS` | `24` | Session cookie lifetime |
 | `AUTH_COOKIE_SAMESITE` | `lax` | Set `none` for cross-origin hosted deployments |

--- a/README.md
+++ b/README.md
@@ -1,302 +1,413 @@
-# traders-cockpit
+<div align="center">
+  <img src="docs/logo.svg" width="90" alt="Traders Cockpit Logo" />
 
-`traders-cockpit` is an open-source, production-style swing-trade management cockpit built from an existing HTML prototype and a backend contract. It uses a Next.js frontend, a FastAPI backend, PostgreSQL persistence, Redis-backed realtime fanout, and a staged GitHub workflow modeled after `TradeCtrl`.
+  <h1>Traders Cockpit</h1>
 
-## Stack
+  <p><strong>A production-grade swing trade management terminal.</strong><br/>
+  Precision entry · Structured exits · Real-time position control · Built for serious traders.</p>
 
-- Frontend: Next.js, React, TypeScript, Tailwind CSS
-- Backend: FastAPI, SQLAlchemy, Alembic
-- Data: PostgreSQL, Redis
-- Realtime: WebSocket
-- Tooling: Docker Compose, Ruff, Black, ESLint, Prettier, pytest, Vitest
+  <p>
+    <img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-00c8d4?style=flat-square" />
+    <img alt="Python 3.13" src="https://img.shields.io/badge/python-3.13-00d07a?style=flat-square&logo=python&logoColor=white" />
+    <img alt="Node 22" src="https://img.shields.io/badge/node-22-00d07a?style=flat-square&logo=node.js&logoColor=white" />
+    <img alt="Next.js" src="https://img.shields.io/badge/Next.js-15-white?style=flat-square&logo=next.js&logoColor=black" />
+    <img alt="FastAPI" src="https://img.shields.io/badge/FastAPI-0.115-009688?style=flat-square&logo=fastapi&logoColor=white" />
+    <img alt="Docker" src="https://img.shields.io/badge/docker-compose-2496ED?style=flat-square&logo=docker&logoColor=white" />
+  </p>
 
-## Repository Layout
+  <p>
+    <a href="#-quick-start">Quick Start</a> ·
+    <a href="#-the-interface">Interface</a> ·
+    <a href="#-architecture">Architecture</a> ·
+    <a href="#-configuration">Configuration</a> ·
+    <a href="#-roadmap">Roadmap</a>
+  </p>
+</div>
 
-- `frontend/` Next.js cockpit app
-- `backend/` FastAPI service, DB models, migrations, tests
-- `docs/` workflow docs, issue templates, durable repo memory
-- `scripts/` development helpers and promotion scripts
-- `.github/` GitHub Actions plus issue and PR templates
+---
 
-## Source Contracts
+## What is Traders Cockpit?
 
-- [`UI.html`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/UI.html) is the visual and interaction contract
-- [`Traders Cockpit.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/Traders%20Cockpit.md) is the backend and architecture contract
-- `TradeCtrl` is the process and repo-hygiene reference
-- [`docs/architecture/OVERVIEW.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/architecture/OVERVIEW.md) documents the current runtime architecture
-- [`docs/architecture/COMPONENT_MATRIX.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/architecture/COMPONENT_MATRIX.md) tracks component status and TradeCtrl reuse boundaries
+**Traders Cockpit** is an open-source, full-stack swing trade management terminal. It gives you a structured, server-side workflow for planning trades, sizing positions, managing stop ladders, and executing tranche-based profit plans — all in a single keyboard-driven dark UI.
 
-## Development Workflow
+Unlike a spreadsheet or a broker's default interface, Traders Cockpit enforces a **disciplined, repeatable process**:
 
-This repo uses a staged, recovery-friendly delivery flow.
+- You define your **risk per trade** (e.g. 1% of equity), and the system sizes your position for you
+- Stops and profit targets are calculated server-side and tracked as a **parent-child order tree**
+- Every decision is logged to a **durable audit trail** with real-time WebSocket fanout
+- Live trading is **off by default** — the full workflow runs in paper mode until you explicitly enable it
 
-1. Create or link an issue before implementation.
-2. Branch from `codex/integration-app`.
-3. Use `codex/feature-*`, `codex/bugfix-*`, or `codex/refactor-*`.
-4. Open a PR into `codex/integration-app`.
-5. Validate there first.
-6. Promote with a PR from `codex/integration-app` into `main`.
+It is built for traders who want the control of a custom system without building one from scratch.
 
-See:
+---
 
-- [`docs/process/WORKFLOW.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/process/WORKFLOW.md)
-- [`docs/process/BRANCH_PROTECTION.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/process/BRANCH_PROTECTION.md)
-- [`docs/process/RELEASE_PROMOTION_CHECKLIST.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/process/RELEASE_PROMOTION_CHECKLIST.md)
-- [`docs/process/BRANCHING_AND_WORKTREES.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/process/BRANCHING_AND_WORKTREES.md)
-- [`AGENTS.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/AGENTS.md)
+## ✨ Features
 
-## Local Setup
+| | Feature | Details |
+|---|---|---|
+| 📐 | **Server-side risk sizing** | Equity × risk% ÷ per-share risk. No manual math. |
+| 🎯 | **Structured stop ladder** | 1, 2, or 3 independent stop groups per position |
+| 💰 | **Tranche profit plans** | Sell in up to 3 tranches at 1R, 2R, 3R, or manual targets |
+| 🏃 | **Runner management** | Trailing stops ($ or %) for the runner tranche |
+| ⚡ | **Real-time WebSocket** | Live price ticks, position and order updates pushed to the UI |
+| 🔐 | **Session auth** | Cookie-based login with admin and trader roles |
+| 🛡️ | **Safety guardrails** | Max notional cap, daily loss limit, max open positions, duplicate order prevention |
+| 📋 | **Full audit log** | Every action — entry, stop, profit, flatten — is logged with timestamps |
+| 🔌 | **Alpaca integration** | Paper and live execution via Alpaca API (live requires explicit opt-in) |
+| 🐳 | **Docker-first** | One command to get the entire stack running locally |
 
-### Recommended Local Bootstrap
+---
 
-For day-to-day prototyping, use the hybrid local path:
+## 🖥 The Interface
+
+The UI is a dark terminal-style cockpit built with **Next.js + Tailwind + IBM Plex Mono**. It is designed to be information-dense without being cluttered.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  TRADERS·COCKPIT   [$ AAPL ▸]  [LOAD]  [RESET]   $187.42  +1.3%   │
+│  ─────────────────────────────────────────────────────────── PAPER  │
+├──────────────────┬───────────────────────────┬──────────────────────┤
+│  SETUP           │  ENTRY PANEL              │  ACTIVITY LOG        │
+│  ─────────────   │  ─────────────────────    │  ─────────────────   │
+│  Bid    187.38   │  Entry Price:  187.42     │  09:32 [EXEC]        │
+│  Ask    187.46   │  Stop Ref:     LOD ▾      │  Buy 53sh AAPL       │
+│  Last   187.42   │  Stop Price:   184.10     │  @ 187.42 (MKT)      │
+│  LOD    184.10   │  Per-share R:  $3.32      │                      │
+│  HOD    189.20   │  Shares:       53         │  09:32 [SYS]         │
+│  ATR14  3.45     │  Dollar Risk:  $176       │  T1=18sh T2=18sh     │
+│                  │  ─────────────────────    │  T3=17sh             │
+│  R1     190.74   │  Tranches: 1  2  3        │                      │
+│  R2     194.06   │                           │  09:31 [SYS]         │
+│  R3     197.38   │  [PREVIEW]  [ENTER TRADE] │  Cockpit initialized │
+│                  ├───────────────────────────┤                      │
+│  POSITIONS       │  STOP PROTECTION          │                      │
+│  ─────────────   │  ─────────────────────    │                      │
+│  ● AAPL  PROT    │  Mode: ○1 ○2 ●3           │                      │
+│                  │  S1 100%  S2 50%  S3 33%  │                      │
+│                  │                           │                      │
+│                  │  [EXECUTE STOPS]  [→ BE]  │                      │
+│                  │  [■ FLATTEN]               │                      │
+│                  ├───────────────────────────┤                      │
+│                  │  PROFIT TAKING             │                      │
+│                  │  ─────────────────────    │                      │
+│                  │  T1: 18sh → 1R  $190.74   │                      │
+│                  │  T2: 18sh → 2R  $194.06   │                      │
+│                  │  T3: 17sh → RUN trail $2  │                      │
+│                  │                           │                      │
+│                  │  [EXECUTE PROFIT PLAN]    │                      │
+└──────────────────┴───────────────────────────┴──────────────────────┘
+```
+
+**Panels:**
+
+- **Setup** — Real-time quote data (bid/ask, LOD/HOD, ATR14, SMAs, RVOL), computed R-levels, and open position list
+- **Entry Panel** — Set entry price, stop reference (LOD / ATR / manual), preview sizing, enter trade
+- **Stop Protection** — Configure 1/2/3 independent stop groups, move all stops to breakeven, or flatten instantly
+- **Profit Taking** — Configure up to 3 tranches with 1R/2R/3R/manual limit targets or a trailing stop runner
+- **Activity Log** — Live-scrolling audit log with color-coded tags: `EXEC`, `SYS`, `WARN`, `CLOSE`
+
+---
+
+## 🚀 Quick Start
+
+### Option 1 — Docker (recommended)
+
+> Get the full stack running in under 2 minutes.
+
+```bash
+git clone https://github.com/your-org/traders-cockpit.git
+cd traders-cockpit
+
+# Copy and configure your environment
+cp .env.example .env
+
+# Start everything
+docker compose --env-file .env up --build -d
+```
+
+| Service | URL |
+|---|---|
+| **Frontend** | http://127.0.0.1:3000 |
+| **Backend API** | http://127.0.0.1:8000 |
+| **API Docs (Swagger)** | http://127.0.0.1:8000/docs |
+
+Default login: `admin` / `admin123!`
+
+---
+
+### Option 2 — Hybrid Local (fastest for development)
+
+Run the frontend and backend as native processes, with only Postgres and Redis in Docker. This gives you instant hot reload on both sides.
 
 ```powershell
+# Copy your personal-paper env file
 Copy-Item .env.personal-paper.example .env.personal-paper.local
+# Edit .env.personal-paper.local and add your Alpaca paper API keys
+
+# Start the stack
 .\scripts\dev\start-hybrid-local-personal-paper.ps1
 ```
 
-This starts:
+| Service | URL |
+|---|---|
+| **Frontend** | http://127.0.0.1:3010 |
+| **Backend API** | http://127.0.0.1:8010 |
+| **PostgreSQL** | localhost:55432 |
+| **Redis** | localhost:56379 |
 
-- Frontend locally on `3010`
-- Backend locally on `8010`
-- PostgreSQL in Docker on `55432`
-- Redis in Docker on `56379`
+To stop: `.\scripts\dev\stop-hybrid-local-personal-paper.ps1`
 
-Why this is the default development path:
+---
 
-- much faster frontend/backend iteration
-- real Alpaca paper quote and execution path
-- same local Postgres/Redis persistence model
-- no full Docker image rebuild on each code change
+### Option 3 — Manual
 
-Use the full Docker-local path as the slower validation/signoff runtime:
-
-```powershell
-Copy-Item .env.personal-paper.example .env.personal-paper.local
-.\scripts\dev\start-docker-local-personal-paper.ps1 -Build
-```
-
-This starts:
-
-- Frontend on `3000`
-- Backend on `8000`
-- PostgreSQL on `55432`
-- Redis on `56379`
-
-If those localhost ports are already used by another stack, override them explicitly:
-
-```powershell
-.\scripts\dev\start-docker-local-personal-paper.ps1 -Build -FrontendPort 3100 -BackendPort 8100 -PostgresPort 55452 -RedisPort 56399
-```
-
-The Docker-local personal-paper path fails fast unless:
-
-- `BROKER_MODE=alpaca_paper`
-- `ALLOW_LIVE_TRADING=false`
-- `ALLOW_CONTROLLER_MOCK=false`
-- Alpaca paper credentials are present
-
-For deterministic development and tests, keep using the existing script-driven local path:
-
-```powershell
-.\scripts\dev\start-local.ps1
-```
-
-To stop the Docker-local personal-paper stack:
-
-```powershell
-.\scripts\dev\stop-docker-local-personal-paper.ps1
-```
-
-To stop the hybrid local personal-paper stack:
-
-```powershell
-.\scripts\dev\stop-hybrid-local-personal-paper.ps1
-```
-
-To run the real Docker-local paper smoke flow:
-
-```powershell
-.\scripts\dev\run-docker-local-paper-smoke.ps1 -StartStack -Build
-```
-
-To run the fast hybrid-local paper smoke flow:
-
-```powershell
-.\scripts\dev\run-hybrid-local-paper-smoke.ps1 -StartStack
-```
-
-To validate and QC the script-driven personal-paper profile explicitly:
-
-```powershell
-.\scripts\dev\check-local-paper-readiness.ps1 -EnvFile ".env.personal-paper.local"
-.\scripts\dev\run-qc.ps1 -StartStack -PersonalPaper -EnvFile ".env.personal-paper.local"
-```
-
-### Docker
-
-```powershell
-docker compose --env-file .env.personal-paper.local up --build -d
-```
-
-Frontend:
-
-- http://127.0.0.1:3000
-
-Backend:
-
-- http://127.0.0.1:8000
-- http://127.0.0.1:8000/docs
-
-Infra host ports:
-
-- PostgreSQL: `55432`
-- Redis: `56379`
-
-### Manual Backend
-
+**Backend:**
 ```bash
 cd backend
-python -m venv .venv
-. .venv/Scripts/activate
+python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -e .[dev]
 alembic upgrade head
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-If you are not using `.\scripts\dev\start-local.ps1`, export `DATABASE_URL=postgresql://traders_cockpit:traders_cockpit@127.0.0.1:55432/traders_cockpit` and `REDIS_URL=redis://127.0.0.1:56379/0` before starting the backend.
-
-To apply migrations against the repo-owned local Postgres runtime:
-
-```powershell
-.\scripts\dev\migrate-local.ps1
-```
-
-### Manual Frontend
-
+**Frontend:**
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
 
-## Environment
+> Requires PostgreSQL on `55432` and Redis on `56379`. See [docker-compose.yml](docker-compose.yml) to spin up just the infra.
 
-Copy `.env.example` to `.env` at the repo root and fill only the values you need. The backend boots env files from both the current working directory and the backend project directory, following the `TradeCtrl` pattern.
+---
 
-Important defaults:
+## 🏗 Architecture
 
-- paper mode first for deterministic tests
-- hybrid local personal-paper mode is the primary development runtime; Docker-local personal-paper is the validation/signoff runtime
-- live mode disabled unless explicitly allowed
-- local session auth enabled by default
-- staged/hosted deployments should use `AUTH_COOKIE_SAMESITE=none` and `AUTH_COOKIE_SECURE=true` so the hosted frontend can authenticate against a separate backend origin
-- auth sessions are stored separately from trading data in `AUTH_DB_PATH`, following the TradeCtrl session-store pattern without sharing the same database
-- broker and market-data adapters can fall back to deterministic local data for development and tests
-- in Docker-local personal-paper mode, the latest quote and execution path must come from Alpaca; derived technical fields remain fallback-backed for now
-- if Alpaca quote or execution fails in Docker-local personal-paper mode, the app fails loudly instead of silently degrading to mock behavior
-- PostgreSQL on `55432` and Redis on `56379` are the default local persistence endpoints
-- SQLite is fallback-only and should be enabled explicitly when needed
-- hosted Postgres URLs that begin with `postgresql://` are normalized by the backend to `postgresql+psycopg://` so Render-style connection strings work with the installed driver
+```
+User Browser
+     │  REST (HTTP)  /  WebSocket (ws://)
+     ▼
+┌─────────────┐                ┌──────────────────────┐
+│  Next.js    │ ── REST ──▶   │  FastAPI Backend      │
+│  Frontend   │ ◀── WS ─────  │  Python / Uvicorn     │
+│ (port 3010) │               └──────────┬────────────┘
+└─────────────┘                          │
+                                ┌────────┴──────────┐
+                                │                   │
+                           ┌────▼────┐        ┌─────▼────┐
+                           │Postgres │        │  Redis   │
+                           │ :55432  │        │  :56379  │
+                           └─────────┘        └──────────┘
+                                                    │
+                                             ┌──────▼──────┐
+                                             │  Alpaca API │
+                                             │ paper / live│
+                                             └─────────────┘
+```
 
-Additional realtime/safety envs:
+**Stack:**
 
-- `REDIS_CHANNEL_PREFIX` scopes websocket pub/sub fanout across environments
-- `ALLOW_LIVE_TRADING=false` keeps live execution disabled even if `BROKER_MODE=alpaca_live`
-- `LIVE_CONFIRMATION_TOKEN` must be present before live execution can become effective
+| Layer | Technology |
+|---|---|
+| Frontend | Next.js 15, React, TypeScript, Tailwind CSS |
+| Backend | FastAPI, SQLAlchemy 2, Alembic, Pydantic v2 |
+| Database | PostgreSQL 16 (SQLite fallback for tests) |
+| Realtime | WebSocket + Redis pub/sub fanout |
+| Broker | Alpaca Markets API (paper + live) |
+| Auth | Cookie-based session auth (SQLite-backed) |
+| Infra | Docker Compose, Render (hosted) |
 
-## Architecture Notes
+**Key backend layers:**
 
-- The frontend preserves the prototype layout and state shape as closely as possible.
-- The backend computes sizing, stop ladders, tranche splits, and state transitions server-side.
-- Orders use parent-child hierarchy rooted on the entry order.
-- Realtime fanout uses Redis when available and falls back to single-process websocket broadcast in local-only scenarios.
-- Live trading is scaffolded but disabled by default.
-- Setup responses now expose quote/technical/execution provider metadata so the UI can distinguish real Alpaca paper quotes from fallback-backed derived fields.
-- TradeCtrl reuse is intentional for config/auth/safety patterns, while trading DB state stays isolated to `traders-cockpit`.
+- `app/api/` — Route handlers (auth, account, market, positions, trade)
+- `app/services/cockpit.py` — All business logic: sizing, lifecycle, order hierarchy, safety checks
+- `app/adapters/broker.py` — `PaperBrokerAdapter` (sim) and `AlpacaBrokerAdapter` (real execution)
+- `app/adapters/market_data.py` — Alpaca/Polygon quotes with deterministic fallback
+- `app/ws/manager.py` — Redis pub/sub fanout with single-process fallback
 
-## Realtime Contract
+See [`docs/architecture/OVERVIEW.md`](docs/architecture/OVERVIEW.md) for a full breakdown.
 
-`WS /ws/cockpit` publishes normalized envelopes:
+---
 
-- `price_update`
-- `position_update`
-- `order_update`
-- `log_update`
+## 📈 Trade Lifecycle
 
-The frontend still tolerates legacy local event names during the transition, but these normalized event names are now the intended contract.
+Every position flows through a strict server-side state machine:
 
-## Testing
+```
+idle
+ └─▶ setup_loaded      (ticker loaded, market data fetched)
+      └─▶ trade_entered  (entry order placed, tranches created)
+           └─▶ protected   (stop orders active)
+                ├─▶ P1_done      (first tranche sold)
+                │    └─▶ P2_done   (second tranche sold)
+                ├─▶ runner_only  (all limits filled, runner trailing)
+                └─▶ closed       (all tranches exited or flattened)
+```
 
+**Order hierarchy** — every child order links back to the root entry:
+
+```
+ORD-0001  MKT  AAPL  53sh  FILLED     ← root entry order
+├─ ORD-0002  STOP  18sh  @ 184.10  ACTIVE   ← stop group S1
+├─ ORD-0003  STOP  35sh  @ 185.50  ACTIVE   ← stop group S2
+├─ ORD-0004  LMT   18sh  @ 190.74  FILLED   ← T1 profit (1R)
+├─ ORD-0005  LMT   18sh  @ 194.06  FILLED   ← T2 profit (2R)
+└─ ORD-0006  TRAIL 17sh  trail $2  ACTIVE   ← T3 runner
+```
+
+---
+
+## 🔧 Configuration
+
+Copy `.env.example` to `.env` and set the values you need. Most have safe defaults.
+
+### Core
+
+| Variable | Default | Description |
+|---|---|---|
+| `APP_ENV` | `development` | Environment: `development`, `staging`, `production` |
+| `DATABASE_URL` | local postgres | PostgreSQL connection string |
+| `REDIS_URL` | `redis://127.0.0.1:56379/0` | Redis connection string |
+| `REDIS_CHANNEL_PREFIX` | `traders-cockpit` | Scopes WS pub/sub per environment |
+
+### Auth
+
+| Variable | Default | Description |
+|---|---|---|
+| `AUTH_REQUIRE_LOGIN` | `true` | Enforce login before access |
+| `AUTH_ADMIN_USERNAME` | `admin` | Admin account username |
+| `AUTH_ADMIN_PASSWORD` | `admin123!` | **Change this in production** |
+| `AUTH_TRADER_USERNAME` | `trader` | Trader account username |
+| `AUTH_SESSION_TTL_HOURS` | `24` | Session cookie lifetime |
+| `AUTH_COOKIE_SAMESITE` | `lax` | Set `none` for cross-origin hosted deployments |
+| `AUTH_COOKIE_SECURE` | `false` | Set `true` in staging/production |
+
+### Broker
+
+| Variable | Default | Description |
+|---|---|---|
+| `BROKER_MODE` | `paper` | `paper`, `alpaca_paper`, or `alpaca_live` |
+| `ALLOW_LIVE_TRADING` | `false` | Master switch for live execution |
+| `LIVE_CONFIRMATION_TOKEN` | _(empty)_ | Required before live mode becomes effective |
+| `ALPACA_API_KEY_ID` | _(empty)_ | Alpaca paper/live API key |
+| `ALPACA_API_SECRET_KEY` | _(empty)_ | Alpaca paper/live API secret |
+| `ALLOW_CONTROLLER_MOCK` | `true` | Fall back to sim if Alpaca credentials are missing |
+
+### Risk Limits
+
+| Variable | Default | Description |
+|---|---|---|
+| `DEFAULT_ACCOUNT_EQUITY` | `100000` | Starting equity ($) |
+| `DEFAULT_RISK_PCT` | `1` | Default risk per trade (%) |
+| `MAX_POSITION_NOTIONAL_PCT` | `100` | Max position size as % of equity |
+| `DAILY_LOSS_LIMIT_PCT` | `2` | Stop trading if daily loss exceeds this % |
+| `MAX_OPEN_POSITIONS` | `6` | Maximum concurrent open positions |
+
+---
+
+## 🔌 Broker Modes
+
+| Mode | Execution | Market Data | Use Case |
+|---|---|---|---|
+| `paper` | Simulated (instant fills) | Fallback local data | Deterministic dev & tests |
+| `alpaca_paper` | Alpaca paper API | Real Alpaca quotes | Dev with real quotes, no real money |
+| `alpaca_live` | Alpaca live API | Real Alpaca quotes | **Real money — requires explicit opt-in** |
+
+> Live trading requires **all three**: `BROKER_MODE=alpaca_live` + `ALLOW_LIVE_TRADING=true` + `LIVE_CONFIRMATION_TOKEN=<token>`. Missing any one of them keeps execution in paper mode.
+
+---
+
+## 🧪 Testing
+
+**Backend:**
 ```bash
 cd backend
 pytest -q
 ```
 
+**Frontend:**
 ```bash
 cd frontend
-npm run lint
-npm run test
-npm run build
+npm run lint      # ESLint
+npm run test      # Vitest unit tests
+npm run build     # TypeScript + production build check
 ```
 
-Browser smoke and fidelity evidence are written under `frontend/output/playwright/` when using `.\scripts\dev\run-qc.ps1`.
+**Full QC (backend + frontend + browser smoke):**
+```powershell
+.\scripts\dev\run-qc.ps1 -StartStack
+```
 
-Required state artifacts:
+Browser smoke artifacts land in `frontend/output/playwright/` and include baseline screenshots at key trade lifecycle stages.
 
-- `baseline-idle.png`
-- `baseline-setup-loaded.png`
-- `baseline-trade-entered.png`
-- `baseline-protected.png`
-- `baseline-profit-flow.png`
+---
 
-## Contribution
+## 🚢 Deployment
 
-1. Create or link an issue.
-2. Branch from `codex/integration-app`.
-3. Open a PR back into `codex/integration-app`.
-4. Run the repo QC path before asking for review.
-5. Promote only through a separate PR from `codex/integration-app` into `main`.
-6. After promotion, close the linked issue doc and delete merged feature branches.
+### Recommended hosted topology
 
-For release preparation, use:
+| Service | Host |
+|---|---|
+| Frontend | [Vercel](https://vercel.com) |
+| Backend | [Render](https://render.com) (Docker) |
+| Database | Managed PostgreSQL (Render / Supabase / Neon) |
+| Cache | Managed Redis (Render / Upstash) |
 
-- [`docs/process/STAGING_RELEASE_PLAYBOOK.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/process/STAGING_RELEASE_PLAYBOOK.md)
-- [`docs/handoffs/2026-03-21-integration-readiness.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/handoffs/2026-03-21-integration-readiness.md)
+A `render.yaml` is included for one-click Render deployment.
 
-## Hosted Deployment
+**Important for cross-origin hosted deployments:**
+```env
+AUTH_COOKIE_SAMESITE=none
+AUTH_COOKIE_SECURE=true
+CORS_ORIGINS=https://your-frontend.vercel.app
+```
 
-Recommended hosted topology:
-
-- frontend on Vercel
-- backend on Render or another Docker-capable host
-- managed Postgres
-- managed Redis
-
-Deployment assets now included:
-
-- [`frontend/Dockerfile`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/frontend/Dockerfile)
-- [`backend/Dockerfile`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/backend/Dockerfile)
-- [`render.yaml`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/render.yaml)
-- [`docs/process/HOSTED_DEPLOYMENT.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/process/HOSTED_DEPLOYMENT.md)
-
-Validate hosted envs before deploy:
-
+Validate your hosted env before deploying:
 ```powershell
 .\scripts\dev\check-hosted-env.ps1 -EnvFile ".env"
 ```
 
-## OSS
+---
 
-- License: MIT
-- Contributions are welcome through issue-first, PR-first workflow
-- Protect `codex/integration-app` and `main` using [`docs/process/BRANCH_PROTECTION.md`](/Users/melvi/OneDrive/Desktop/Traders%20Cockpit/docs/process/BRANCH_PROTECTION.md)
+## 🗺 Roadmap
 
-## Roadmap
+- [ ] **Real Alpaca paper reconciliation** — sync broker fills back into position state
+- [ ] **Polygon technicals** — full ATR, SMAs, RVOL, days-to-cover from Polygon API
+- [ ] **Position snapshots** — point-in-time state captures for post-trade review
+- [ ] **Multi-instance Redis hardening** — battle-tested fanout for cloud deployments
+- [ ] **Richer audit trail** — P&L per tranche, slippage tracking, trade journal export
+- [ ] **Browser smoke expansion** — full lifecycle coverage in Playwright QC suite
 
-- Real Alpaca paper execution with broker reconciliation
-- Polygon-backed technicals and short-interest enrichment
-- Multi-instance Redis event fanout hardening in deployment environments
-- Position snapshotting and richer audit trails
-- Expanded smoke and browser QC coverage
+---
+
+## 🤝 Contributing
+
+Contributions are welcome. This repo uses an issue-first, PR-first workflow.
+
+1. **Open or link an issue** before starting any work
+2. **Branch from** `codex/integration-app` using `codex/feature-*`, `codex/bugfix-*`, or `codex/refactor-*`
+3. **Open a PR** back into `codex/integration-app` (not directly into `main`)
+4. **Run the full QC path** before requesting review:
+   ```powershell
+   .\scripts\dev\run-qc.ps1 -StartStack
+   ```
+5. **Promote to `main`** only via a separate PR from `codex/integration-app → main`
+
+See [`docs/process/WORKFLOW.md`](docs/process/WORKFLOW.md) for the full branching and release process.
+
+---
+
+## 📄 License
+
+[MIT](LICENSE) — free to use, fork, and build on.
+
+---
+
+<div align="center">
+  <sub>Built with precision. Trade with discipline.</sub><br/>
+  <sub>
+    <a href="docs/architecture/OVERVIEW.md">Architecture</a> ·
+    <a href="docs/process/WORKFLOW.md">Workflow</a> ·
+    <a href="docs/process/HOSTED_DEPLOYMENT.md">Deployment</a>
+  </sub>
+</div>

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -8,7 +8,6 @@ Create Date: 2026-03-20
 from alembic import op
 import sqlalchemy as sa
 
-
 revision = "0001_initial"
 down_revision = None
 branch_labels = None

--- a/backend/alembic/versions/0002_hedge_hardening_foundation.py
+++ b/backend/alembic/versions/0002_hedge_hardening_foundation.py
@@ -1,0 +1,150 @@
+"""hedge hardening foundation
+
+Revision ID: 0002_hedge_hardening_foundation
+Revises: 0001_initial
+Create Date: 2026-03-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002_hedge_hardening_foundation"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("positions", sa.Column("last_intent_id", sa.String(length=64), nullable=True))
+    op.add_column(
+        "positions",
+        sa.Column("projection_version", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "positions",
+        sa.Column(
+            "reconcile_status", sa.String(length=32), nullable=False, server_default="synchronized"
+        ),
+    )
+    op.add_column(
+        "positions", sa.Column("last_reconciled_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "orders", sa.Column("filled_qty", sa.Integer(), nullable=False, server_default="0")
+    )
+    op.add_column("orders", sa.Column("intent_id", sa.String(length=64), nullable=True))
+
+    op.create_table(
+        "event_log",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("event_id", sa.String(length=64), nullable=False, unique=True),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("symbol", sa.String(length=16), nullable=True),
+        sa.Column("intent_id", sa.String(length=64), nullable=True),
+        sa.Column("broker_order_id", sa.String(length=128), nullable=True),
+        sa.Column("fill_id", sa.String(length=128), nullable=True),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "order_intents",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("intent_id", sa.String(length=64), nullable=False, unique=True),
+        sa.Column("symbol", sa.String(length=16), nullable=False),
+        sa.Column("action", sa.String(length=32), nullable=False),
+        sa.Column("side", sa.String(length=8), nullable=False),
+        sa.Column("qty", sa.Integer(), nullable=False),
+        sa.Column("price", sa.Float(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("blocking_reasons", sa.JSON(), nullable=False),
+        sa.Column("broker_order_id", sa.String(length=128), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "broker_orders",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("broker_order_id", sa.String(length=128), nullable=False, unique=True),
+        sa.Column("symbol", sa.String(length=16), nullable=False),
+        sa.Column("broker", sa.String(length=32), nullable=False),
+        sa.Column("intent_id", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("side", sa.String(length=8), nullable=True),
+        sa.Column("order_type", sa.String(length=32), nullable=True),
+        sa.Column("qty", sa.Integer(), nullable=False),
+        sa.Column("filled_qty", sa.Integer(), nullable=False),
+        sa.Column("remaining_qty", sa.Integer(), nullable=False),
+        sa.Column("avg_fill_price", sa.Float(), nullable=True),
+        sa.Column("raw_payload", sa.JSON(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "broker_fills",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("fill_id", sa.String(length=128), nullable=False, unique=True),
+        sa.Column("broker_order_id", sa.String(length=128), nullable=True),
+        sa.Column("symbol", sa.String(length=16), nullable=False),
+        sa.Column("intent_id", sa.String(length=64), nullable=True),
+        sa.Column("qty", sa.Integer(), nullable=False),
+        sa.Column("price", sa.Float(), nullable=False),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("raw_payload", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "position_projections",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("symbol", sa.String(length=16), nullable=False, unique=True),
+        sa.Column("phase", sa.String(length=32), nullable=False),
+        sa.Column("reconcile_status", sa.String(length=32), nullable=False),
+        sa.Column("projection_version", sa.Integer(), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_reconciled_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        "account_snapshots",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("broker", sa.String(length=32), nullable=False),
+        sa.Column("mode", sa.String(length=32), nullable=False),
+        sa.Column("equity", sa.Float(), nullable=False),
+        sa.Column("buying_power", sa.Float(), nullable=False),
+        sa.Column("cash", sa.Float(), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("recorded_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_table(
+        "reconcile_runs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.String(length=64), nullable=False, unique=True),
+        sa.Column("trigger", sa.String(length=32), nullable=False),
+        sa.Column("broker", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("processed_orders", sa.Integer(), nullable=False),
+        sa.Column("processed_fills", sa.Integer(), nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.alter_column("positions", "projection_version", server_default=None)
+    op.alter_column("positions", "reconcile_status", server_default=None)
+    op.alter_column("orders", "filled_qty", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_table("reconcile_runs")
+    op.drop_table("account_snapshots")
+    op.drop_table("position_projections")
+    op.drop_table("broker_fills")
+    op.drop_table("broker_orders")
+    op.drop_table("order_intents")
+    op.drop_table("event_log")
+    op.drop_column("orders", "intent_id")
+    op.drop_column("orders", "filled_qty")
+    op.drop_column("positions", "last_reconciled_at")
+    op.drop_column("positions", "reconcile_status")
+    op.drop_column("positions", "projection_version")
+    op.drop_column("positions", "last_intent_id")

--- a/backend/app/adapters/broker.py
+++ b/backend/app/adapters/broker.py
@@ -42,6 +42,9 @@ class BrokerAdapter:
     def get_session_state(self) -> str:
         raise NotImplementedError
 
+    def get_account_summary(self) -> dict[str, float] | None:
+        raise NotImplementedError
+
 
 class PaperBrokerAdapter(BrokerAdapter):
     def place_market_order(self, symbol: str, qty: int, side: str) -> BrokerOrderResult:
@@ -69,6 +72,9 @@ class PaperBrokerAdapter(BrokerAdapter):
 
     def get_session_state(self) -> str:
         return "regular_open"
+
+    def get_account_summary(self) -> dict[str, float] | None:
+        return None
 
 
 class AlpacaBrokerAdapter(BrokerAdapter):
@@ -301,3 +307,27 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             if self.settings.allow_controller_mock:
                 return "regular_open"
             raise ValueError(self._extract_http_error_message("Alpaca market clock lookup failed", exc)) from exc
+
+    def get_account_summary(self) -> dict[str, float] | None:
+        if not self.settings.has_alpaca_credentials:
+            if self.settings.allow_controller_mock:
+                return None
+            raise ValueError("Alpaca paper credentials are missing for broker account lookup")
+        try:
+            with self._client() as client:
+                response = client.get("/v2/account")
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:
+            if self.settings.allow_controller_mock:
+                return None
+            raise ValueError(self._extract_http_error_message("Alpaca account lookup failed", exc)) from exc
+        try:
+            equity = float(payload.get("equity") or 0.0)
+            buying_power = float(payload.get("buying_power") or 0.0)
+            cash = float(payload.get("cash") or 0.0)
+        except (TypeError, ValueError):
+            return None
+        if equity <= 0 or buying_power <= 0:
+            return None
+        return {"equity": equity, "buying_power": buying_power, "cash": cash}

--- a/backend/app/adapters/broker.py
+++ b/backend/app/adapters/broker.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+import hashlib
+import json
 from zoneinfo import ZoneInfo
 
 import httpx
@@ -13,30 +15,89 @@ from app.core.config import Settings
 class BrokerOrderResult:
     broker_order_id: str | None
     status: str
+    payload: dict | None = None
+
+
+@dataclass
+class BrokerEntryOrder:
+    symbol: str
+    qty: int
+    side: str
+    order_type: str
+    time_in_force: str
+    limit_price: float | None = None
+    stop_price: float | None = None
+    order_class: str = "simple"
+    extended_hours: bool = False
+    take_profit_limit_price: float | None = None
+    stop_loss_stop_price: float | None = None
+    stop_loss_limit_price: float | None = None
+
+
+@dataclass
+class BrokerWebhookEvent:
+    event_id: str
+    event_type: str
+    kind: str
+    broker_order_id: str | None = None
+    symbol: str | None = None
+    payload: dict | None = None
+    fill_id: str | None = None
+    occurred_at: datetime | None = None
+    account_payload: dict | None = None
 
 
 class BrokerAdapter:
+    def place_entry_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
+        raise NotImplementedError
+
     def place_market_order(self, symbol: str, qty: int, side: str) -> BrokerOrderResult:
+        return self.place_entry_order(
+            BrokerEntryOrder(
+                symbol=symbol,
+                qty=qty,
+                side=side,
+                order_type="market",
+                time_in_force="day",
+            )
+        )
+
+    def place_stop_order(
+        self, symbol: str, qty: int, stop_price: float, side: str = "sell"
+    ) -> BrokerOrderResult:
         raise NotImplementedError
 
-    def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
-        raise NotImplementedError
-
-    def place_limit_order(self, symbol: str, qty: int, limit_price: float) -> BrokerOrderResult:
+    def place_limit_order(
+        self,
+        symbol: str,
+        qty: int,
+        limit_price: float,
+        side: str = "sell",
+        time_in_force: str = "gtc",
+        extended_hours: bool = False,
+    ) -> BrokerOrderResult:
         raise NotImplementedError
 
     def place_trailing_stop(
-        self, symbol: str, qty: int, trail: float, trail_unit: str
+        self, symbol: str, qty: int, trail: float, trail_unit: str, side: str = "sell"
     ) -> BrokerOrderResult:
         raise NotImplementedError
 
     def close_position(self, symbol: str) -> BrokerOrderResult:
         raise NotImplementedError
 
-    def wait_for_position(self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0) -> int:
+    def wait_for_position(
+        self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0
+    ) -> int:
         raise NotImplementedError
 
     def cancel_order(self, broker_order_id: str) -> None:
+        raise NotImplementedError
+
+    def list_recent_orders(self, limit: int = 50) -> list[dict]:
+        raise NotImplementedError
+
+    def get_order(self, broker_order_id: str) -> dict | None:
         raise NotImplementedError
 
     def get_session_state(self) -> str:
@@ -45,29 +106,68 @@ class BrokerAdapter:
     def get_account_summary(self) -> dict[str, float] | None:
         raise NotImplementedError
 
+    def normalize_webhook_payload(self, payload: dict) -> list[BrokerWebhookEvent]:
+        return []
+
 
 class PaperBrokerAdapter(BrokerAdapter):
+    def place_entry_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
+        return BrokerOrderResult(
+            broker_order_id=None,
+            status=("ACTIVE" if order.order_class in {"bracket", "oco", "oto"} else "FILLED"),
+            payload={
+                "symbol": order.symbol,
+                "qty": str(order.qty),
+                "side": order.side,
+                "type": order.order_type,
+                "time_in_force": order.time_in_force,
+                "order_class": order.order_class,
+                "limit_price": order.limit_price,
+                "stop_price": order.stop_price,
+                "extended_hours": order.extended_hours,
+                "status": "accepted",
+            },
+        )
+
     def place_market_order(self, symbol: str, qty: int, side: str) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="FILLED")
 
-    def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
+    def place_stop_order(
+        self, symbol: str, qty: int, stop_price: float, side: str = "sell"
+    ) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="ACTIVE")
 
-    def place_limit_order(self, symbol: str, qty: int, limit_price: float) -> BrokerOrderResult:
+    def place_limit_order(
+        self,
+        symbol: str,
+        qty: int,
+        limit_price: float,
+        side: str = "sell",
+        time_in_force: str = "gtc",
+        extended_hours: bool = False,
+    ) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="FILLED")
 
     def place_trailing_stop(
-        self, symbol: str, qty: int, trail: float, trail_unit: str
+        self, symbol: str, qty: int, trail: float, trail_unit: str, side: str = "sell"
     ) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="ACTIVE")
 
     def close_position(self, symbol: str) -> BrokerOrderResult:
         return BrokerOrderResult(broker_order_id=None, status="FILLED")
 
-    def wait_for_position(self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0) -> int:
+    def wait_for_position(
+        self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0
+    ) -> int:
         return min_qty
 
     def cancel_order(self, broker_order_id: str) -> None:
+        return None
+
+    def list_recent_orders(self, limit: int = 50) -> list[dict]:
+        return []
+
+    def get_order(self, broker_order_id: str) -> dict | None:
         return None
 
     def get_session_state(self) -> str:
@@ -75,6 +175,9 @@ class PaperBrokerAdapter(BrokerAdapter):
 
     def get_account_summary(self) -> dict[str, float] | None:
         return None
+
+    def normalize_webhook_payload(self, payload: dict) -> list[BrokerWebhookEvent]:
+        return []
 
 
 class AlpacaBrokerAdapter(BrokerAdapter):
@@ -86,6 +189,8 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             else settings.alpaca_api_base_url
         )
         self.market_tz = ZoneInfo("America/New_York")
+        self._account_summary_cache: tuple[float, dict[str, float]] | None = None
+        self._recent_orders_cache: tuple[float, int, list[dict]] | None = None
 
     def _client(self) -> httpx.Client:
         self._ensure_execution_allowed()
@@ -95,7 +200,7 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 "APCA-API-KEY-ID": self.settings.alpaca_api_key_id,
                 "APCA-API-SECRET-KEY": self.settings.alpaca_api_secret_key,
             },
-            timeout=10.0,
+            timeout=4.0,
         )
 
     def _ensure_execution_allowed(self) -> None:
@@ -144,38 +249,76 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return "after_hours"
         return "overnight"
 
-    def place_market_order(self, symbol: str, qty: int, side: str, time_in_force: str = "day") -> BrokerOrderResult:
+    def place_entry_order(self, order: BrokerEntryOrder) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("FILLED", "Alpaca paper credentials are missing for broker execution")
-        payload = {"symbol": symbol, "qty": qty, "side": side, "type": "market", "time_in_force": time_in_force}
-        try:
-            with self._client() as client:
-                response = client.post("/v2/orders", json=payload)
-                response.raise_for_status()
-                data = response.json()
-        except httpx.HTTPError as exc:
-            return self._fallback_or_raise("FILLED", self._extract_http_error_message("Alpaca market order failed", exc))
-        return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper())
-
-    def place_stop_order(self, symbol: str, qty: int, stop_price: float) -> BrokerOrderResult:
-        if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("ACTIVE", "Alpaca paper credentials are missing for stop execution")
-        payload = {
-            "symbol": symbol,
-            "qty": qty,
-            "side": "sell",
-            "type": "stop",
-            "stop_price": stop_price,
-            "time_in_force": "gtc",
+            return self._fallback_or_raise(
+                "FILLED", "Alpaca paper credentials are missing for broker execution"
+            )
+        payload: dict[str, object] = {
+            "symbol": order.symbol,
+            "qty": order.qty,
+            "side": order.side,
+            "type": order.order_type,
+            "time_in_force": order.time_in_force,
         }
+        if order.limit_price is not None:
+            payload["limit_price"] = order.limit_price
+        if order.stop_price is not None:
+            payload["stop_price"] = order.stop_price
+        if order.order_class != "simple":
+            payload["order_class"] = order.order_class
+        if order.extended_hours:
+            payload["extended_hours"] = True
+        if order.take_profit_limit_price is not None:
+            payload["take_profit"] = {"limit_price": order.take_profit_limit_price}
+        if order.stop_loss_stop_price is not None:
+            stop_loss: dict[str, float] = {"stop_price": order.stop_loss_stop_price}
+            if order.stop_loss_limit_price is not None:
+                stop_loss["limit_price"] = order.stop_loss_limit_price
+            payload["stop_loss"] = stop_loss
         try:
             with self._client() as client:
                 response = client.post("/v2/orders", json=payload)
                 response.raise_for_status()
                 data = response.json()
         except httpx.HTTPError as exc:
-            return self._fallback_or_raise("ACTIVE", self._extract_http_error_message("Alpaca stop order failed", exc))
-        return BrokerOrderResult(data.get("id"), str(data.get("status", "new")).upper())
+            return self._fallback_or_raise(
+                "FILLED",
+                self._extract_http_error_message("Alpaca market order failed", exc),
+            )
+        return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper(), data)
+
+    def place_market_order(
+        self, symbol: str, qty: int, side: str, time_in_force: str = "day"
+    ) -> BrokerOrderResult:
+        return self.place_entry_order(
+            BrokerEntryOrder(
+                symbol=symbol,
+                qty=qty,
+                side=side,
+                order_type="market",
+                time_in_force=time_in_force,
+            )
+        )
+
+    def place_stop_order(
+        self, symbol: str, qty: int, stop_price: float, side: str = "sell"
+    ) -> BrokerOrderResult:
+        if not self.settings.has_alpaca_credentials:
+            return self._fallback_or_raise(
+                "ACTIVE", "Alpaca paper credentials are missing for stop execution"
+            )
+        result = self.place_entry_order(
+            BrokerEntryOrder(
+                symbol=symbol,
+                qty=qty,
+                side=side,
+                order_type="stop",
+                stop_price=stop_price,
+                time_in_force="gtc",
+            )
+        )
+        return BrokerOrderResult(result.broker_order_id, result.status, result.payload)
 
     def place_limit_order(
         self,
@@ -187,35 +330,32 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         extended_hours: bool = False,
     ) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("FILLED", "Alpaca paper credentials are missing for profit execution")
+            return self._fallback_or_raise(
+                "FILLED", "Alpaca paper credentials are missing for profit execution"
+            )
+        return self.place_entry_order(
+            BrokerEntryOrder(
+                symbol=symbol,
+                qty=qty,
+                side=side,
+                order_type="limit",
+                limit_price=limit_price,
+                time_in_force=time_in_force,
+                extended_hours=extended_hours,
+            )
+        )
+
+    def place_trailing_stop(
+        self, symbol: str, qty: int, trail: float, trail_unit: str, side: str = "sell"
+    ) -> BrokerOrderResult:
+        if not self.settings.has_alpaca_credentials:
+            return self._fallback_or_raise(
+                "ACTIVE", "Alpaca paper credentials are missing for runner execution"
+            )
         payload = {
             "symbol": symbol,
             "qty": qty,
             "side": side,
-            "type": "limit",
-            "limit_price": limit_price,
-            "time_in_force": time_in_force,
-        }
-        if extended_hours:
-            payload["extended_hours"] = True
-        try:
-            with self._client() as client:
-                response = client.post("/v2/orders", json=payload)
-                response.raise_for_status()
-                data = response.json()
-        except httpx.HTTPError as exc:
-            return self._fallback_or_raise("FILLED", self._extract_http_error_message("Alpaca limit order failed", exc))
-        return BrokerOrderResult(data.get("id"), str(data.get("status", "accepted")).upper())
-
-    def place_trailing_stop(
-        self, symbol: str, qty: int, trail: float, trail_unit: str
-    ) -> BrokerOrderResult:
-        if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("ACTIVE", "Alpaca paper credentials are missing for runner execution")
-        payload = {
-            "symbol": symbol,
-            "qty": qty,
-            "side": "sell",
             "type": "trailing_stop",
             "time_in_force": "gtc",
         }
@@ -229,22 +369,32 @@ class AlpacaBrokerAdapter(BrokerAdapter):
                 response.raise_for_status()
                 data = response.json()
         except httpx.HTTPError as exc:
-            return self._fallback_or_raise("ACTIVE", self._extract_http_error_message("Alpaca trailing stop failed", exc))
+            return self._fallback_or_raise(
+                "ACTIVE",
+                self._extract_http_error_message("Alpaca trailing stop failed", exc),
+            )
         return BrokerOrderResult(data.get("id"), str(data.get("status", "new")).upper())
 
     def close_position(self, symbol: str) -> BrokerOrderResult:
         if not self.settings.has_alpaca_credentials:
-            return self._fallback_or_raise("FILLED", "Alpaca paper credentials are missing for flatten execution")
+            return self._fallback_or_raise(
+                "FILLED", "Alpaca paper credentials are missing for flatten execution"
+            )
         try:
             with self._client() as client:
                 response = client.delete(f"/v2/positions/{symbol}")
                 response.raise_for_status()
                 data = response.json()
         except httpx.HTTPError as exc:
-            return self._fallback_or_raise("FILLED", self._extract_http_error_message("Alpaca close position failed", exc))
+            return self._fallback_or_raise(
+                "FILLED",
+                self._extract_http_error_message("Alpaca close position failed", exc),
+            )
         return BrokerOrderResult(data.get("id"), "FILLED")
 
-    def wait_for_position(self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0) -> int:
+    def wait_for_position(
+        self, symbol: str, min_qty: int = 1, timeout_seconds: float = 15.0
+    ) -> int:
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
                 return min_qty
@@ -287,7 +437,61 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
                 return
-            raise ValueError(self._extract_http_error_message("Alpaca order cancellation failed", exc)) from exc
+            raise ValueError(
+                self._extract_http_error_message("Alpaca order cancellation failed", exc)
+            ) from exc
+
+    def list_recent_orders(self, limit: int = 50) -> list[dict]:
+        import time
+
+        cache_entry = self._recent_orders_cache
+        if cache_entry is not None:
+            cached_at, cached_limit, cached_payload = cache_entry
+            if cached_limit >= limit and time.monotonic() - cached_at < 2.0:
+                return [dict(order) for order in cached_payload[:limit]]
+        if not self.settings.has_alpaca_credentials:
+            if self.settings.allow_controller_mock:
+                return []
+            raise ValueError("Alpaca paper credentials are missing for broker order lookup")
+        try:
+            with self._client() as client:
+                response = client.get(
+                    "/v2/orders",
+                    params={"status": "all", "direction": "desc", "limit": limit},
+                )
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:
+            if self.settings.allow_controller_mock:
+                return []
+            raise ValueError(
+                self._extract_http_error_message("Alpaca recent orders lookup failed", exc)
+            ) from exc
+        rows = [dict(order) for order in payload] if isinstance(payload, list) else []
+        self._recent_orders_cache = (time.monotonic(), limit, rows)
+        return [dict(order) for order in rows]
+
+    def get_order(self, broker_order_id: str) -> dict | None:
+        if not broker_order_id:
+            return None
+        if not self.settings.has_alpaca_credentials:
+            if self.settings.allow_controller_mock:
+                return None
+            raise ValueError("Alpaca paper credentials are missing for broker order lookup")
+        try:
+            with self._client() as client:
+                response = client.get(f"/v2/orders/{broker_order_id}")
+                if response.status_code == 404:
+                    return None
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:
+            if self.settings.allow_controller_mock:
+                return None
+            raise ValueError(
+                self._extract_http_error_message("Alpaca order lookup failed", exc)
+            ) from exc
+        return payload if isinstance(payload, dict) else None
 
     def get_session_state(self) -> str:
         if not self.settings.has_alpaca_credentials:
@@ -306,9 +510,18 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
                 return "regular_open"
-            raise ValueError(self._extract_http_error_message("Alpaca market clock lookup failed", exc)) from exc
+            raise ValueError(
+                self._extract_http_error_message("Alpaca market clock lookup failed", exc)
+            ) from exc
 
     def get_account_summary(self) -> dict[str, float] | None:
+        import time
+
+        cache_entry = self._account_summary_cache
+        if cache_entry is not None:
+            cached_at, payload = cache_entry
+            if time.monotonic() - cached_at < 5.0:
+                return dict(payload)
         if not self.settings.has_alpaca_credentials:
             if self.settings.allow_controller_mock:
                 return None
@@ -321,7 +534,9 @@ class AlpacaBrokerAdapter(BrokerAdapter):
         except httpx.HTTPError as exc:
             if self.settings.allow_controller_mock:
                 return None
-            raise ValueError(self._extract_http_error_message("Alpaca account lookup failed", exc)) from exc
+            raise ValueError(
+                self._extract_http_error_message("Alpaca account lookup failed", exc)
+            ) from exc
         try:
             equity = float(payload.get("equity") or 0.0)
             buying_power = float(payload.get("buying_power") or 0.0)
@@ -330,4 +545,97 @@ class AlpacaBrokerAdapter(BrokerAdapter):
             return None
         if equity <= 0 or buying_power <= 0:
             return None
-        return {"equity": equity, "buying_power": buying_power, "cash": cash}
+        summary = {"equity": equity, "buying_power": buying_power, "cash": cash}
+        self._account_summary_cache = (time.monotonic(), summary)
+        return dict(summary)
+
+    def normalize_webhook_payload(self, payload: dict) -> list[BrokerWebhookEvent]:
+        if not isinstance(payload, dict):
+            return []
+        raw_events = payload.get("events") if isinstance(payload.get("events"), list) else [payload]
+        normalized: list[BrokerWebhookEvent] = []
+        for raw_event in raw_events:
+            if not isinstance(raw_event, dict):
+                continue
+            order = self._extract_webhook_order(raw_event)
+            account = self._extract_webhook_account(raw_event)
+            event_type = str(
+                raw_event.get("event")
+                or raw_event.get("type")
+                or raw_event.get("event_type")
+                or "alpaca_webhook"
+            ).lower()
+            timestamp = self._parse_timestamp(
+                str(
+                    raw_event.get("timestamp")
+                    or (order or {}).get("updated_at")
+                    or (order or {}).get("filled_at")
+                    or ""
+                )
+            )
+            if order is not None:
+                normalized.append(
+                    BrokerWebhookEvent(
+                        event_id=self._stable_event_id("order", event_type, order, timestamp),
+                        event_type=event_type,
+                        kind="order",
+                        broker_order_id=str(order.get("id") or "").strip() or None,
+                        symbol=str(order.get("symbol") or "").upper() or None,
+                        payload=order,
+                        fill_id=self._fill_id_for_event(event_type, order, timestamp),
+                        occurred_at=timestamp,
+                    )
+                )
+            if account is not None:
+                normalized.append(
+                    BrokerWebhookEvent(
+                        event_id=self._stable_event_id("account", event_type, account, timestamp),
+                        event_type=event_type,
+                        kind="account",
+                        payload=account,
+                        occurred_at=timestamp,
+                        account_payload=account,
+                    )
+                )
+        return normalized
+
+    def _extract_webhook_order(self, payload: dict) -> dict | None:
+        for key in ("order", "data", "payload"):
+            candidate = payload.get(key)
+            if isinstance(candidate, dict) and candidate.get("id") and candidate.get("symbol"):
+                return candidate
+        if payload.get("id") and payload.get("symbol"):
+            return payload
+        return None
+
+    def _extract_webhook_account(self, payload: dict) -> dict | None:
+        for key in ("account", "account_snapshot"):
+            candidate = payload.get(key)
+            if isinstance(candidate, dict):
+                return candidate
+        if payload.get("equity") is not None and payload.get("buying_power") is not None:
+            return payload
+        return None
+
+    def _stable_event_id(
+        self, kind: str, event_type: str, payload: dict, timestamp: datetime | None
+    ) -> str:
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(
+            f"{kind}|{event_type}|{timestamp.isoformat() if timestamp else ''}|{canonical}".encode()
+        ).hexdigest()[:24]
+        return f"alpaca-{kind}-{digest}"
+
+    def _fill_id_for_event(
+        self, event_type: str, order: dict, timestamp: datetime | None
+    ) -> str | None:
+        normalized_type = event_type.lower()
+        if normalized_type not in {"fill", "partial_fill", "filled", "partially_filled"}:
+            status = str(order.get("status") or "").lower()
+            if status not in {"filled", "partially_filled"}:
+                return None
+        key = (
+            f"{order.get('id') or ''}|{order.get('filled_qty') or ''}|"
+            f"{timestamp.isoformat() if timestamp else ''}"
+        )
+        return f"fill-{hashlib.sha256(key.encode()).hexdigest()[:24]}"

--- a/backend/app/adapters/market_data.py
+++ b/backend/app/adapters/market_data.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from concurrent.futures import ThreadPoolExecutor
 from zoneinfo import ZoneInfo
+import time
 
 import httpx
 
 from app.core.config import Settings
-
 
 MOCK_MARKET_DATA: dict[str, dict[str, float]] = {
     "AAPL": {
@@ -73,7 +74,9 @@ class SetupMarketData:
 
 
 class MockMarketDataAdapter:
-    def get_setup_data(self, symbol: str, fallback_reason: str | None = None) -> SetupMarketData:
+    def get_setup_data(
+        self, symbol: str, fallback_reason: str | None = None
+    ) -> SetupMarketData:
         payload = MOCK_MARKET_DATA.get(symbol.upper(), MOCK_MARKET_DATA["AAPL"])
         return SetupMarketData(
             symbol=symbol.upper(),
@@ -97,6 +100,7 @@ class AlpacaPolygonMarketDataAdapter:
         self.settings = settings
         self.fallback = MockMarketDataAdapter()
         self._market_tz = ZoneInfo("America/New_York")
+        self._setup_cache: dict[str, tuple[float, SetupMarketData]] = {}
 
     def _data_client(self) -> httpx.Client:
         return httpx.Client(
@@ -105,7 +109,7 @@ class AlpacaPolygonMarketDataAdapter:
                 "APCA-API-KEY-ID": self.settings.alpaca_api_key_id,
                 "APCA-API-SECRET-KEY": self.settings.alpaca_api_secret_key,
             },
-            timeout=10.0,
+            timeout=4.0,
         )
 
     def _trading_client(self) -> httpx.Client:
@@ -115,10 +119,14 @@ class AlpacaPolygonMarketDataAdapter:
                 "APCA-API-KEY-ID": self.settings.alpaca_api_key_id,
                 "APCA-API-SECRET-KEY": self.settings.alpaca_api_secret_key,
             },
-            timeout=10.0,
+            timeout=4.0,
         )
 
-    def _fail_or_fallback(self, symbol: str, reason: str, message: str) -> SetupMarketData:
+    def _fail_or_fallback(
+        self, symbol: str, reason: str, message: str
+    ) -> SetupMarketData:
+        if self.settings.broker_mode in {"alpaca_paper", "alpaca_live"}:
+            raise ValueError(message)
         if self.settings.allow_controller_mock:
             return self.fallback.get_setup_data(symbol, fallback_reason=reason)
         raise ValueError(message)
@@ -154,7 +162,9 @@ class AlpacaPolygonMarketDataAdapter:
             return self._session_state_from_timestamp(datetime.now(UTC))
         if bool(clock_payload.get("is_open")):
             return "regular_open"
-        current = self._parse_quote_timestamp(str(clock_payload.get("timestamp") or "")) or datetime.now(UTC)
+        current = self._parse_quote_timestamp(
+            str(clock_payload.get("timestamp") or "")
+        ) or datetime.now(UTC)
         return self._session_state_from_timestamp(current)
 
     def _session_state_from_timestamp(self, timestamp: datetime) -> str:
@@ -170,7 +180,9 @@ class AlpacaPolygonMarketDataAdapter:
             return "after_hours"
         return "overnight"
 
-    def _latest_quote(self, client: httpx.Client, symbol: str) -> tuple[dict | None, datetime | None]:
+    def _latest_quote(
+        self, client: httpx.Client, symbol: str
+    ) -> tuple[dict | None, datetime | None]:
         response = client.get(f"/v2/stocks/{symbol}/quotes/latest")
         response.raise_for_status()
         quote = response.json().get("quote")
@@ -178,7 +190,9 @@ class AlpacaPolygonMarketDataAdapter:
             return None, None
         return quote, self._parse_quote_timestamp(str(quote.get("t") or ""))
 
-    def _snapshot_quote(self, client: httpx.Client, symbol: str) -> tuple[dict | None, datetime | None]:
+    def _snapshot_quote(
+        self, client: httpx.Client, symbol: str
+    ) -> tuple[dict | None, datetime | None]:
         response = client.get(f"/v2/stocks/{symbol}/snapshot")
         response.raise_for_status()
         quote = response.json().get("latestQuote")
@@ -192,7 +206,13 @@ class AlpacaPolygonMarketDataAdapter:
         payload = response.json()
         return payload if isinstance(payload, dict) else None
 
-    def _historical_quote(self, client: httpx.Client, symbol: str) -> tuple[dict | None, datetime | None]:
+    def _load_snapshot_payload(self, symbol: str) -> dict | None:
+        with self._data_client() as client:
+            return self._snapshot_payload(client, symbol)
+
+    def _historical_quote(
+        self, client: httpx.Client, symbol: str
+    ) -> tuple[dict | None, datetime | None]:
         response = client.get(
             f"/v2/stocks/{symbol}/quotes",
             params={"limit": 1, "sort": "desc", "feed": "iex"},
@@ -206,7 +226,9 @@ class AlpacaPolygonMarketDataAdapter:
             return None, None
         return quote, self._parse_quote_timestamp(str(quote.get("t") or ""))
 
-    def _daily_bars(self, client: httpx.Client, symbol: str, *, limit: int = 60) -> list[dict]:
+    def _daily_bars(
+        self, client: httpx.Client, symbol: str, *, limit: int = 60
+    ) -> list[dict]:
         end = datetime.now(UTC)
         start = end - timedelta(days=max(limit * 2, 45))
         response = client.get(
@@ -225,6 +247,10 @@ class AlpacaPolygonMarketDataAdapter:
         if not isinstance(rows, list):
             return []
         return [row for row in rows if isinstance(row, dict)]
+
+    def _load_daily_bars(self, symbol: str, *, limit: int = 60) -> list[dict]:
+        with self._data_client() as client:
+            return self._daily_bars(client, symbol, limit=limit)
 
     def _atr14(self, bars: list[dict]) -> float | None:
         if len(bars) < 14:
@@ -260,7 +286,29 @@ class AlpacaPolygonMarketDataAdapter:
         except httpx.HTTPError:
             return None
 
+    def _cache_ttl(self, session_state: str) -> float:
+        return 8.0 if session_state == "regular_open" else 45.0
+
+    def _get_cached_setup(self, symbol: str) -> SetupMarketData | None:
+        cache_entry = self._setup_cache.get(symbol.upper())
+        if cache_entry is None:
+            return None
+        cached_at, payload = cache_entry
+        if time.monotonic() - cached_at > self._cache_ttl(payload.session_state):
+            self._setup_cache.pop(symbol.upper(), None)
+            return None
+        return SetupMarketData(**payload.__dict__)
+
+    def _store_cached_setup(
+        self, symbol: str, payload: SetupMarketData
+    ) -> SetupMarketData:
+        self._setup_cache[symbol.upper()] = (time.monotonic(), payload)
+        return SetupMarketData(**payload.__dict__)
+
     def get_setup_data(self, symbol: str) -> SetupMarketData:
+        cached = self._get_cached_setup(symbol)
+        if cached is not None:
+            return cached
         if not self.settings.has_alpaca_credentials:
             return self._fail_or_fallback(
                 symbol,
@@ -268,40 +316,70 @@ class AlpacaPolygonMarketDataAdapter:
                 message="Alpaca paper credentials are missing for latest quote retrieval.",
             )
         try:
-            quote: dict | None = None
-            quote_timestamp: datetime | None = None
-            quote_state = "quote_unavailable"
-            session_state = "closed"
+            upper_symbol = symbol.upper()
+            with ThreadPoolExecutor(max_workers=3) as executor:
+                snapshot_future = executor.submit(
+                    self._load_snapshot_payload, upper_symbol
+                )
+                daily_bars_future = executor.submit(self._load_daily_bars, upper_symbol)
+                clock_future = executor.submit(self._market_clock)
+                snapshot_payload = snapshot_future.result()
+                daily_bars = daily_bars_future.result()
+                clock_payload = clock_future.result()
+            snapshot_quote = (
+                snapshot_payload.get("latestQuote")
+                if isinstance(snapshot_payload, dict)
+                else None
+            )
+            latest_trade = (
+                snapshot_payload.get("latestTrade")
+                if isinstance(snapshot_payload, dict)
+                else None
+            )
+            daily_bar = (
+                snapshot_payload.get("dailyBar")
+                if isinstance(snapshot_payload, dict)
+                else None
+            )
+            prev_daily_bar = (
+                snapshot_payload.get("prevDailyBar")
+                if isinstance(snapshot_payload, dict)
+                else None
+            )
             with self._data_client() as client:
-                snapshot_payload = self._snapshot_payload(client, symbol.upper())
-                snapshot_quote = snapshot_payload.get("latestQuote") if isinstance(snapshot_payload, dict) else None
-                latest_trade = snapshot_payload.get("latestTrade") if isinstance(snapshot_payload, dict) else None
-                daily_bar = snapshot_payload.get("dailyBar") if isinstance(snapshot_payload, dict) else None
-                prev_daily_bar = snapshot_payload.get("prevDailyBar") if isinstance(snapshot_payload, dict) else None
-                latest_quote, latest_timestamp = self._latest_quote(client, symbol.upper())
-                if self._has_usable_bid_ask(latest_quote):
-                    quote = latest_quote
-                    quote_timestamp = latest_timestamp
-                    quote_state = "live_quote"
+                quote: dict | None = None
+                quote_timestamp: datetime | None = None
+                quote_state = "quote_unavailable"
+                snapshot_timestamp = self._parse_quote_timestamp(
+                    str((snapshot_quote or {}).get("t") or "")
+                )
+                if self._has_usable_bid_ask(snapshot_quote):
+                    quote = snapshot_quote
+                    quote_timestamp = snapshot_timestamp
+                    quote_state = "cached_quote"
                 else:
-                    snapshot_timestamp = self._parse_quote_timestamp(str((snapshot_quote or {}).get("t") or ""))
-                    if self._has_usable_bid_ask(snapshot_quote):
-                        quote = snapshot_quote
-                        quote_timestamp = snapshot_timestamp
-                        quote_state = "cached_quote"
+                    latest_quote, latest_timestamp = self._latest_quote(
+                        client, symbol.upper()
+                    )
+                    if self._has_usable_bid_ask(latest_quote):
+                        quote = latest_quote
+                        quote_timestamp = latest_timestamp
+                        quote_state = "live_quote"
                     else:
-                        historical_quote, historical_timestamp = self._historical_quote(client, symbol.upper())
+                        historical_quote, historical_timestamp = self._historical_quote(
+                            client, upper_symbol
+                        )
                         if isinstance(historical_quote, dict):
                             quote = historical_quote
                             quote_timestamp = historical_timestamp
                             quote_state = "cached_quote"
-                daily_bars = self._daily_bars(client, symbol.upper(), limit=60)
-            clock_payload = self._market_clock()
             session_state = self._session_state_from_clock(clock_payload)
             if session_state != "regular_open" and quote_state == "live_quote":
                 quote_state = "cached_quote"
             if not quote:
-                raise ValueError(f"Alpaca quote unavailable for {symbol.upper()} right now.")
+                raise ValueError(
+                    f"Alpaca quote unavailable for {upper_symbol} right now."
+                )
             last_trade_price = self._parse_float((latest_trade or {}).get("p"))
             fallback = self.fallback.get_setup_data(symbol)
             bid = self._parse_float(quote.get("bp"))
@@ -311,20 +389,35 @@ class AlpacaPolygonMarketDataAdapter:
             if ask <= 0:
                 ask = last_trade_price
             if bid <= 0 or ask <= 0:
-                raise ValueError(f"Alpaca quote unavailable for {symbol.upper()} right now.")
+                raise ValueError(
+                    f"Alpaca quote unavailable for {upper_symbol} right now."
+                )
             if not isinstance(daily_bar, dict):
-                raise ValueError(f"Alpaca daily bar unavailable for {symbol.upper()} right now.")
+                raise ValueError(
+                    f"Alpaca daily bar unavailable for {upper_symbol} right now."
+                )
             lod = self._parse_float(daily_bar.get("l"))
             hod = self._parse_float(daily_bar.get("h"))
-            prev_close = self._parse_float((prev_daily_bar or {}).get("c"), fallback.prev_close)
+            prev_close = self._parse_float(
+                (prev_daily_bar or {}).get("c"), fallback.prev_close
+            )
             atr14 = self._atr14(daily_bars)
             if lod <= 0 or hod <= 0:
-                raise ValueError(f"Alpaca daily range unavailable for {symbol.upper()} right now.")
+                raise ValueError(
+                    f"Alpaca daily range unavailable for {upper_symbol} right now."
+                )
             if atr14 is None or atr14 <= 0:
-                raise ValueError(f"Alpaca ATR14 unavailable for {symbol.upper()} right now.")
-            entry_basis = "bid_ask_midpoint" if self._parse_float(quote.get("bp")) > 0 and self._parse_float(quote.get("ap")) > 0 else "hybrid_quote_trade_midpoint"
-            return SetupMarketData(
-                symbol=symbol.upper(),
+                raise ValueError(
+                    f"Alpaca ATR14 unavailable for {upper_symbol} right now."
+                )
+            entry_basis = (
+                "bid_ask_midpoint"
+                if self._parse_float(quote.get("bp")) > 0
+                and self._parse_float(quote.get("ap")) > 0
+                else "hybrid_quote_trade_midpoint"
+            )
+            payload = SetupMarketData(
+                symbol=upper_symbol,
                 provider="alpaca_market",
                 provider_state="real_quote_range_atr_fallback_technicals",
                 quote_provider="alpaca",
@@ -338,7 +431,9 @@ class AlpacaPolygonMarketDataAdapter:
                 entry_basis=entry_basis,
                 bid=bid,
                 ask=ask,
-                last=round(last_trade_price if last_trade_price > 0 else (bid + ask) / 2, 2),
+                last=round(
+                    last_trade_price if last_trade_price > 0 else (bid + ask) / 2, 2
+                ),
                 lod=lod,
                 hod=hod,
                 prev_close=prev_close,
@@ -350,6 +445,7 @@ class AlpacaPolygonMarketDataAdapter:
                 rvol=fallback.rvol,
                 days_to_cover=fallback.days_to_cover,
             )
+            return self._store_cached_setup(symbol, payload)
         except Exception as exc:
             return self._fail_or_fallback(
                 symbol,

--- a/backend/app/adapters/market_data.py
+++ b/backend/app/adapters/market_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import httpx
@@ -56,6 +56,7 @@ class SetupMarketData:
     quote_timestamp: datetime | None
     session_state: str
     quote_state: str
+    entry_basis: str
     bid: float
     ask: float
     last: float
@@ -86,6 +87,7 @@ class MockMarketDataAdapter:
             quote_timestamp=datetime.now(UTC),
             session_state="closed",
             quote_state="quote_unavailable",
+            entry_basis="bid_ask_midpoint",
             **payload,
         )
 
@@ -141,6 +143,12 @@ class AlpacaPolygonMarketDataAdapter:
             return False
         return bid > 0 and ask > 0
 
+    def _parse_float(self, value: object, fallback: float = 0.0) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return fallback
+
     def _session_state_from_clock(self, clock_payload: dict | None) -> str:
         if not clock_payload:
             return self._session_state_from_timestamp(datetime.now(UTC))
@@ -178,6 +186,12 @@ class AlpacaPolygonMarketDataAdapter:
             return None, None
         return quote, self._parse_quote_timestamp(str(quote.get("t") or ""))
 
+    def _snapshot_payload(self, client: httpx.Client, symbol: str) -> dict | None:
+        response = client.get(f"/v2/stocks/{symbol}/snapshot")
+        response.raise_for_status()
+        payload = response.json()
+        return payload if isinstance(payload, dict) else None
+
     def _historical_quote(self, client: httpx.Client, symbol: str) -> tuple[dict | None, datetime | None]:
         response = client.get(
             f"/v2/stocks/{symbol}/quotes",
@@ -191,6 +205,50 @@ class AlpacaPolygonMarketDataAdapter:
         if not isinstance(quote, dict):
             return None, None
         return quote, self._parse_quote_timestamp(str(quote.get("t") or ""))
+
+    def _daily_bars(self, client: httpx.Client, symbol: str, *, limit: int = 60) -> list[dict]:
+        end = datetime.now(UTC)
+        start = end - timedelta(days=max(limit * 2, 45))
+        response = client.get(
+            f"/v2/stocks/{symbol}/bars",
+            params={
+                "timeframe": "1Day",
+                "start": start.isoformat().replace("+00:00", "Z"),
+                "end": end.isoformat().replace("+00:00", "Z"),
+                "limit": max(20, min(limit, 200)),
+                "feed": "iex",
+                "adjustment": "raw",
+            },
+        )
+        response.raise_for_status()
+        rows = response.json().get("bars")
+        if not isinstance(rows, list):
+            return []
+        return [row for row in rows if isinstance(row, dict)]
+
+    def _atr14(self, bars: list[dict]) -> float | None:
+        if len(bars) < 14:
+            return None
+        true_ranges: list[float] = []
+        prev_close: float | None = None
+        for bar in bars:
+            high = self._parse_float(bar.get("h"))
+            low = self._parse_float(bar.get("l"))
+            close = self._parse_float(bar.get("c"))
+            if min(high, low, close) <= 0:
+                continue
+            if prev_close is None:
+                tr = high - low
+            else:
+                tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+            true_ranges.append(tr)
+            prev_close = close
+        if len(true_ranges) < 14:
+            return None
+        atr = sum(true_ranges[:14]) / 14
+        for tr in true_ranges[14:]:
+            atr = ((atr * 13) + tr) / 14
+        return round(atr, 4)
 
     def _market_clock(self) -> dict | None:
         try:
@@ -215,51 +273,76 @@ class AlpacaPolygonMarketDataAdapter:
             quote_state = "quote_unavailable"
             session_state = "closed"
             with self._data_client() as client:
+                snapshot_payload = self._snapshot_payload(client, symbol.upper())
+                snapshot_quote = snapshot_payload.get("latestQuote") if isinstance(snapshot_payload, dict) else None
+                latest_trade = snapshot_payload.get("latestTrade") if isinstance(snapshot_payload, dict) else None
+                daily_bar = snapshot_payload.get("dailyBar") if isinstance(snapshot_payload, dict) else None
+                prev_daily_bar = snapshot_payload.get("prevDailyBar") if isinstance(snapshot_payload, dict) else None
                 latest_quote, latest_timestamp = self._latest_quote(client, symbol.upper())
                 if self._has_usable_bid_ask(latest_quote):
                     quote = latest_quote
                     quote_timestamp = latest_timestamp
                     quote_state = "live_quote"
                 else:
-                    snapshot_quote, snapshot_timestamp = self._snapshot_quote(client, symbol.upper())
+                    snapshot_timestamp = self._parse_quote_timestamp(str((snapshot_quote or {}).get("t") or ""))
                     if self._has_usable_bid_ask(snapshot_quote):
                         quote = snapshot_quote
                         quote_timestamp = snapshot_timestamp
                         quote_state = "cached_quote"
                     else:
                         historical_quote, historical_timestamp = self._historical_quote(client, symbol.upper())
-                        if self._has_usable_bid_ask(historical_quote):
+                        if isinstance(historical_quote, dict):
                             quote = historical_quote
                             quote_timestamp = historical_timestamp
                             quote_state = "cached_quote"
+                daily_bars = self._daily_bars(client, symbol.upper(), limit=60)
             clock_payload = self._market_clock()
             session_state = self._session_state_from_clock(clock_payload)
             if session_state != "regular_open" and quote_state == "live_quote":
                 quote_state = "cached_quote"
             if not quote:
                 raise ValueError(f"Alpaca quote unavailable for {symbol.upper()} right now.")
+            last_trade_price = self._parse_float((latest_trade or {}).get("p"))
             fallback = self.fallback.get_setup_data(symbol)
-            bid = float(quote.get("bp", fallback.bid))
-            ask = float(quote.get("ap", fallback.ask))
+            bid = self._parse_float(quote.get("bp"))
+            ask = self._parse_float(quote.get("ap"))
+            if bid <= 0:
+                bid = last_trade_price
+            if ask <= 0:
+                ask = last_trade_price
+            if bid <= 0 or ask <= 0:
+                raise ValueError(f"Alpaca quote unavailable for {symbol.upper()} right now.")
+            if not isinstance(daily_bar, dict):
+                raise ValueError(f"Alpaca daily bar unavailable for {symbol.upper()} right now.")
+            lod = self._parse_float(daily_bar.get("l"))
+            hod = self._parse_float(daily_bar.get("h"))
+            prev_close = self._parse_float((prev_daily_bar or {}).get("c"), fallback.prev_close)
+            atr14 = self._atr14(daily_bars)
+            if lod <= 0 or hod <= 0:
+                raise ValueError(f"Alpaca daily range unavailable for {symbol.upper()} right now.")
+            if atr14 is None or atr14 <= 0:
+                raise ValueError(f"Alpaca ATR14 unavailable for {symbol.upper()} right now.")
+            entry_basis = "bid_ask_midpoint" if self._parse_float(quote.get("bp")) > 0 and self._parse_float(quote.get("ap")) > 0 else "hybrid_quote_trade_midpoint"
             return SetupMarketData(
                 symbol=symbol.upper(),
-                provider="alpaca_quote",
-                provider_state="real_quote_fallback_technicals",
+                provider="alpaca_market",
+                provider_state="real_quote_range_atr_fallback_technicals",
                 quote_provider="alpaca",
                 technicals_provider="mock",
                 quote_is_real=True,
                 technicals_are_fallback=True,
-                fallback_reason="technicals_fallback_only",
+                fallback_reason="partial_technicals_fallback_only",
                 quote_timestamp=quote_timestamp,
                 session_state=session_state,
                 quote_state=quote_state,
+                entry_basis=entry_basis,
                 bid=bid,
                 ask=ask,
-                last=round((bid + ask) / 2, 2),
-                lod=fallback.lod,
-                hod=fallback.hod,
-                prev_close=fallback.prev_close,
-                atr14=fallback.atr14,
+                last=round(last_trade_price if last_trade_price > 0 else (bid + ask) / 2, 2),
+                lod=lod,
+                hod=hod,
+                prev_close=prev_close,
+                atr14=atr14,
                 sma10=fallback.sma10,
                 sma50=fallback.sma50,
                 sma200=fallback.sma200,

--- a/backend/app/api/deps_auth.py
+++ b/backend/app/api/deps_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 from typing import Any
 
 from fastapi import Depends, HTTPException, Request, WebSocket, status
@@ -12,7 +13,11 @@ auth_store = get_auth_store(settings)
 
 
 def _default_user() -> dict[str, Any]:
-    username = settings.auth_admin_username if settings.app_default_role == "admin" else settings.auth_trader_username
+    username = (
+        settings.auth_admin_username
+        if settings.app_default_role == "admin"
+        else settings.auth_trader_username
+    )
     return {
         "user": {
             "id": 0,
@@ -36,7 +41,58 @@ def require_session(request: Request) -> dict[str, Any]:
     return session
 
 
-def require_operator_session(session: dict[str, Any] = Depends(require_session)) -> dict[str, Any]:
+def require_trusted_origin(request: Request) -> None:
+    if request.method.upper() in {"GET", "HEAD", "OPTIONS"}:
+        return
+    origin = request.headers.get("origin")
+    if not origin:
+        return
+    if origin not in settings.trusted_origins:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Untrusted request origin",
+        )
+
+
+def require_csrf(request: Request) -> None:
+    if not settings.auth_require_csrf:
+        return
+    if request.method.upper() in {"GET", "HEAD", "OPTIONS"}:
+        return
+    cookie_token = request.cookies.get(settings.auth_csrf_cookie_name)
+    header_token = request.headers.get(settings.auth_csrf_header_name)
+    if not cookie_token or not header_token or cookie_token != header_token:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF validation failed",
+        )
+
+
+def require_write_guard(request: Request, _: dict[str, Any] = Depends(require_session)) -> None:
+    require_trusted_origin(request)
+    require_csrf(request)
+
+
+def require_webhook_secret(request: Request) -> None:
+    expected = settings.ops_signing_secret.strip()
+    if not expected:
+        if settings.app_env in {"staging", "production"}:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Webhook signing secret is not configured",
+            )
+        return
+    provided = request.headers.get(settings.webhook_secret_header_name, "").strip()
+    if not provided or not hmac.compare_digest(provided, expected):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid webhook secret",
+        )
+
+
+def require_operator_session(
+    session: dict[str, Any] = Depends(require_session),
+) -> dict[str, Any]:
     if settings.require_ops_auth and str(session["user"]["role"]) != "admin":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin session required")
     return session

--- a/backend/app/api/routes_account.py
+++ b/backend/app/api/routes_account.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.api.deps_auth import require_operator_session, require_session
+from app.api.deps_auth import require_operator_session, require_session, require_write_guard
 from app.db.session import get_db
 from app.schemas.cockpit import AccountSettingsUpdate, AccountSettingsView, LogEntry
 from app.services.cockpit import CockpitService
@@ -17,22 +17,27 @@ def build_router(service: CockpitService) -> APIRouter:
         return service.get_account(db)
 
     @router.put("/account/settings", response_model=AccountSettingsView)
-    def update_account(
+    async def update_account(
         payload: AccountSettingsUpdate,
         db: Session = Depends(get_db),
         _: dict = Depends(require_operator_session),
+        __: None = Depends(require_write_guard),
     ) -> AccountSettingsView:
         try:
-            return service.update_account(db, payload)
+            view = service.update_account(db, payload)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        await service.broadcast_account_update(db)
+        return view
 
     @router.get("/activity-log", response_model=list[LogEntry])
     def get_logs(db: Session = Depends(get_db)) -> list[LogEntry]:
         return service.get_logs(db)
 
     @router.delete("/activity-log")
-    def clear_logs(db: Session = Depends(get_db)) -> dict[str, int]:
+    def clear_logs(
+        db: Session = Depends(get_db), _: None = Depends(require_write_guard)
+    ) -> dict[str, int]:
         return {"cleared": service.clear_logs(db)}
 
     return router

--- a/backend/app/api/routes_auth.py
+++ b/backend/app/api/routes_auth.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import secrets
+
 from fastapi import APIRouter, HTTPException, Request, Response
 
 from app.core.config import Settings
@@ -29,15 +31,24 @@ def login(payload: LoginRequest, request: Request, response: Response) -> LoginR
     user = auth_store.authenticate(username=payload.username, password=payload.password)
     if user is None:
         raise HTTPException(status_code=401, detail="Invalid credentials")
+    auth_store.revoke_session(session_token=request.cookies.get(settings.auth_cookie_name))
     session_token, session_data = auth_store.create_session(
         user=user,
         user_agent=request.headers.get("user-agent"),
         ip_addr=request.client.host if request.client else None,
     )
+    csrf_token = secrets.token_urlsafe(32)
     response.set_cookie(
         settings.auth_cookie_name,
         session_token,
         httponly=True,
+        samesite=settings.auth_cookie_samesite,
+        secure=settings.auth_cookie_secure,
+    )
+    response.set_cookie(
+        settings.auth_csrf_cookie_name,
+        csrf_token,
+        httponly=False,
         samesite=settings.auth_cookie_samesite,
         secure=settings.auth_cookie_secure,
     )
@@ -54,6 +65,12 @@ def logout(request: Request, response: Response) -> dict[str, bool]:
     response.delete_cookie(
         settings.auth_cookie_name,
         httponly=True,
+        samesite=settings.auth_cookie_samesite,
+        secure=settings.auth_cookie_secure,
+    )
+    response.delete_cookie(
+        settings.auth_csrf_cookie_name,
+        httponly=False,
         samesite=settings.auth_cookie_samesite,
         secure=settings.auth_cookie_secure,
     )

--- a/backend/app/api/routes_broker.py
+++ b/backend/app/api/routes_broker.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.deps_auth import require_webhook_secret
+from app.db.session import get_db
+from app.services.cockpit import CockpitService
+
+
+def build_router(service: CockpitService) -> APIRouter:
+    router = APIRouter(prefix="/api/broker", tags=["broker"])
+
+    @router.post("/webhook")
+    async def broker_webhook(
+        payload: dict[str, Any] = Body(default_factory=dict),
+        db: Session = Depends(get_db),
+        _: None = Depends(require_webhook_secret),
+    ) -> dict[str, Any]:
+        try:
+            result = service.ingest_broker_webhook(db, payload)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        db.commit()
+
+        for symbol in result.get("symbols", []):
+            try:
+                view = service.get_position(db, symbol)
+            except ValueError:
+                continue
+            await service.broadcast_position_projection(db, view)
+
+        if result.get("accountChanged"):
+            await service.broadcast_account_update(db)
+
+        return {
+            "received": result.get("received", 0),
+            "processedOrders": result.get("processedOrders", 0),
+            "processedFills": result.get("processedFills", 0),
+            "processedAccounts": result.get("processedAccounts", 0),
+            "symbols": result.get("symbols", []),
+            "accountChanged": bool(result.get("accountChanged")),
+        }
+
+    return router

--- a/backend/app/api/routes_market.py
+++ b/backend/app/api/routes_market.py
@@ -10,7 +10,9 @@ from app.services.cockpit import CockpitService
 
 
 def build_router(service: CockpitService) -> APIRouter:
-    router = APIRouter(prefix="/api", tags=["market"], dependencies=[Depends(require_session)])
+    router = APIRouter(
+        prefix="/api", tags=["market"], dependencies=[Depends(require_session)]
+    )
 
     @router.get("/setup/{symbol}", response_model=SetupResponse)
     def get_setup(symbol: str, db: Session = Depends(get_db)) -> SetupResponse:

--- a/backend/app/api/routes_positions.py
+++ b/backend/app/api/routes_positions.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from app.api.deps_auth import require_session
+from app.api.deps_auth import require_session, require_write_guard
 from app.db.session import get_db
 from app.schemas.cockpit import OrderView, PositionView
 from app.services.cockpit import CockpitService
@@ -23,5 +24,20 @@ def build_router(service: CockpitService) -> APIRouter:
     @router.get("/orders/{symbol}", response_model=list[OrderView])
     def get_orders(symbol: str, db: Session = Depends(get_db)) -> list[OrderView]:
         return service.get_orders(db, symbol)
+
+    @router.get("/orders", response_model=list[OrderView])
+    def get_recent_orders(db: Session = Depends(get_db)) -> list[OrderView]:
+        return service.get_recent_orders(db)
+
+    @router.delete("/orders/{broker_order_id}", response_model=OrderView)
+    def cancel_order(
+        broker_order_id: str,
+        db: Session = Depends(get_db),
+        _: None = Depends(require_write_guard),
+    ) -> OrderView:
+        try:
+            return service.cancel_recent_order(db, broker_order_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return router

--- a/backend/app/api/routes_trade.py
+++ b/backend/app/api/routes_trade.py
@@ -3,52 +3,84 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.api.deps_auth import require_session
+from app.api.deps_auth import require_session, require_write_guard
 from app.db.session import get_db
-from app.schemas.cockpit import MoveToBeRequest, PositionView, ProfitRequest, StopsRequest, TradeEnterRequest, TradePreviewRequest
+from app.schemas.cockpit import (
+    MoveToBeRequest,
+    PositionView,
+    ProfitRequest,
+    StopsRequest,
+    TradeEnterRequest,
+    TradePreviewRequest,
+    TradePreviewResponse,
+)
 from app.services.cockpit import CockpitService
 
 
 def build_router(service: CockpitService) -> APIRouter:
     router = APIRouter(prefix="/api/trade", tags=["trade"], dependencies=[Depends(require_session)])
 
-    @router.post("/preview")
-    def preview(payload: TradePreviewRequest, db: Session = Depends(get_db)) -> dict:
+    @router.post("/preview", response_model=TradePreviewResponse)
+    def preview(
+        payload: TradePreviewRequest,
+        db: Session = Depends(get_db),
+        _: None = Depends(require_write_guard),
+    ) -> TradePreviewResponse:
         try:
             return service.preview_trade(db, payload)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/enter", response_model=PositionView)
-    async def enter(payload: TradeEnterRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def enter(
+        payload: TradeEnterRequest,
+        db: Session = Depends(get_db),
+        _: None = Depends(require_write_guard),
+    ) -> PositionView:
         try:
             return await service.enter_trade(db, payload)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/stops", response_model=PositionView)
-    async def stops(payload: StopsRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def stops(
+        payload: StopsRequest,
+        db: Session = Depends(get_db),
+        _: None = Depends(require_write_guard),
+    ) -> PositionView:
         try:
             return await service.apply_stops(db, payload)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/profit", response_model=PositionView)
-    async def profit(payload: ProfitRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def profit(
+        payload: ProfitRequest,
+        db: Session = Depends(get_db),
+        _: None = Depends(require_write_guard),
+    ) -> PositionView:
         try:
             return await service.execute_profit_plan(db, payload)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/flatten", response_model=PositionView)
-    async def flatten(payload: MoveToBeRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def flatten(
+        payload: MoveToBeRequest,
+        db: Session = Depends(get_db),
+        _: None = Depends(require_write_guard),
+    ) -> PositionView:
         try:
             return await service.flatten(db, payload.symbol)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @router.post("/move_to_be", response_model=PositionView)
-    async def move_to_be(payload: MoveToBeRequest, db: Session = Depends(get_db)) -> PositionView:
+    async def move_to_be(
+        payload: MoveToBeRequest,
+        db: Session = Depends(get_db),
+        _: None = Depends(require_write_guard),
+    ) -> PositionView:
         try:
             return await service.move_to_be(db, payload.symbol)
         except ValueError as exc:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -61,6 +61,10 @@ class Settings:
     auth_cookie_name: str
     auth_cookie_samesite: str
     auth_cookie_secure: bool
+    auth_csrf_cookie_name: str
+    auth_csrf_header_name: str
+    auth_require_csrf: bool
+    webhook_secret_header_name: str
     auth_db_path: str
     auth_seed_users: bool
     auth_admin_username: str
@@ -71,6 +75,7 @@ class Settings:
     redis_url: str
     redis_channel_prefix: str
     cors_origins: list[str]
+    trusted_origins: list[str]
     broker_mode: str
     allow_live_trading: bool
     allow_controller_mock: bool
@@ -87,6 +92,12 @@ class Settings:
     max_position_notional_pct: float
     daily_loss_limit_pct: float
     max_open_positions: int
+    trading_enabled: bool
+    disabled_symbols: list[str]
+    max_quote_age_seconds: int
+    reconcile_fast_interval_seconds: int
+    reconcile_slow_interval_seconds: int
+    max_reconcile_age_seconds: int
     ops_api_key: str
     ops_admin_api_key: str
     ops_signing_secret: str
@@ -106,23 +117,41 @@ class Settings:
             "testing": "test",
         }.get(app_env_raw, "development")
         app_default_role_raw = os.getenv("APP_DEFAULT_ROLE", "admin").strip().lower()
-        app_default_role = app_default_role_raw if app_default_role_raw in {"admin", "trader"} else "admin"
+        app_default_role = (
+            app_default_role_raw if app_default_role_raw in {"admin", "trader"} else "admin"
+        )
         allow_role_override_default = "false" if app_env == "production" else "true"
-        allow_role_override = _as_bool(os.getenv("APP_ALLOW_ROLE_OVERRIDE", allow_role_override_default))
+        allow_role_override = _as_bool(
+            os.getenv("APP_ALLOW_ROLE_OVERRIDE", allow_role_override_default)
+        )
         require_ops_auth_default = "true" if app_env == "production" else "false"
         require_ops_auth = _as_bool(os.getenv("OPS_REQUIRE_AUTH", require_ops_auth_default))
-        sqlite_fallback_url = os.getenv("SQLITE_FALLBACK_URL", "sqlite:///./data/traders_cockpit.db").strip()
+        sqlite_fallback_url = os.getenv(
+            "SQLITE_FALLBACK_URL", "sqlite:///./data/traders_cockpit.db"
+        ).strip()
         allow_sqlite_fallback = _as_bool(os.getenv("ALLOW_SQLITE_FALLBACK", "false"))
         auth_db_path = os.getenv("AUTH_DB_PATH", "./data/auth.db").strip() or "./data/auth.db"
         auth_cookie_secure_default = "true" if app_env in {"staging", "production"} else "false"
         auth_cookie_samesite_default = "none" if app_env in {"staging", "production"} else "lax"
-        auth_cookie_samesite_raw = os.getenv("AUTH_COOKIE_SAMESITE", auth_cookie_samesite_default).strip().lower()
-        auth_cookie_samesite = auth_cookie_samesite_raw if auth_cookie_samesite_raw in {"lax", "strict", "none"} else auth_cookie_samesite_default
+        auth_cookie_samesite_raw = (
+            os.getenv("AUTH_COOKIE_SAMESITE", auth_cookie_samesite_default).strip().lower()
+        )
+        auth_cookie_samesite = (
+            auth_cookie_samesite_raw
+            if auth_cookie_samesite_raw in {"lax", "strict", "none"}
+            else auth_cookie_samesite_default
+        )
         default_db = (
             sqlite_fallback_url
             if app_env == "test" or allow_sqlite_fallback
             else "postgresql://traders_cockpit:traders_cockpit@127.0.0.1:55432/traders_cockpit"
         )
+        broker_mode_raw = os.getenv("BROKER_MODE", "paper").strip().lower()
+        broker_mode = {
+            "sim_paper": "paper",
+            "broker_paper": "alpaca_paper",
+            "live": "alpaca_live",
+        }.get(broker_mode_raw, broker_mode_raw)
         return cls(
             app_env=app_env,
             app_default_role=app_default_role,
@@ -132,13 +161,28 @@ class Settings:
             auth_session_ttl_hours=max(1, int(os.getenv("AUTH_SESSION_TTL_HOURS", "24"))),
             auth_cookie_name=os.getenv("AUTH_COOKIE_NAME", "traders_cockpit_session").strip(),
             auth_cookie_samesite=auth_cookie_samesite,
-            auth_cookie_secure=_as_bool(os.getenv("AUTH_COOKIE_SECURE", auth_cookie_secure_default)),
+            auth_cookie_secure=_as_bool(
+                os.getenv("AUTH_COOKIE_SECURE", auth_cookie_secure_default)
+            ),
+            auth_csrf_cookie_name=os.getenv(
+                "AUTH_CSRF_COOKIE_NAME", "traders_cockpit_csrf"
+            ).strip(),
+            auth_csrf_header_name=os.getenv("AUTH_CSRF_HEADER_NAME", "X-CSRF-Token").strip(),
+            auth_require_csrf=_as_bool(
+                os.getenv(
+                    "AUTH_REQUIRE_CSRF",
+                    "true" if app_env in {"staging", "production"} else "false",
+                )
+            ),
+            webhook_secret_header_name=os.getenv(
+                "WEBHOOK_SECRET_HEADER_NAME", "X-Webhook-Secret"
+            ).strip(),
             auth_db_path=auth_db_path,
             auth_seed_users=_as_bool(os.getenv("AUTH_SEED_USERS", "true"), True),
             auth_admin_username=os.getenv("AUTH_ADMIN_USERNAME", "admin").strip(),
-            auth_admin_password=os.getenv("AUTH_ADMIN_PASSWORD", "admin123!").strip(),
+            auth_admin_password=os.getenv("AUTH_ADMIN_PASSWORD", "change-me-admin").strip(),
             auth_trader_username=os.getenv("AUTH_TRADER_USERNAME", "trader").strip(),
-            auth_trader_password=os.getenv("AUTH_TRADER_PASSWORD", "trader123!").strip(),
+            auth_trader_password=os.getenv("AUTH_TRADER_PASSWORD", "change-me-trader").strip(),
             database_url=_normalize_database_url(os.getenv("DATABASE_URL", default_db)),
             redis_url=os.getenv("REDIS_URL", "redis://127.0.0.1:56379/0").strip(),
             redis_channel_prefix=os.getenv("REDIS_CHANNEL_PREFIX", "traders-cockpit").strip(),
@@ -150,9 +194,26 @@ class Settings:
                 ).split(",")
                 if item.strip()
             ],
-            broker_mode=os.getenv("BROKER_MODE", "paper").strip().lower(),
+            trusted_origins=[
+                item.strip()
+                for item in os.getenv(
+                    "TRUSTED_ORIGINS",
+                    os.getenv(
+                        "CORS_ORIGINS",
+                        "http://127.0.0.1:3000,http://localhost:3000,http://127.0.0.1:3010,http://localhost:3010",
+                    ),
+                ).split(",")
+                if item.strip()
+            ],
+            broker_mode=broker_mode,
             allow_live_trading=_as_bool(os.getenv("ALLOW_LIVE_TRADING", "false")),
-            allow_controller_mock=_as_bool(os.getenv("ALLOW_CONTROLLER_MOCK", "true"), True),
+            allow_controller_mock=_as_bool(
+                os.getenv(
+                    "ALLOW_CONTROLLER_MOCK",
+                    "true" if app_env in {"development", "test"} else "false",
+                ),
+                app_env in {"development", "test"},
+            ),
             live_confirmation_token=os.getenv("LIVE_CONFIRMATION_TOKEN", "").strip(),
             alpaca_api_key_id=os.getenv("ALPACA_API_KEY_ID", "").strip(),
             alpaca_api_secret_key=os.getenv("ALPACA_API_SECRET_KEY", "").strip(),
@@ -167,13 +228,28 @@ class Settings:
             ).strip(),
             massive_api_key=os.getenv("MASSIVE_API_KEY", "") or os.getenv("POLYGON_API_KEY", ""),
             massive_api_base_url=os.getenv(
-                "MASSIVE_API_BASE_URL", os.getenv("POLYGON_API_BASE_URL", "https://api.polygon.io")
+                "MASSIVE_API_BASE_URL",
+                os.getenv("POLYGON_API_BASE_URL", "https://api.polygon.io"),
             ).strip(),
             default_account_equity=float(os.getenv("DEFAULT_ACCOUNT_EQUITY", "100000")),
             default_risk_pct=float(os.getenv("DEFAULT_RISK_PCT", "1")),
             max_position_notional_pct=float(os.getenv("MAX_POSITION_NOTIONAL_PCT", "100")),
             daily_loss_limit_pct=float(os.getenv("DAILY_LOSS_LIMIT_PCT", "2")),
             max_open_positions=max(1, int(os.getenv("MAX_OPEN_POSITIONS", "6"))),
+            trading_enabled=_as_bool(os.getenv("TRADING_ENABLED", "true"), True),
+            disabled_symbols=[
+                item.strip().upper()
+                for item in os.getenv("DISABLED_SYMBOLS", "").split(",")
+                if item.strip()
+            ],
+            max_quote_age_seconds=max(1, int(os.getenv("MAX_QUOTE_AGE_SECONDS", "15"))),
+            reconcile_fast_interval_seconds=max(
+                1, int(os.getenv("RECONCILE_FAST_INTERVAL_SECONDS", "3"))
+            ),
+            reconcile_slow_interval_seconds=max(
+                1, int(os.getenv("RECONCILE_SLOW_INTERVAL_SECONDS", "20"))
+            ),
+            max_reconcile_age_seconds=max(1, int(os.getenv("MAX_RECONCILE_AGE_SECONDS", "45"))),
             ops_api_key=os.getenv("OPS_API_KEY", "").strip(),
             ops_admin_api_key=os.getenv("OPS_ADMIN_API_KEY", "").strip(),
             ops_signing_secret=os.getenv("OPS_SIGNING_SECRET", "").strip(),
@@ -198,6 +274,14 @@ class Settings:
         return self.broker_mode in {"alpaca_paper", "alpaca_live"}
 
     @property
+    def normalized_broker_mode(self) -> str:
+        return {
+            "paper": "sim_paper",
+            "alpaca_paper": "broker_paper",
+            "alpaca_live": "live",
+        }.get(self.broker_mode, self.broker_mode)
+
+    @property
     def broker_execution_provider(self) -> str:
         if self.uses_alpaca_broker and self.has_alpaca_credentials:
             return self.broker_mode
@@ -205,8 +289,37 @@ class Settings:
 
     @property
     def local_personal_paper_ready(self) -> bool:
-        return self.broker_mode == "alpaca_paper" and not self.allow_live_trading and self.has_alpaca_credentials
+        return (
+            self.broker_mode == "alpaca_paper"
+            and not self.allow_live_trading
+            and self.has_alpaca_credentials
+        )
 
     @property
     def live_trading_enabled(self) -> bool:
-        return self.broker_mode == "alpaca_live" and self.allow_live_trading and bool(self.live_confirmation_token)
+        return (
+            self.broker_mode == "alpaca_live"
+            and self.allow_live_trading
+            and bool(self.live_confirmation_token)
+        )
+
+    def validate_runtime(self) -> None:
+        if self.is_production:
+            if self.auth_seed_users:
+                raise ValueError("AUTH_SEED_USERS must be disabled in production.")
+            weak_passwords = {"", "change-me-admin", "change-me-trader"}
+            if (
+                self.auth_admin_password in weak_passwords
+                or self.auth_trader_password in weak_passwords
+            ):
+                raise ValueError("Unsafe default auth credentials are not allowed in production.")
+        if self.app_env not in {"production", "staging"} and self.broker_mode == "alpaca_live":
+            raise ValueError("Non-production environments cannot point at live broker mode.")
+        if (
+            self.broker_mode in {"alpaca_paper", "alpaca_live"}
+            and self.allow_controller_mock
+            and self.app_env not in {"development", "test"}
+        ):
+            raise ValueError(
+                "Mock execution/data cannot coexist with broker-backed modes outside development."
+            )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,13 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.deps_auth import require_websocket_session
-from app.api import routes_account, routes_market, routes_positions, routes_trade
+from app.api import (
+    routes_account,
+    routes_broker,
+    routes_market,
+    routes_positions,
+    routes_trade,
+)
 from app.api.routes_auth import router as auth_router
 from app.core.config import Settings
 from app.db.base import Base
@@ -18,14 +24,32 @@ from app.services.cockpit import CockpitService
 from app.ws.manager import WebSocketManager
 
 settings = Settings.from_env()
+settings.validate_runtime()
 ws_manager = WebSocketManager(settings.redis_url, settings.redis_channel_prefix)
 service = CockpitService(settings, ws_manager)
 auth_store = get_auth_store(settings)
 
 
+async def reconcile_heartbeat_loop(stop_event: asyncio.Event) -> None:
+    while not stop_event.is_set():
+        interval = settings.reconcile_slow_interval_seconds
+        try:
+            with SessionLocal() as db:
+                service.run_reconcile_heartbeat(db)
+                interval = service.next_reconcile_interval_seconds(db)
+        except Exception:
+            interval = settings.reconcile_slow_interval_seconds
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+        except TimeoutError:
+            continue
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await ws_manager.start()
+    reconcile_stop = asyncio.Event()
+    reconcile_task: asyncio.Task[None] | None = None
     if settings.uses_sqlite:
         Base.metadata.create_all(bind=engine)
     auth_store.bootstrap_users(
@@ -37,7 +61,12 @@ async def lifespan(app: FastAPI):
     )
     with SessionLocal() as db:
         service.ensure_seed_data(db)
+    if not settings.uses_sqlite:
+        reconcile_task = asyncio.create_task(reconcile_heartbeat_loop(reconcile_stop))
     yield
+    reconcile_stop.set()
+    if reconcile_task is not None:
+        await reconcile_task
     await ws_manager.stop()
 
 
@@ -52,6 +81,7 @@ app.add_middleware(
 
 app.include_router(auth_router)
 app.include_router(routes_account.build_router(service))
+app.include_router(routes_broker.build_router(service))
 app.include_router(routes_market.build_router(service))
 app.include_router(routes_positions.build_router(service))
 app.include_router(routes_trade.build_router(service))

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,27 @@
-from app.models.entities import AccountSettingsEntity, OrderEntity, PositionEntity, TradeLogEntity
+from app.models.entities import (
+    AccountSettingsEntity,
+    AccountSnapshotEntity,
+    BrokerFillEntity,
+    BrokerOrderEntity,
+    EventLogEntity,
+    OrderEntity,
+    OrderIntentEntity,
+    PositionEntity,
+    PositionProjectionEntity,
+    ReconcileRunEntity,
+    TradeLogEntity,
+)
 
-__all__ = ["AccountSettingsEntity", "OrderEntity", "PositionEntity", "TradeLogEntity"]
+__all__ = [
+    "AccountSettingsEntity",
+    "AccountSnapshotEntity",
+    "BrokerFillEntity",
+    "BrokerOrderEntity",
+    "EventLogEntity",
+    "OrderEntity",
+    "OrderIntentEntity",
+    "PositionEntity",
+    "PositionProjectionEntity",
+    "ReconcileRunEntity",
+    "TradeLogEntity",
+]

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -41,6 +41,14 @@ class PositionEntity(Base):
     tranches: Mapped[list[dict]] = mapped_column(JSON, nullable=False, default=list)
     setup_snapshot: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
     root_order_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_intent_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    projection_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    reconcile_status: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="synchronized"
+    )
+    last_reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=utcnow, onupdate=utcnow
@@ -66,6 +74,124 @@ class OrderEntity(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
     filled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     fill_price: Mapped[float | None] = mapped_column(Float, nullable=True)
+    filled_qty: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    intent_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+
+class EventLogEntity(Base):
+    __tablename__ = "event_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    event_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    symbol: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    intent_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    broker_order_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    fill_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    source: Mapped[str] = mapped_column(String(32), nullable=False, default="system")
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class OrderIntentEntity(Base):
+    __tablename__ = "order_intents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    intent_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    symbol: Mapped[str] = mapped_column(String(16), nullable=False)
+    action: Mapped[str] = mapped_column(String(32), nullable=False)
+    side: Mapped[str] = mapped_column(String(8), nullable=False)
+    qty: Mapped[int] = mapped_column(Integer, nullable=False)
+    price: Mapped[float | None] = mapped_column(Float, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    blocking_reasons: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    broker_order_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+
+class BrokerOrderEntity(Base):
+    __tablename__ = "broker_orders"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    broker_order_id: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    symbol: Mapped[str] = mapped_column(String(16), nullable=False)
+    broker: Mapped[str] = mapped_column(String(32), nullable=False)
+    intent_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    side: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    order_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    qty: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    filled_qty: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    remaining_qty: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    avg_fill_price: Mapped[float | None] = mapped_column(Float, nullable=True)
+    raw_payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+
+
+class BrokerFillEntity(Base):
+    __tablename__ = "broker_fills"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    fill_id: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    broker_order_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    symbol: Mapped[str] = mapped_column(String(16), nullable=False)
+    intent_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    qty: Mapped[int] = mapped_column(Integer, nullable=False)
+    price: Mapped[float] = mapped_column(Float, nullable=False)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    raw_payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class PositionProjectionEntity(Base):
+    __tablename__ = "position_projections"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    symbol: Mapped[str] = mapped_column(String(16), nullable=False, unique=True)
+    phase: Mapped[str] = mapped_column(String(32), nullable=False)
+    reconcile_status: Mapped[str] = mapped_column(String(32), nullable=False)
+    projection_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utcnow, onupdate=utcnow
+    )
+    last_reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+
+class AccountSnapshotEntity(Base):
+    __tablename__ = "account_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    broker: Mapped[str] = mapped_column(String(32), nullable=False)
+    mode: Mapped[str] = mapped_column(String(32), nullable=False)
+    equity: Mapped[float] = mapped_column(Float, nullable=False)
+    buying_power: Mapped[float] = mapped_column(Float, nullable=False)
+    cash: Mapped[float | None] = mapped_column(Float, nullable=True)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    recorded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+
+
+class ReconcileRunEntity(Base):
+    __tablename__ = "reconcile_runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    trigger: Mapped[str] = mapped_column(String(32), nullable=False)
+    broker: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    processed_orders: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    processed_fills: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class TradeLogEntity(Base):

--- a/backend/app/schemas/cockpit.py
+++ b/backend/app/schemas/cockpit.py
@@ -11,8 +11,16 @@ class StopMode(BaseModel):
     pct: float | None = None
 
 
+EntrySide = Literal["buy", "sell"]
+
+
+class EntryOrderDraft(BaseModel):
+    side: EntrySide = "buy"
+
+
 class TrancheMode(BaseModel):
     mode: Literal["limit", "runner"] = "limit"
+    allocationPct: float | None = None
     trail: float = 2.0
     trailUnit: Literal["$", "%"] = "$"
     target: Literal["1R", "2R", "3R", "Manual"] = "1R"
@@ -24,7 +32,14 @@ class Tranche(BaseModel):
     qty: int
     stop: float
     target: float | None = None
-    status: Literal["active", "sold", "canceled"] = "active"
+    status: Literal["active", "pending_exit", "partially_filled", "sold", "closed", "canceled"] = (
+        "active"
+    )
+    exitPrice: float | None = None
+    exitFilledAt: datetime | None = None
+    exitOrderType: str | None = None
+    filledQty: int = 0
+    remainingQty: int | None = None
     mode: Literal["limit", "runner"] = "limit"
     trail: float = 2.0
     trailUnit: Literal["$", "%"] = "$"
@@ -32,26 +47,50 @@ class Tranche(BaseModel):
     runnerStop: float | None = None
 
 
+class OrderFillView(BaseModel):
+    id: str
+    brokerOrderId: str | None = None
+    symbol: str
+    qty: int
+    price: float
+    occurredAt: datetime
+    intentId: str | None = None
+
+
 class OrderView(BaseModel):
     id: str
+    symbol: str
+    side: str | None = None
     type: str
     qty: int
     origQty: int
+    filledQty: int = 0
+    remainingQty: int = 0
     price: float
     status: str
     tranche: str
     coveredTranches: list[str] = Field(default_factory=list)
     parentId: str | None = None
     brokerOrderId: str | None = None
+    cancelable: bool = False
     createdAt: datetime | None = None
+    updatedAt: datetime | None = None
     filledAt: datetime | None = None
     fillPrice: float | None = None
+    intentId: str | None = None
+    intentStatus: str | None = None
+    brokerStatus: str | None = None
+    reconcileStatus: str | None = None
+    fills: list[OrderFillView] = Field(default_factory=list)
 
 
 class PositionView(BaseModel):
     symbol: str
     phase: str
+    side: EntrySide = "buy"
     livePrice: float
+    markState: Literal["live", "frozen"] = "frozen"
+    markLabel: str | None = None
     setup: dict
     tranches: list[Tranche]
     orders: list[OrderView]
@@ -60,6 +99,15 @@ class PositionView(BaseModel):
     rootOrderId: str | None = None
     stopMode: int = 0
     trancheCount: int = 3
+    intentId: str | None = None
+    intentStatus: str | None = None
+    brokerOrderId: str | None = None
+    brokerStatus: str | None = None
+    reconcileStatus: str | None = None
+    blockingReasons: list[str] = Field(default_factory=list)
+    projectionVersion: int = 1
+    lastReconciledAt: datetime | None = None
+    fills: list[OrderFillView] = Field(default_factory=list)
 
 
 class LogEntry(BaseModel):
@@ -81,14 +129,27 @@ class SetupResponse(BaseModel):
     technicalsAreFallback: bool = True
     fallbackReason: str | None = None
     quoteTimestamp: datetime | None = None
-    sessionState: Literal["regular_open", "overnight", "pre_market", "after_hours", "closed"] = "closed"
+    sessionState: Literal["regular_open", "overnight", "pre_market", "after_hours", "closed"] = (
+        "closed"
+    )
     quoteState: Literal["live_quote", "cached_quote", "quote_unavailable"] = "quote_unavailable"
     entryBasis: str = "midpoint"
+    dataQuality: Literal["live", "fallback", "stale", "blocked"] = "blocked"
+    quoteAgeMs: int | None = None
+    reconcileStatus: Literal["synchronized", "pending", "stale"] = "synchronized"
+    lastReconciledAt: datetime | None = None
+    isExecutable: bool = False
+    executionBlockingReasons: list[str] = Field(default_factory=list)
     stopReferenceDefault: Literal["lod", "atr", "manual"] = "lod"
+    shortStopReferenceDefault: Literal["lod", "atr", "manual"] = "lod"
     lodIsValid: bool = True
     atrIsValid: bool = True
+    hodIsValid: bool = True
+    shortAtrIsValid: bool = True
     lodStop: float
     atrStop: float
+    hodStop: float
+    shortAtrStop: float
     manualStopWarning: str | None = None
     bid: float
     ask: float
@@ -114,9 +175,24 @@ class SetupResponse(BaseModel):
     riskPct: float
     accountEquity: float
     accountBuyingPower: float
+    accountCash: float | None = None
     equitySource: str = "local_settings"
+    sizingWarning: str | None = None
+    buyingPowerNote: str | None = None
     atrExtension: float
     extFrom10Ma: float
+
+
+class TradePreviewResponse(BaseModel):
+    symbol: str
+    entry: float
+    finalStop: float
+    perShareRisk: float
+    shares: int
+    dollarRisk: float
+    sizingWarning: str | None = None
+    isExecutable: bool = False
+    blockingReasons: list[str] = Field(default_factory=list)
 
 
 class TradePreviewRequest(BaseModel):
@@ -125,6 +201,7 @@ class TradePreviewRequest(BaseModel):
     stopRef: Literal["lod", "atr", "manual"] = "lod"
     stopPrice: float
     riskPct: float
+    order: EntryOrderDraft = Field(default_factory=EntryOrderDraft)
 
 
 class TradeEnterRequest(BaseModel):
@@ -135,6 +212,7 @@ class TradeEnterRequest(BaseModel):
     trancheCount: int = 3
     trancheModes: list[TrancheMode]
     offHoursMode: Literal["queue_for_open", "extended_hours_limit"] | None = None
+    order: EntryOrderDraft = Field(default_factory=EntryOrderDraft)
 
 
 class StopsRequest(BaseModel):
@@ -155,6 +233,7 @@ class MoveToBeRequest(BaseModel):
 class AccountSettingsView(BaseModel):
     equity: float
     buying_power: float
+    cash: float | None = None
     risk_pct: float
     mode: str
     effective_mode: str
@@ -165,6 +244,12 @@ class AccountSettingsView(BaseModel):
     daily_loss_limit_pct: float
     max_open_positions: int
     live_disabled_reason: str | None = None
+    reconcile_status: str = "synchronized"
+    last_reconciled_at: datetime | None = None
+    reconcileStatus: str = "synchronized"
+    lastReconciledAt: datetime | None = None
+    isExecutable: bool = True
+    executionBlockingReasons: list[str] = Field(default_factory=list)
 
 
 class AccountSettingsUpdate(BaseModel):

--- a/backend/app/schemas/cockpit.py
+++ b/backend/app/schemas/cockpit.py
@@ -84,7 +84,12 @@ class SetupResponse(BaseModel):
     sessionState: Literal["regular_open", "overnight", "pre_market", "after_hours", "closed"] = "closed"
     quoteState: Literal["live_quote", "cached_quote", "quote_unavailable"] = "quote_unavailable"
     entryBasis: str = "midpoint"
-    stopReferenceDefault: str = "lod"
+    stopReferenceDefault: Literal["lod", "atr", "manual"] = "lod"
+    lodIsValid: bool = True
+    atrIsValid: bool = True
+    lodStop: float
+    atrStop: float
+    manualStopWarning: str | None = None
     bid: float
     ask: float
     last: float
@@ -108,6 +113,8 @@ class SetupResponse(BaseModel):
     perShareRisk: float
     riskPct: float
     accountEquity: float
+    accountBuyingPower: float
+    equitySource: str = "local_settings"
     atrExtension: float
     extFrom10Ma: float
 
@@ -151,6 +158,7 @@ class AccountSettingsView(BaseModel):
     risk_pct: float
     mode: str
     effective_mode: str
+    equity_source: str = "local_settings"
     daily_realized_pnl: float
     allow_live_trading: bool
     max_position_notional_pct: float

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -6,7 +6,7 @@ import os
 import secrets
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -35,12 +35,11 @@ class AuthStore:
 
     @staticmethod
     def _now_iso() -> str:
-        return datetime.now(timezone.utc).isoformat()
+        return datetime.now(UTC).isoformat()
 
     def _init_db(self) -> None:
         with self._connect() as conn:
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS auth_users (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     username TEXT NOT NULL UNIQUE,
@@ -51,10 +50,8 @@ class AuthStore:
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 )
-                """
-            )
-            conn.execute(
-                """
+                """)
+            conn.execute("""
                 CREATE TABLE IF NOT EXISTS auth_sessions (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     session_token_hash TEXT NOT NULL UNIQUE,
@@ -67,14 +64,11 @@ class AuthStore:
                     ip_addr TEXT,
                     FOREIGN KEY(user_id) REFERENCES auth_users(id) ON DELETE CASCADE
                 )
-                """
-            )
-            conn.execute(
-                """
+                """)
+            conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_auth_sessions_user_active
                 ON auth_sessions(user_id, revoked_at, expires_at)
-                """
-            )
+                """)
             conn.commit()
 
     @staticmethod
@@ -92,7 +86,9 @@ class AuthStore:
             salt = bytes.fromhex(str(salt_hex))
         else:
             salt = os.urandom(16)
-        digest = hashlib.pbkdf2_hmac("sha256", str(password or "").encode("utf-8"), salt, 210_000)
+        digest = hashlib.pbkdf2_hmac(
+            "sha256", str(password or "").encode("utf-8"), salt, 210_000
+        )
         return salt.hex(), digest.hex()
 
     @staticmethod
@@ -107,7 +103,9 @@ class AuthStore:
         salt_hex, hash_hex = self._hash_password(password)
         now = self._now_iso()
         with self._connect() as conn:
-            existing = conn.execute("SELECT id FROM auth_users WHERE username = ?", (clean_username,)).fetchone()
+            existing = conn.execute(
+                "SELECT id FROM auth_users WHERE username = ?", (clean_username,)
+            ).fetchone()
             if existing is None:
                 conn.execute(
                     """
@@ -146,9 +144,13 @@ class AuthStore:
         if not seed_enabled:
             return
         if str(admin_username or "").strip() and str(admin_password or "").strip():
-            self.ensure_user(username=admin_username, password=admin_password, role="admin")
+            self.ensure_user(
+                username=admin_username, password=admin_password, role="admin"
+            )
         if str(trader_username or "").strip() and str(trader_password or "").strip():
-            self.ensure_user(username=trader_username, password=trader_password, role="trader")
+            self.ensure_user(
+                username=trader_username, password=trader_password, role="trader"
+            )
 
     def authenticate(self, *, username: str, password: str) -> AuthUser | None:
         clean_username = self._normalize_username(username)
@@ -166,7 +168,9 @@ class AuthStore:
             ).fetchone()
         if row is None or int(row["is_active"] or 0) != 1:
             return None
-        _, computed_hash = self._hash_password(password, salt_hex=str(row["password_salt"] or ""))
+        _, computed_hash = self._hash_password(
+            password, salt_hex=str(row["password_salt"] or "")
+        )
         if not hmac.compare_digest(str(row["password_hash"] or ""), computed_hash):
             return None
         return AuthUser(
@@ -185,7 +189,7 @@ class AuthStore:
     ) -> tuple[str, dict[str, Any]]:
         token = secrets.token_urlsafe(48)
         token_hash = self._session_token_hash(token)
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         now_iso = now.isoformat()
         expires_at = (now + timedelta(hours=self.session_ttl_hours)).isoformat()
         with self._connect() as conn:
@@ -222,7 +226,7 @@ class AuthStore:
         token = str(session_token or "").strip()
         if not token:
             return None
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         now_iso = now.isoformat()
         token_hash = self._session_token_hash(token)
         with self._connect() as conn:
@@ -246,13 +250,18 @@ class AuthStore:
             if row is None:
                 return None
             try:
-                expires_dt = datetime.fromisoformat(str(row["expires_at"] or "").replace("Z", "+00:00"))
+                expires_dt = datetime.fromisoformat(
+                    str(row["expires_at"] or "").replace("Z", "+00:00")
+                )
             except ValueError:
                 return None
             if expires_dt.tzinfo is None:
-                expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+                expires_dt = expires_dt.replace(tzinfo=UTC)
             if expires_dt <= now:
-                conn.execute("UPDATE auth_sessions SET revoked_at = ? WHERE id = ?", (now_iso, int(row["session_id"])))
+                conn.execute(
+                    "UPDATE auth_sessions SET revoked_at = ? WHERE id = ?",
+                    (now_iso, int(row["session_id"])),
+                )
                 conn.commit()
                 return None
             if int(row["is_active"] or 0) != 1:
@@ -298,6 +307,9 @@ def get_auth_store(settings: Settings) -> AuthStore:
     cache_key = str(Path(settings.auth_db_path).resolve())
     store = _auth_store_cache.get(cache_key)
     if store is None:
-        store = AuthStore(db_path=settings.auth_db_path, session_ttl_hours=settings.auth_session_ttl_hours)
+        store = AuthStore(
+            db_path=settings.auth_db_path,
+            session_ttl_hours=settings.auth_session_ttl_hours,
+        )
         _auth_store_cache[cache_key] = store
     return store

--- a/backend/app/services/cockpit.py
+++ b/backend/app/services/cockpit.py
@@ -68,12 +68,22 @@ class CockpitService:
         account = db.scalar(select(AccountSettingsEntity))
         assert account is not None
         effective_mode = self._effective_account_mode(account.mode)
+        equity = account.equity
+        buying_power = account.buying_power
+        equity_source = "local_settings"
+        if effective_mode == "alpaca_paper":
+            broker_summary = self.broker.get_account_summary()
+            if broker_summary:
+                equity = broker_summary.get("equity", equity)
+                buying_power = broker_summary.get("buying_power", buying_power)
+                equity_source = "alpaca_account"
         return AccountSettingsView(
-            equity=account.equity,
-            buying_power=account.buying_power,
+            equity=equity,
+            buying_power=buying_power,
             risk_pct=account.risk_pct,
             mode=account.mode,
             effective_mode=effective_mode,
+            equity_source=equity_source,
             daily_realized_pnl=account.daily_realized_pnl,
             allow_live_trading=self.settings.allow_live_trading,
             max_position_notional_pct=self.settings.max_position_notional_pct,
@@ -103,13 +113,13 @@ class CockpitService:
     def get_setup(self, db: Session, symbol: str) -> SetupResponse:
         account = self.get_account(db)
         market = self.market_data.get_setup_data(symbol)
-        return self._build_setup_response(market, account.equity, account.risk_pct)
+        return self._build_setup_response(market, account.equity, account.buying_power, account.risk_pct, account.equity_source)
 
     def preview_trade(self, db: Session, payload: TradePreviewRequest) -> dict:
         setup = self.get_setup(db, payload.symbol)
         self._validate_stop(payload.entry, payload.stopPrice)
         per_share_risk = round(payload.entry - payload.stopPrice, 2)
-        shares = self._calculate_shares(setup.accountEquity, payload.riskPct, per_share_risk)
+        shares = self._calculate_shares(setup.accountEquity, setup.accountBuyingPower, payload.entry, payload.riskPct, per_share_risk)
         self._log(
             db,
             payload.symbol.upper(),
@@ -131,6 +141,8 @@ class CockpitService:
         setup = self.get_setup(db, symbol)
         self._validate_stop(payload.entry, payload.stopPrice)
         self._validate_tranche_modes(payload.trancheCount, payload.trancheModes)
+        if setup.shares <= 0:
+            raise ValueError("Calculated shares is zero for this setup. Increase risk or choose a tighter valid stop.")
         self._enforce_risk_checks(db, symbol, payload.entry, setup.shares)
         qtys = self._split_shares(setup.shares, payload.trancheCount)
         session_state = setup.sessionState
@@ -536,11 +548,24 @@ class CockpitService:
             ),
         )
 
-    def _build_setup_response(self, market: SetupMarketData, equity: float, risk_pct: float) -> SetupResponse:
+    def _build_setup_response(
+        self,
+        market: SetupMarketData,
+        equity: float,
+        buying_power: float,
+        risk_pct: float,
+        equity_source: str,
+    ) -> SetupResponse:
         entry = round((market.bid + market.ask) / 2, 2)
-        final_stop = market.lod
-        per_share_risk = round(max(0.01, entry - final_stop), 2)
-        shares = self._calculate_shares(equity, risk_pct, per_share_risk)
+        lod_stop = round(market.lod, 2)
+        atr_stop = round(max(0.01, entry - market.atr14), 2)
+        lod_is_valid = lod_stop < entry
+        atr_is_valid = 0 < atr_stop < entry
+        stop_reference_default = "lod" if lod_is_valid else "manual"
+        final_stop = lod_stop if lod_is_valid else 0.0
+        manual_stop_warning = None if lod_is_valid else "Low of day is above the current entry price. Enter a manual stop for this setup."
+        per_share_risk = round(entry - final_stop, 2) if lod_is_valid else 0.0
+        shares = self._calculate_shares(equity, buying_power, entry, risk_pct, per_share_risk)
         return SetupResponse(
             symbol=market.symbol,
             provider=market.provider,
@@ -554,8 +579,13 @@ class CockpitService:
             quoteTimestamp=market.quote_timestamp,
             sessionState=market.session_state,
             quoteState=market.quote_state,
-            entryBasis="bid_ask_midpoint",
-            stopReferenceDefault="lod",
+            entryBasis=market.entry_basis,
+            stopReferenceDefault=stop_reference_default,
+            lodIsValid=lod_is_valid,
+            atrIsValid=atr_is_valid,
+            lodStop=lod_stop,
+            atrStop=atr_stop,
+            manualStopWarning=manual_stop_warning,
             bid=market.bid,
             ask=market.ask,
             last=market.last,
@@ -571,22 +601,29 @@ class CockpitService:
             days_to_cover=market.days_to_cover,
             entry=entry,
             finalStop=final_stop,
-            r1=round(entry + per_share_risk, 2),
-            r2=round(entry + per_share_risk * 2, 2),
-            r3=round(entry + per_share_risk * 3, 2),
+            r1=round(entry + per_share_risk, 2) if per_share_risk > 0 else entry,
+            r2=round(entry + per_share_risk * 2, 2) if per_share_risk > 0 else entry,
+            r3=round(entry + per_share_risk * 3, 2) if per_share_risk > 0 else entry,
             shares=shares,
             dollarRisk=round(equity * (risk_pct / 100), 2),
             perShareRisk=per_share_risk,
             riskPct=risk_pct,
             accountEquity=equity,
+            accountBuyingPower=buying_power,
+            equitySource=equity_source,
             atrExtension=round((entry - market.sma50) / market.atr14, 2),
             extFrom10Ma=round(((entry - market.sma10) / market.sma10) * 100, 2),
         )
 
-    def _calculate_shares(self, equity: float, risk_pct: float, per_share_risk: float) -> int:
-        if per_share_risk <= 0:
+    def _calculate_shares(self, equity: float, buying_power: float, entry: float, risk_pct: float, per_share_risk: float) -> int:
+        if per_share_risk <= 0 or entry <= 0:
             return 0
-        return max(1, floor((equity * (risk_pct / 100)) / per_share_risk))
+        risk_budget = floor((equity * (risk_pct / 100)) / per_share_risk)
+        max_notional = equity * (self.settings.max_position_notional_pct / 100)
+        effective_notional_cap = min(buying_power, max_notional) if buying_power > 0 else max_notional
+        buying_power_cap = floor(effective_notional_cap / entry) if effective_notional_cap > 0 else 0
+        capped = min(risk_budget, buying_power_cap) if buying_power_cap > 0 else risk_budget
+        return max(0, capped)
 
     def _split_shares(self, shares: int, count: int) -> list[int]:
         if count <= 1:

--- a/backend/app/services/cockpit.py
+++ b/backend/app/services/cockpit.py
@@ -2,20 +2,41 @@ from __future__ import annotations
 
 from copy import deepcopy
 from datetime import UTC, datetime
+import hashlib
+import json
 from math import floor
-from random import uniform
+from uuid import uuid4
 
-from sqlalchemy import desc, func, select
+from sqlalchemy import desc, select
 from sqlalchemy.orm import Session
 
-from app.adapters.broker import AlpacaBrokerAdapter, PaperBrokerAdapter
+from app.adapters.broker import (
+    AlpacaBrokerAdapter,
+    BrokerEntryOrder,
+    BrokerWebhookEvent,
+    PaperBrokerAdapter,
+)
 from app.adapters.market_data import AlpacaPolygonMarketDataAdapter, SetupMarketData
 from app.core.config import Settings
-from app.models.entities import AccountSettingsEntity, OrderEntity, PositionEntity, TradeLogEntity
+from app.models.entities import (
+    AccountSettingsEntity,
+    AccountSnapshotEntity,
+    BrokerFillEntity,
+    BrokerOrderEntity,
+    EventLogEntity,
+    OrderEntity,
+    OrderIntentEntity,
+    PositionEntity,
+    PositionProjectionEntity,
+    ReconcileRunEntity,
+    TradeLogEntity,
+)
 from app.schemas.cockpit import (
     AccountSettingsUpdate,
     AccountSettingsView,
+    EntryOrderDraft,
     LogEntry,
+    OrderFillView,
     OrderView,
     PositionView,
     ProfitRequest,
@@ -24,6 +45,7 @@ from app.schemas.cockpit import (
     StopsRequest,
     TradeEnterRequest,
     TradePreviewRequest,
+    TradePreviewResponse,
     Tranche,
     TrancheMode,
 )
@@ -63,6 +85,516 @@ class CockpitService:
             self._log(db, None, "sys", "Cockpit initialized. Enter ticker to begin.")
             db.commit()
 
+    def _new_id(self, prefix: str) -> str:
+        return f"{prefix}-{uuid4().hex[:12]}"
+
+    def _record_event(
+        self,
+        db: Session,
+        event_type: str,
+        *,
+        symbol: str | None = None,
+        intent_id: str | None = None,
+        broker_order_id: str | None = None,
+        fill_id: str | None = None,
+        source: str = "system",
+        payload: dict | None = None,
+    ) -> None:
+        db.add(
+            EventLogEntity(
+                event_id=self._new_id("evt"),
+                event_type=event_type,
+                symbol=symbol,
+                intent_id=intent_id,
+                broker_order_id=broker_order_id,
+                fill_id=fill_id,
+                source=source,
+                payload=payload or {},
+                created_at=utcnow(),
+            )
+        )
+
+    def _record_external_event(
+        self,
+        db: Session,
+        event: BrokerWebhookEvent,
+    ) -> bool:
+        if self._event_already_recorded(db, event.event_id):
+            return False
+        db.add(
+            EventLogEntity(
+                event_id=event.event_id,
+                event_type=event.event_type,
+                symbol=event.symbol,
+                intent_id=(
+                    self._lookup_intent_id(db, event.broker_order_id)
+                    if event.broker_order_id
+                    else None
+                ),
+                broker_order_id=event.broker_order_id,
+                fill_id=event.fill_id,
+                source="webhook",
+                payload=event.payload or event.account_payload or {},
+                created_at=event.occurred_at or utcnow(),
+            )
+        )
+        return True
+
+    def _event_already_recorded(self, db: Session, event_id: str) -> bool:
+        if not event_id:
+            return False
+        if any(
+            isinstance(instance, EventLogEntity) and instance.event_id == event_id
+            for instance in db.new
+        ):
+            return True
+        return (
+            db.scalar(select(EventLogEntity).where(EventLogEntity.event_id == event_id)) is not None
+        )
+
+    def _upsert_intent(
+        self,
+        db: Session,
+        *,
+        intent_id: str,
+        symbol: str,
+        action: str,
+        side: str,
+        qty: int,
+        price: float | None,
+        status: str,
+        blocking_reasons: list[str] | None = None,
+        broker_order_id: str | None = None,
+        payload: dict | None = None,
+    ) -> OrderIntentEntity:
+        intent = db.scalar(
+            select(OrderIntentEntity).where(OrderIntentEntity.intent_id == intent_id)
+        )
+        if intent is None:
+            intent = OrderIntentEntity(
+                intent_id=intent_id,
+                symbol=symbol,
+                action=action,
+                side=side,
+                qty=qty,
+                price=price,
+                status=status,
+                blocking_reasons=list(blocking_reasons or []),
+                broker_order_id=broker_order_id,
+                payload=payload or {},
+                created_at=utcnow(),
+                updated_at=utcnow(),
+            )
+            db.add(intent)
+        else:
+            intent.status = status
+            intent.blocking_reasons = list(blocking_reasons or [])
+            intent.broker_order_id = broker_order_id
+            intent.payload = payload or intent.payload
+            intent.updated_at = utcnow()
+        return intent
+
+    def _sync_broker_order_snapshot(
+        self,
+        db: Session,
+        *,
+        broker_order_id: str | None,
+        symbol: str,
+        intent_id: str | None,
+        payload: dict | None,
+        fallback_status: str,
+    ) -> None:
+        if not broker_order_id:
+            return
+        snapshot = next(
+            (
+                instance
+                for instance in db.new
+                if isinstance(instance, BrokerOrderEntity)
+                and instance.broker_order_id == broker_order_id
+            ),
+            None,
+        )
+        if snapshot is None:
+            snapshot = db.scalar(
+                select(BrokerOrderEntity).where(
+                    BrokerOrderEntity.broker_order_id == broker_order_id
+                )
+            )
+        status = (
+            str(payload.get("status") or fallback_status).upper() if payload else fallback_status
+        )
+        qty = self._broker_qty(payload) if payload else 0
+        filled_qty = self._broker_filled_qty(payload) if payload else 0
+        remaining_qty = self._broker_remaining_qty(payload, qty, qty, filled_qty)
+        avg_fill_price = self._broker_fill_price(payload, None) if payload else None
+        if snapshot is None:
+            snapshot = BrokerOrderEntity(
+                broker_order_id=broker_order_id,
+                symbol=symbol,
+                broker=self.settings.broker_execution_provider,
+                intent_id=intent_id,
+                status=status,
+                side=self._broker_side(payload),
+                order_type=str(payload.get("type") or "").upper() if payload else None,
+                qty=qty,
+                filled_qty=filled_qty,
+                remaining_qty=remaining_qty,
+                avg_fill_price=avg_fill_price,
+                raw_payload=payload or {},
+                updated_at=utcnow(),
+            )
+            db.add(snapshot)
+        else:
+            snapshot.intent_id = intent_id
+            snapshot.status = status
+            snapshot.side = self._broker_side(payload)
+            snapshot.order_type = (
+                str(payload.get("type") or "").upper() if payload else snapshot.order_type
+            )
+            snapshot.qty = qty
+            snapshot.filled_qty = filled_qty
+            snapshot.remaining_qty = remaining_qty
+            snapshot.avg_fill_price = avg_fill_price
+            snapshot.raw_payload = payload or snapshot.raw_payload
+            snapshot.updated_at = utcnow()
+
+    def _record_fill(
+        self,
+        db: Session,
+        *,
+        fill_id: str,
+        broker_order_id: str | None,
+        symbol: str,
+        intent_id: str | None,
+        qty: int,
+        price: float,
+        occurred_at: datetime,
+        payload: dict | None = None,
+    ) -> None:
+        existing = db.scalar(select(BrokerFillEntity).where(BrokerFillEntity.fill_id == fill_id))
+        if existing is not None:
+            return
+        db.add(
+            BrokerFillEntity(
+                fill_id=fill_id,
+                broker_order_id=broker_order_id,
+                symbol=symbol,
+                intent_id=intent_id,
+                qty=qty,
+                price=price,
+                occurred_at=occurred_at,
+                raw_payload=payload or {},
+                created_at=utcnow(),
+            )
+        )
+
+    def _sync_account_snapshot(
+        self,
+        db: Session,
+        *,
+        mode: str,
+        equity: float,
+        buying_power: float,
+        cash: float | None,
+        payload: dict | None = None,
+    ) -> None:
+        db.add(
+            AccountSnapshotEntity(
+                broker=self.settings.broker_execution_provider,
+                mode=mode,
+                equity=equity,
+                buying_power=buying_power,
+                cash=cash,
+                payload=payload or {},
+                recorded_at=utcnow(),
+            )
+        )
+
+    def _sync_projection(self, db: Session, position: PositionEntity) -> None:
+        db.flush()
+        projection = self._projection_for_symbol(db, position.symbol)
+        payload = self._projection_payload(db, position)
+        if projection is None:
+            projection = PositionProjectionEntity(
+                symbol=position.symbol,
+                phase=position.phase,
+                reconcile_status=position.reconcile_status,
+                projection_version=position.projection_version,
+                payload=payload,
+                updated_at=utcnow(),
+                last_reconciled_at=position.last_reconciled_at,
+            )
+            db.add(projection)
+        else:
+            projection.phase = position.phase
+            projection.reconcile_status = position.reconcile_status
+            projection.projection_version = position.projection_version
+            projection.payload = payload
+            projection.updated_at = utcnow()
+            projection.last_reconciled_at = position.last_reconciled_at
+
+    def _start_reconcile_run(self, db: Session, trigger: str) -> ReconcileRunEntity:
+        run = ReconcileRunEntity(
+            run_id=self._new_id("rec"),
+            trigger=trigger,
+            broker=self.settings.broker_execution_provider,
+            status="RUNNING",
+            processed_orders=0,
+            processed_fills=0,
+            created_at=utcnow(),
+        )
+        db.add(run)
+        return run
+
+    def _finish_reconcile_run(
+        self,
+        run: ReconcileRunEntity,
+        *,
+        processed_orders: int,
+        processed_fills: int,
+        error: str | None = None,
+    ) -> None:
+        run.status = "FAILED" if error else "COMPLETED"
+        run.processed_orders = processed_orders
+        run.processed_fills = processed_fills
+        run.error = error
+        run.completed_at = utcnow()
+
+    def _order_fills(self, db: Session, broker_order_id: str | None) -> list[OrderFillView]:
+        if not broker_order_id:
+            return []
+        rows = db.scalars(
+            select(BrokerFillEntity)
+            .where(BrokerFillEntity.broker_order_id == broker_order_id)
+            .order_by(BrokerFillEntity.occurred_at.asc())
+        ).all()
+        return [
+            OrderFillView(
+                id=row.fill_id,
+                brokerOrderId=row.broker_order_id,
+                symbol=row.symbol,
+                qty=row.qty,
+                price=row.price,
+                occurredAt=row.occurred_at,
+                intentId=row.intent_id,
+            )
+            for row in rows
+        ]
+
+    def _position_fills(self, db: Session, symbol: str) -> list[OrderFillView]:
+        rows = db.scalars(
+            select(BrokerFillEntity)
+            .where(BrokerFillEntity.symbol == symbol)
+            .order_by(BrokerFillEntity.occurred_at.asc())
+        ).all()
+        return [
+            OrderFillView(
+                id=row.fill_id,
+                brokerOrderId=row.broker_order_id,
+                symbol=row.symbol,
+                qty=row.qty,
+                price=row.price,
+                occurredAt=row.occurred_at,
+                intentId=row.intent_id,
+            )
+            for row in rows
+        ]
+
+    def rebuild_position_projections(
+        self, db: Session, symbols: list[str] | None = None
+    ) -> list[str]:
+        requested = [symbol.upper() for symbol in symbols] if symbols else None
+        stmt = select(PositionEntity).order_by(PositionEntity.symbol.asc())
+        if requested:
+            stmt = stmt.where(PositionEntity.symbol.in_(requested))
+        positions = db.scalars(stmt).all()
+        rebuilt_symbols: list[str] = []
+        for position in positions:
+            self._sync_projection(db, position)
+            rebuilt_symbols.append(position.symbol)
+        projection_stmt = select(PositionProjectionEntity)
+        if requested:
+            projection_stmt = projection_stmt.where(PositionProjectionEntity.symbol.in_(requested))
+        for projection in db.scalars(projection_stmt).all():
+            if projection.symbol not in rebuilt_symbols:
+                db.delete(projection)
+        db.flush()
+        return rebuilt_symbols
+
+    def next_reconcile_interval_seconds(self, db: Session) -> int:
+        return (
+            self.settings.reconcile_fast_interval_seconds
+            if self._has_working_orders(db)
+            else self.settings.reconcile_slow_interval_seconds
+        )
+
+    def run_reconcile_heartbeat(self, db: Session) -> None:
+        self._reconcile_all_positions(db)
+        self.get_account(db)
+        db.commit()
+
+    def _has_working_orders(self, db: Session) -> bool:
+        working = db.scalar(
+            select(OrderEntity.id).where(
+                OrderEntity.status.in_(["ACTIVE", "MODIFIED", "PENDING", "ACCEPTED", "NEW"])
+            )
+        )
+        if working is not None:
+            return True
+        return (
+            db.scalar(
+                select(PositionEntity.id).where(
+                    PositionEntity.phase.in_(["entry_pending", "closing", "protected"])
+                )
+            )
+            is not None
+        )
+
+    def _latest_reconcile_run(self, db: Session) -> ReconcileRunEntity | None:
+        return db.scalar(
+            select(ReconcileRunEntity)
+            .where(ReconcileRunEntity.completed_at.is_not(None))
+            .order_by(desc(ReconcileRunEntity.completed_at))
+        )
+
+    def _reconcile_health(
+        self,
+        db: Session,
+        *,
+        symbol: str | None = None,
+        position: PositionEntity | None = None,
+    ) -> tuple[str, datetime | None, list[str]]:
+        symbol = symbol.upper() if symbol else None
+        if position is None and symbol:
+            position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == symbol))
+        latest_run = self._latest_reconcile_run(db)
+        timestamps = [
+            self._coerce_utc(timestamp)
+            for timestamp in [
+                position.last_reconciled_at if position is not None else None,
+                latest_run.completed_at if latest_run is not None else None,
+            ]
+            if timestamp is not None
+        ]
+        last_reconciled_at = max(timestamps) if timestamps else None
+        reasons: list[str] = []
+        if self.settings.broker_execution_provider != "paper":
+            if latest_run is None or last_reconciled_at is None:
+                reasons.append("Reconciliation heartbeat is unavailable.")
+            elif latest_run.status == "FAILED":
+                reasons.append("Reconciliation heartbeat is failing.")
+            elif (
+                utcnow() - last_reconciled_at
+            ).total_seconds() > self.settings.max_reconcile_age_seconds:
+                reasons.append("Reconciliation is stale and execution is blocked.")
+        if (
+            position is not None
+            and position.reconcile_status == "pending"
+            and self.settings.broker_execution_provider != "paper"
+        ):
+            reasons.append(f"{position.symbol} is awaiting broker reconciliation.")
+        if any("stale" in reason.lower() or "failing" in reason.lower() for reason in reasons):
+            return "stale", last_reconciled_at, self._distinct_reasons(reasons)
+        if reasons:
+            return "pending", last_reconciled_at, self._distinct_reasons(reasons)
+        if position is not None and position.reconcile_status == "pending":
+            return "pending", last_reconciled_at, []
+        return "synchronized", last_reconciled_at or utcnow(), []
+
+    def _account_execution_blocking_reasons(
+        self, db: Session, account: AccountSettingsEntity
+    ) -> tuple[list[str], str, datetime | None]:
+        reconcile_status, last_reconciled_at, reconcile_reasons = self._reconcile_health(db)
+        reasons: list[str] = list(reconcile_reasons)
+        if not self.settings.trading_enabled:
+            reasons.append("Trading is disabled by runtime configuration.")
+        if (
+            account.mode in {"alpaca_paper", "alpaca_live"}
+            and not self.settings.has_alpaca_credentials
+        ):
+            reasons.append("Broker credentials are missing for the configured execution mode.")
+        return self._distinct_reasons(reasons), reconcile_status, last_reconciled_at
+
+    def _pre_intent_blocking_reasons(
+        self,
+        db: Session,
+        *,
+        symbol: str,
+        setup: SetupResponse | None = None,
+        entry: float | None = None,
+        shares: int | None = None,
+        allow_active_intent: bool = False,
+    ) -> list[str]:
+        reasons = list(setup.executionBlockingReasons) if setup is not None else []
+        if not allow_active_intent:
+            reasons.extend(self._active_intent_blocking_reasons(db, symbol))
+        if entry is not None and shares is not None:
+            reasons.extend(self._entry_risk_blocking_reasons(db, symbol, entry, shares))
+        return self._distinct_reasons(reasons)
+
+    def _active_intent_blocking_reasons(self, db: Session, symbol: str) -> list[str]:
+        active_intent = db.scalar(
+            select(OrderIntentEntity).where(
+                OrderIntentEntity.symbol == symbol.upper(),
+                OrderIntentEntity.status.in_(
+                    ["intent_accepted", "broker_accepted", "partially_filled"]
+                ),
+            )
+        )
+        if active_intent is None:
+            return []
+        return ["Another trade intent is already pending for this symbol."]
+
+    def _entry_risk_blocking_reasons(
+        self, db: Session, symbol: str, entry: float, shares: int
+    ) -> list[str]:
+        account = self.get_account(db)
+        reasons: list[str] = []
+        if entry * shares > account.equity * (self.settings.max_position_notional_pct / 100):
+            reasons.append("Position exceeds max notional cap")
+        if account.daily_realized_pnl < -(
+            account.equity * (self.settings.daily_loss_limit_pct / 100)
+        ):
+            reasons.append("Daily loss limit reached")
+        open_positions = db.scalars(
+            select(PositionEntity).where(PositionEntity.phase != "closed")
+        ).all()
+        if any(position.symbol == symbol.upper() for position in open_positions):
+            reasons.append(f"An open position already exists for {symbol.upper()}.")
+        elif len(open_positions) >= self.settings.max_open_positions:
+            reasons.append("Max open positions reached")
+        self._cancel_stale_active_orders(db, symbol)
+        active_orders = db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == symbol.upper(),
+                OrderEntity.status.in_(["ACTIVE", "MODIFIED"]),
+            )
+        ).all()
+        if active_orders:
+            reasons.append("Duplicate active orders exist for this symbol")
+        return reasons
+
+    @staticmethod
+    def _distinct_reasons(reasons: list[str]) -> list[str]:
+        seen: set[str] = set()
+        unique: list[str] = []
+        for reason in reasons:
+            normalized = reason.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            unique.append(normalized)
+        return unique
+
+    @staticmethod
+    def _coerce_utc(timestamp: datetime | None) -> datetime | None:
+        if timestamp is None:
+            return None
+        if timestamp.tzinfo is None:
+            return timestamp.replace(tzinfo=UTC)
+        return timestamp.astimezone(UTC)
+
     def get_account(self, db: Session) -> AccountSettingsView:
         self.ensure_seed_data(db)
         account = db.scalar(select(AccountSettingsEntity))
@@ -70,16 +602,30 @@ class CockpitService:
         effective_mode = self._effective_account_mode(account.mode)
         equity = account.equity
         buying_power = account.buying_power
+        cash = None
         equity_source = "local_settings"
         if effective_mode == "alpaca_paper":
             broker_summary = self.broker.get_account_summary()
             if broker_summary:
                 equity = broker_summary.get("equity", equity)
                 buying_power = broker_summary.get("buying_power", buying_power)
+                cash = broker_summary.get("cash")
                 equity_source = "alpaca_account"
+        blocking_reasons, reconcile_status, last_reconciled_at = (
+            self._account_execution_blocking_reasons(db, account)
+        )
+        self._sync_account_snapshot(
+            db,
+            mode=account.mode,
+            equity=equity,
+            buying_power=buying_power,
+            cash=cash,
+            payload={"equity_source": equity_source},
+        )
         return AccountSettingsView(
             equity=equity,
             buying_power=buying_power,
+            cash=cash,
             risk_pct=account.risk_pct,
             mode=account.mode,
             effective_mode=effective_mode,
@@ -90,6 +636,12 @@ class CockpitService:
             daily_loss_limit_pct=self.settings.daily_loss_limit_pct,
             max_open_positions=self.settings.max_open_positions,
             live_disabled_reason=self._live_disabled_reason(account.mode),
+            reconcile_status=reconcile_status,
+            last_reconciled_at=self._coerce_utc(last_reconciled_at),
+            reconcileStatus=reconcile_status,
+            lastReconciledAt=self._coerce_utc(last_reconciled_at),
+            isExecutable=not blocking_reasons,
+            executionBlockingReasons=blocking_reasons,
         )
 
     def update_account(self, db: Session, payload: AccountSettingsUpdate) -> AccountSettingsView:
@@ -106,91 +658,238 @@ class CockpitService:
         account.updated_at = utcnow()
         db.commit()
         if previous != (payload.equity, payload.risk_pct, payload.mode):
-            self._log(db, None, "sys", f"Account settings updated: equity {payload.equity:.2f}")
+            self._log(
+                db,
+                None,
+                "sys",
+                f"Account settings updated: equity {payload.equity:.2f}",
+            )
             db.commit()
         return self.get_account(db)
+
+    def ingest_broker_webhook(self, db: Session, payload: dict) -> dict[str, object]:
+        if not isinstance(payload, dict):
+            raise ValueError("Webhook payload must be a JSON object.")
+        normalized_events = self.broker.normalize_webhook_payload(payload)
+        if not normalized_events:
+            normalized_events = self._normalize_fallback_webhook_payload(payload)
+        symbols: set[str] = set()
+        processed_orders = 0
+        processed_fills = 0
+        processed_accounts = 0
+        account_changed = False
+        run = self._start_reconcile_run(db, "webhook")
+        try:
+            for event in normalized_events:
+                if not self._record_external_event(db, event):
+                    continue
+                if event.kind == "order" and event.payload is not None:
+                    symbol = str(event.symbol or "").upper()
+                    broker_order_id = str(event.broker_order_id or "").strip()
+                    if symbol and broker_order_id:
+                        symbols.add(symbol)
+                        processed_orders += 1
+                        if event.fill_id:
+                            processed_fills += 1
+                        self._sync_broker_order_snapshot(
+                            db,
+                            broker_order_id=broker_order_id,
+                            symbol=symbol,
+                            intent_id=self._lookup_intent_id(db, broker_order_id),
+                            payload=event.payload,
+                            fallback_status=str(event.payload.get("status") or "PENDING").upper(),
+                        )
+                        position = db.scalar(
+                            select(PositionEntity).where(PositionEntity.symbol == symbol)
+                        )
+                        if position is not None:
+                            self._reconcile_position(db, position, {broker_order_id: event.payload})
+                if event.kind == "account" and event.account_payload is not None:
+                    equity = self._safe_float(event.account_payload.get("equity"))
+                    buying_power = self._safe_float(event.account_payload.get("buying_power"))
+                    cash = self._safe_float(event.account_payload.get("cash"))
+                    if equity is not None and buying_power is not None:
+                        processed_accounts += 1
+                        account_changed = True
+                        self._sync_account_snapshot(
+                            db,
+                            mode=self.settings.broker_mode,
+                            equity=equity,
+                            buying_power=buying_power,
+                            cash=cash,
+                            payload=event.account_payload,
+                        )
+            self._finish_reconcile_run(
+                run,
+                processed_orders=processed_orders,
+                processed_fills=processed_fills,
+            )
+        except Exception as exc:
+            self._finish_reconcile_run(
+                run,
+                processed_orders=processed_orders,
+                processed_fills=processed_fills,
+                error=str(exc),
+            )
+            raise
+        return {
+            "received": len(normalized_events),
+            "processedOrders": processed_orders,
+            "processedFills": processed_fills,
+            "processedAccounts": processed_accounts,
+            "symbols": sorted(symbols),
+            "accountChanged": account_changed,
+        }
 
     def get_setup(self, db: Session, symbol: str) -> SetupResponse:
         account = self.get_account(db)
         market = self.market_data.get_setup_data(symbol)
-        return self._build_setup_response(market, account.equity, account.buying_power, account.risk_pct, account.equity_source)
+        position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == symbol.upper()))
+        reconcile_status, last_reconciled_at, reconcile_reasons = self._reconcile_health(
+            db, symbol=symbol, position=position
+        )
+        return self._build_setup_response(
+            market,
+            account.equity,
+            account.buying_power,
+            account.risk_pct,
+            account.equity_source,
+            account.cash,
+            reconcile_status=reconcile_status,
+            last_reconciled_at=last_reconciled_at,
+            additional_blocking_reasons=reconcile_reasons,
+        )
 
-    def preview_trade(self, db: Session, payload: TradePreviewRequest) -> dict:
+    def preview_trade(self, db: Session, payload: TradePreviewRequest) -> TradePreviewResponse:
         setup = self.get_setup(db, payload.symbol)
-        self._validate_stop(payload.entry, payload.stopPrice)
-        per_share_risk = round(payload.entry - payload.stopPrice, 2)
-        shares = self._calculate_shares(setup.accountEquity, setup.accountBuyingPower, payload.entry, payload.riskPct, per_share_risk)
+        blocking_reasons = list(setup.executionBlockingReasons)
+        preview_entry = round(setup.entry, 2)
+        side = payload.order.side
+        self._validate_stop(preview_entry, payload.stopPrice, side)
+        per_share_risk = self._per_share_risk(preview_entry, payload.stopPrice, side)
+        shares = self._calculate_shares(
+            setup.accountEquity,
+            setup.accountBuyingPower,
+            preview_entry,
+            payload.riskPct,
+            per_share_risk,
+        )
+        sizing_warning = self._sizing_warning(setup.accountBuyingPower, preview_entry, shares)
         self._log(
             db,
             payload.symbol.upper(),
             "info",
-            f"Preview: {payload.symbol.upper()} buy {shares} sh @ {payload.entry:.2f} stop {payload.stopPrice:.2f}",
+            f"Preview: {payload.symbol.upper()} {side.upper()} {shares} sh LMT GTC @ {preview_entry:.2f} stop {payload.stopPrice:.2f}",
         )
         db.commit()
-        return {
-            "symbol": payload.symbol.upper(),
-            "entry": payload.entry,
-            "finalStop": payload.stopPrice,
-            "perShareRisk": per_share_risk,
-            "shares": shares,
-            "dollarRisk": round(setup.accountEquity * (payload.riskPct / 100), 2),
-        }
+        return TradePreviewResponse(
+            symbol=payload.symbol.upper(),
+            entry=preview_entry,
+            finalStop=payload.stopPrice,
+            perShareRisk=per_share_risk,
+            shares=shares,
+            dollarRisk=round(setup.accountEquity * (payload.riskPct / 100), 2),
+            sizingWarning=sizing_warning,
+            isExecutable=setup.isExecutable,
+            blockingReasons=blocking_reasons,
+        )
 
     async def enter_trade(self, db: Session, payload: TradeEnterRequest) -> PositionView:
         symbol = payload.symbol.upper()
         setup = self.get_setup(db, symbol)
-        self._validate_stop(payload.entry, payload.stopPrice)
+        order = payload.order
+        preview_entry = round(setup.entry, 2)
+        self._validate_stop(preview_entry, payload.stopPrice, order.side)
         self._validate_tranche_modes(payload.trancheCount, payload.trancheModes)
-        if setup.shares <= 0:
-            raise ValueError("Calculated shares is zero for this setup. Increase risk or choose a tighter valid stop.")
-        self._enforce_risk_checks(db, symbol, payload.entry, setup.shares)
-        qtys = self._split_shares(setup.shares, payload.trancheCount)
+        per_share_risk = self._per_share_risk(preview_entry, payload.stopPrice, order.side)
+        shares = self._calculate_shares(
+            setup.accountEquity,
+            setup.accountBuyingPower,
+            preview_entry,
+            setup.riskPct,
+            per_share_risk,
+        )
+        if shares <= 0:
+            raise ValueError(
+                "Calculated shares is zero for this setup. Increase risk or choose a tighter valid stop."
+            )
+        blocking_reasons = self._pre_intent_blocking_reasons(
+            db,
+            symbol=symbol,
+            setup=setup,
+            entry=preview_entry,
+            shares=shares,
+        )
+        if blocking_reasons:
+            raise ValueError("; ".join(blocking_reasons))
+        qtys = self._split_shares(shares, payload.trancheCount, payload.trancheModes)
+        intent_id = self._new_id("intent")
         session_state = setup.sessionState
         enforce_alpaca_offhours = setup.executionProvider == "alpaca_paper"
         entry_message: str
         broker_status = "PENDING"
-        root_order_type = "MKT"
-        if session_state == "regular_open" or not enforce_alpaca_offhours:
-            broker = self.broker.place_market_order(symbol, setup.shares, "buy")
-            entry_filled = True
-            try:
-                self.broker.wait_for_position(symbol, min_qty=setup.shares, timeout_seconds=5.0)
-                broker_status = "FILLED"
-            except ValueError:
-                entry_filled = False
-                broker_status = "PENDING"
-            entry_message = f"Trade entered: Buy {setup.shares} sh {symbol} @ {payload.entry:.2f} (Alpaca paper)"
+        root_order_type = self._local_entry_order_type(order)
+        order_for_broker = self._build_broker_entry_order(
+            symbol, shares, preview_entry, order, session_state, enforce_alpaca_offhours
+        )
+        broker = self.broker.place_entry_order(order_for_broker)
+        broker_status = broker.status or "PENDING"
+        entry_filled = self._entry_should_start_filled(
+            order_for_broker, broker_status, session_state, enforce_alpaca_offhours
+        )
+        if enforce_alpaca_offhours and session_state != "regular_open":
+            broker_status = "PENDING"
+            entry_filled = False
+        if session_state != "regular_open":
+            entry_message = "Midpoint limit order accepted and waiting for a regular-session fill."
         else:
-            if payload.offHoursMode not in {"queue_for_open", "extended_hours_limit"}:
-                raise ValueError(
-                    "Market is outside the regular session. Choose Queue For Open or Submit Extended-Hours Limit."
-                )
-            if payload.offHoursMode == "queue_for_open":
-                broker = self.broker.place_market_order(symbol, setup.shares, "buy")
-                entry_filled = False
-                broker_status = "PENDING"
-                entry_message = "Market closed. Order accepted and queued for the next regular session."
-            else:
-                broker = self.broker.place_limit_order(
-                    symbol,
-                    setup.shares,
-                    payload.entry,
-                    side="buy",
-                    time_in_force="day",
-                    extended_hours=True,
-                )
-                root_order_type = "LMT"
-                entry_filled = True
-                try:
-                    self.broker.wait_for_position(symbol, min_qty=setup.shares, timeout_seconds=5.0)
-                    broker_status = "FILLED"
-                except ValueError:
-                    entry_filled = False
-                    broker_status = "PENDING"
-                entry_message = (
-                    "Extended-hours limit order submitted. It will only execute if the limit can trade during "
-                    "Alpaca's supported extended session."
-                )
+            entry_message = (
+                f"Trade entered: {order_for_broker.side.upper()} {shares} sh {symbol} {order_for_broker.order_type.upper()} "
+                f"{order_for_broker.time_in_force.upper()} @ {preview_entry:.2f}"
+            )
+        intent_status = "filled" if entry_filled else "broker_accepted"
+        self._upsert_intent(
+            db,
+            intent_id=intent_id,
+            symbol=symbol,
+            action="enter",
+            side=order.side,
+            qty=shares,
+            price=preview_entry,
+            status=intent_status,
+            broker_order_id=broker.broker_order_id,
+            payload={
+                "request": payload.model_dump(mode="json"),
+                "setup": setup.model_dump(mode="json"),
+            },
+        )
+        self._record_event(
+            db,
+            "OrderIntentCreated",
+            symbol=symbol,
+            intent_id=intent_id,
+            payload={"action": "enter", "qty": shares, "price": preview_entry},
+        )
+        self._record_event(
+            db,
+            (
+                "BrokerOrderAccepted"
+                if broker_status not in {"REJECTED", "ERROR"}
+                else "BrokerOrderRejected"
+            ),
+            symbol=symbol,
+            intent_id=intent_id,
+            broker_order_id=broker.broker_order_id,
+            payload=broker.payload or {"status": broker_status},
+        )
+        self._sync_broker_order_snapshot(
+            db,
+            broker_order_id=broker.broker_order_id,
+            symbol=symbol,
+            intent_id=intent_id,
+            payload=broker.payload,
+            fallback_status=broker_status,
+        )
         tranches = [
             Tranche(
                 id=f"T{i+1}",
@@ -209,34 +908,60 @@ class CockpitService:
             position = PositionEntity(
                 symbol=symbol,
                 phase="trade_entered" if entry_filled else "entry_pending",
-                entry_price=payload.entry,
+                entry_price=preview_entry,
                 live_price=setup.last,
-                shares=setup.shares,
+                shares=shares,
                 stop_ref=payload.stopRef,
                 stop_price=payload.stopPrice,
                 tranche_count=payload.trancheCount,
                 tranche_modes=[item.model_dump() for item in payload.trancheModes],
                 stop_modes=[StopMode().model_dump() for _ in range(3)],
                 tranches=tranches,
-                setup_snapshot=setup.model_dump(mode="json"),
+                setup_snapshot={
+                    **setup.model_dump(mode="json"),
+                    "entryOrder": order.model_dump(mode="json"),
+                    "markState": ("frozen" if setup.sessionState != "regular_open" else "live"),
+                    "markLabel": (
+                        "Frozen outside regular session."
+                        if setup.sessionState != "regular_open"
+                        else None
+                    ),
+                },
                 root_order_id=root_order_id,
+                last_intent_id=intent_id,
+                projection_version=1,
+                reconcile_status="synchronized" if entry_filled else "pending",
+                last_reconciled_at=utcnow() if entry_filled else None,
                 created_at=utcnow(),
                 updated_at=utcnow(),
             )
             db.add(position)
         else:
             position.phase = "trade_entered" if entry_filled else "entry_pending"
-            position.entry_price = payload.entry
+            position.entry_price = preview_entry
             position.live_price = setup.last
-            position.shares = setup.shares
+            position.shares = shares
             position.stop_ref = payload.stopRef
             position.stop_price = payload.stopPrice
             position.tranche_count = payload.trancheCount
             position.tranche_modes = [item.model_dump() for item in payload.trancheModes]
             position.stop_modes = [StopMode().model_dump() for _ in range(3)]
             position.tranches = tranches
-            position.setup_snapshot = setup.model_dump(mode="json")
+            position.setup_snapshot = {
+                **setup.model_dump(mode="json"),
+                "entryOrder": order.model_dump(mode="json"),
+                "markState": ("frozen" if setup.sessionState != "regular_open" else "live"),
+                "markLabel": (
+                    "Frozen outside regular session."
+                    if setup.sessionState != "regular_open"
+                    else None
+                ),
+            }
             position.root_order_id = root_order_id
+            position.last_intent_id = intent_id
+            position.projection_version += 1
+            position.reconcile_status = "synchronized" if entry_filled else "pending"
+            position.last_reconciled_at = utcnow() if entry_filled else position.last_reconciled_at
             position.updated_at = utcnow()
             position.closed_at = None
         db.add(
@@ -245,23 +970,43 @@ class CockpitService:
                 broker_order_id=broker.broker_order_id,
                 symbol=symbol,
                 type=root_order_type,
-                qty=setup.shares,
-                orig_qty=setup.shares,
-                price=payload.entry,
+                qty=shares,
+                orig_qty=shares,
+                price=preview_entry,
                 status="FILLED" if entry_filled else broker_status,
+                intent_id=intent_id,
                 tranche_label=symbol,
                 covered_tranches=[],
                 parent_id=None,
                 created_at=utcnow(),
                 filled_at=utcnow() if entry_filled else None,
-                fill_price=payload.entry if entry_filled else None,
+                fill_price=preview_entry if entry_filled else None,
+                filled_qty=shares if entry_filled else 0,
             )
         )
+        if entry_filled:
+            self._record_fill(
+                db,
+                fill_id=self._new_id("fill"),
+                broker_order_id=broker.broker_order_id,
+                symbol=symbol,
+                intent_id=intent_id,
+                qty=shares,
+                price=preview_entry,
+                occurred_at=utcnow(),
+                payload=broker.payload,
+            )
         if entry_filled:
             self._log(db, symbol, "exec", entry_message)
         else:
             self._log(db, symbol, "warn", entry_message)
-        self._log(db, symbol, "sys", "Tranches: " + " \u00b7 ".join(f"T{i+1}={qty}sh" for i, qty in enumerate(qtys)))
+        self._log(
+            db,
+            symbol,
+            "sys",
+            "Tranches: " + " \u00b7 ".join(f"T{i+1}={qty}sh" for i, qty in enumerate(qtys)),
+        )
+        self._sync_projection(db, position)
         db.commit()
         view = self.get_position(db, symbol)
         await self._broadcast_position_bundle(db, view, pnl=0.0)
@@ -270,10 +1015,23 @@ class CockpitService:
     async def apply_stops(self, db: Session, payload: StopsRequest) -> PositionView:
         position = self._require_position(db, payload.symbol)
         self._ensure_position_is_open(position)
-        self._ensure_position_filled(position, "Protective orders are unavailable until the entry order is filled.")
+        self._ensure_position_filled(
+            position,
+            "Protective orders are unavailable until the entry order is filled.",
+        )
+        setup = self.get_setup(db, position.symbol)
+        blocking_reasons = self._pre_intent_blocking_reasons(
+            db,
+            symbol=position.symbol,
+            setup=setup,
+        )
+        if blocking_reasons:
+            raise ValueError("; ".join(blocking_reasons))
         self._validate_stop_mode(payload.stopMode, payload.stopModes)
         self._reject_duplicate_active_stops(db, position.symbol)
-        stop_range = round(position.entry_price - position.stop_price, 2)
+        position_side = self._position_side(position)
+        exit_side = self._exit_side(position_side)
+        stop_range = abs(round(position.entry_price - position.stop_price, 2))
         current_tranches = deepcopy(position.tranches)
         for index, group in enumerate(self._stop_groups(current_tranches, payload.stopMode)):
             config = payload.stopModes[index]
@@ -281,12 +1039,12 @@ class CockpitService:
             price = (
                 position.entry_price
                 if config.mode == "be"
-                else round(position.entry_price - stop_range * pct / 100.0, 2)
+                else self._stop_price_from_pct(position.entry_price, stop_range, pct, position_side)
             )
-            self._validate_stop(position.entry_price, price)
+            self._validate_stop(position.entry_price, price, position_side)
             qty = sum(item["qty"] for item in group)
             covered = [item["id"] for item in group]
-            broker = self.broker.place_stop_order(position.symbol, qty, price)
+            broker = self.broker.place_stop_order(position.symbol, qty, price, side=exit_side)
             db.add(
                 OrderEntity(
                     order_id=self._next_order_id(db),
@@ -309,6 +1067,8 @@ class CockpitService:
         position.tranches = current_tranches
         position.stop_modes = [item.model_dump() for item in payload.stopModes]
         position.phase = "protected"
+        position.projection_version += 1
+        position.reconcile_status = "pending"
         position.updated_at = utcnow()
         stop_lines: list[str] = []
         for index, group in enumerate(self._stop_groups(current_tranches, payload.stopMode)):
@@ -317,7 +1077,13 @@ class CockpitService:
             qty = sum(item["qty"] for item in group)
             price = position.entry_price if config.mode == "be" else group[0]["stop"]
             stop_lines.append(f"S{index+1} {qty}sh @ {price:.2f} ({pct:.2f}%)")
-        self._log(db, position.symbol, "warn", f"\u2713 Stops applied \u2014 {' \u00b7 '.join(stop_lines)}")
+        self._log(
+            db,
+            position.symbol,
+            "warn",
+            f"\u2713 Stops applied \u2014 {' \u00b7 '.join(stop_lines)}",
+        )
+        self._sync_projection(db, position)
         db.commit()
         view = self.get_position(db, position.symbol)
         await self._broadcast_position_bundle(db, view)
@@ -326,22 +1092,62 @@ class CockpitService:
     async def execute_profit_plan(self, db: Session, payload: ProfitRequest) -> PositionView:
         position = self._require_position(db, payload.symbol)
         self._ensure_profit_actionable(position)
+        setup = self.get_setup(db, position.symbol)
+        blocking_reasons = self._pre_intent_blocking_reasons(
+            db,
+            symbol=position.symbol,
+            setup=setup,
+        )
+        if blocking_reasons:
+            raise ValueError("; ".join(blocking_reasons))
         self._validate_tranche_modes(position.tranche_count, payload.trancheModes)
         tranches = deepcopy(position.tranches)
-        per_share_risk = round(position.entry_price - position.stop_price, 2)
+        position_side = self._position_side(position)
+        exit_side = self._exit_side(position_side)
+        per_share_risk = abs(round(position.entry_price - position.stop_price, 2))
         phase = position.phase
         executed_count = 0
+        latest_intent_id = position.last_intent_id
         self._cancel_broker_exit_orders(db, position.symbol, {"STOP"})
         for index, tranche in enumerate(tranches):
             if tranche["status"] != "active":
                 continue
             mode = payload.trancheModes[index]
             if mode.mode == "runner":
+                intent_id = self._new_id("intent")
+                latest_intent_id = intent_id
                 self._reject_duplicate_active_order(db, position.symbol, tranche["id"], "TRAIL")
-                runner_stop = self._trail_stop(position.live_price, mode.trail, mode.trailUnit)
+                runner_stop = self._trail_stop(
+                    position.live_price, mode.trail, mode.trailUnit, position_side
+                )
                 tranche["mode"] = "runner"
                 tranche["runnerStop"] = runner_stop
-                broker = self.broker.place_trailing_stop(position.symbol, tranche["qty"], mode.trail, mode.trailUnit)
+                broker = self.broker.place_trailing_stop(
+                    position.symbol,
+                    tranche["qty"],
+                    mode.trail,
+                    mode.trailUnit,
+                    side=exit_side,
+                )
+                self._upsert_intent(
+                    db,
+                    intent_id=intent_id,
+                    symbol=position.symbol,
+                    action="runner",
+                    side=exit_side,
+                    qty=tranche["qty"],
+                    price=runner_stop,
+                    status="broker_accepted",
+                    broker_order_id=broker.broker_order_id,
+                    payload={"tranche": tranche["id"], "mode": mode.model_dump()},
+                )
+                self._record_event(
+                    db,
+                    "OrderIntentCreated",
+                    symbol=position.symbol,
+                    intent_id=intent_id,
+                    payload={"action": "runner", "tranche": tranche["id"]},
+                )
                 db.add(
                     OrderEntity(
                         order_id=self._next_order_id(db),
@@ -352,17 +1158,53 @@ class CockpitService:
                         orig_qty=tranche["qty"],
                         price=runner_stop,
                         status="ACTIVE",
+                        intent_id=intent_id,
                         tranche_label=tranche["id"],
                         covered_tranches=[tranche["id"]],
                         parent_id=position.root_order_id,
                         created_at=utcnow(),
+                        filled_qty=0,
                     )
+                )
+                self._sync_broker_order_snapshot(
+                    db,
+                    broker_order_id=broker.broker_order_id,
+                    symbol=position.symbol,
+                    intent_id=intent_id,
+                    payload=broker.payload,
+                    fallback_status=broker.status,
                 )
                 phase = "runner_only"
             else:
+                intent_id = self._new_id("intent")
+                latest_intent_id = intent_id
                 self._reject_duplicate_active_order(db, position.symbol, tranche["id"], "LMT")
-                target = self._resolve_target_price(position.entry_price, per_share_risk, mode)
-                broker = self.broker.place_limit_order(position.symbol, tranche["qty"], target)
+                target = self._resolve_target_price(
+                    position.entry_price, per_share_risk, mode, position_side
+                )
+                broker = self.broker.place_limit_order(
+                    position.symbol, tranche["qty"], target, side=exit_side
+                )
+                is_filled = str(broker.status or "").upper() == "FILLED"
+                self._upsert_intent(
+                    db,
+                    intent_id=intent_id,
+                    symbol=position.symbol,
+                    action="take_profit",
+                    side=exit_side,
+                    qty=tranche["qty"],
+                    price=target,
+                    status="filled" if is_filled else "broker_accepted",
+                    broker_order_id=broker.broker_order_id,
+                    payload={"tranche": tranche["id"], "mode": mode.model_dump()},
+                )
+                self._record_event(
+                    db,
+                    "OrderIntentCreated",
+                    symbol=position.symbol,
+                    intent_id=intent_id,
+                    payload={"action": "take_profit", "tranche": tranche["id"]},
+                )
                 db.add(
                     OrderEntity(
                         order_id=self._next_order_id(db),
@@ -372,30 +1214,78 @@ class CockpitService:
                         qty=tranche["qty"],
                         orig_qty=tranche["qty"],
                         price=target,
-                        status="FILLED",
+                        status="FILLED" if is_filled else "ACTIVE",
+                        intent_id=intent_id,
                         tranche_label=tranche["id"],
                         covered_tranches=[],
                         parent_id=position.root_order_id,
                         created_at=utcnow(),
-                        filled_at=utcnow(),
-                        fill_price=target,
+                        filled_at=utcnow() if is_filled else None,
+                        fill_price=target if is_filled else None,
+                        filled_qty=tranche["qty"] if is_filled else 0,
                     )
                 )
-                tranche["status"] = "sold"
+                self._sync_broker_order_snapshot(
+                    db,
+                    broker_order_id=broker.broker_order_id,
+                    symbol=position.symbol,
+                    intent_id=intent_id,
+                    payload=broker.payload,
+                    fallback_status=broker.status,
+                )
                 tranche["target"] = target
-                self._reduce_stop_orders(db, position.symbol, tranche["id"], tranche["qty"])
-                phase = "P1_done" if index == 0 else "P2_done"
-                executed_count += 1
-        if all(tranche["status"] != "active" for tranche in tranches):
-            phase = "closed"
-            position.closed_at = utcnow()
+                tranche["exitOrderType"] = "LMT"
+                if is_filled:
+                    tranche["status"] = "sold"
+                    tranche["exitPrice"] = target
+                    tranche["exitFilledAt"] = utcnow().isoformat()
+                    tranche["filledQty"] = tranche["qty"]
+                    tranche["remainingQty"] = 0
+                    self._record_fill(
+                        db,
+                        fill_id=self._new_id("fill"),
+                        broker_order_id=broker.broker_order_id,
+                        symbol=position.symbol,
+                        intent_id=intent_id,
+                        qty=tranche["qty"],
+                        price=target,
+                        occurred_at=utcnow(),
+                        payload=broker.payload,
+                    )
+                    self._reduce_stop_orders(db, position.symbol, tranche["id"], tranche["qty"])
+                    phase = "P1_done" if index == 0 else "P2_done"
+                    executed_count += 1
+                else:
+                    tranche["status"] = "pending_exit"
+                    tranche["filledQty"] = 0
+                    tranche["remainingQty"] = tranche["qty"]
+        phase = self._phase_from_tranches(position, tranches)
         position.tranches = tranches
         position.tranche_modes = [item.model_dump() for item in payload.trancheModes]
         position.phase = phase
+        position.last_intent_id = latest_intent_id
+        position.projection_version += 1
+        position.reconcile_status = (
+            "pending"
+            if any(
+                tranche["status"] in {"pending_exit", "partially_filled"} for tranche in tranches
+            )
+            else "synchronized"
+        )
+        position.last_reconciled_at = (
+            utcnow() if position.reconcile_status == "synchronized" else position.last_reconciled_at
+        )
+        position.closed_at = utcnow() if phase == "closed" else None
         position.updated_at = utcnow()
         if executed_count == 0 and phase == "runner_only":
             raise ValueError("No executable profit tranches remain; runner already active")
-        self._log(db, position.symbol, "exec", f"\u2713 Profit plan executed \u2014 {executed_count} tranche(s) filled")
+        self._log(
+            db,
+            position.symbol,
+            "exec",
+            f"\u2713 Profit plan executed \u2014 {executed_count} tranche(s) filled",
+        )
+        self._sync_projection(db, position)
         db.commit()
         view = self.get_position(db, position.symbol)
         await self._broadcast_position_bundle(db, view)
@@ -404,18 +1294,45 @@ class CockpitService:
     async def move_to_be(self, db: Session, symbol: str) -> PositionView:
         position = self._require_position(db, symbol)
         self._ensure_position_is_open(position)
-        self._ensure_position_filled(position, "Protective orders are unavailable until the entry order is filled.")
+        self._ensure_position_filled(
+            position,
+            "Protective orders are unavailable until the entry order is filled.",
+        )
+        setup = self.get_setup(db, position.symbol)
+        blocking_reasons = self._pre_intent_blocking_reasons(
+            db,
+            symbol=position.symbol,
+            setup=setup,
+        )
+        if blocking_reasons:
+            raise ValueError("; ".join(blocking_reasons))
         position.tranches = [
-            {**tranche, "stop": position.entry_price} if tranche["status"] == "active" else tranche
+            (
+                {**tranche, "stop": position.entry_price}
+                if tranche["status"] == "active"
+                else tranche
+            )
             for tranche in deepcopy(position.tranches)
         ]
-        for order in db.scalars(select(OrderEntity).where(OrderEntity.symbol == position.symbol, OrderEntity.type == "STOP")):
+        for order in db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == position.symbol, OrderEntity.type == "STOP"
+            )
+        ):
             if order.status in {"ACTIVE", "MODIFIED"}:
                 order.price = position.entry_price
                 order.status = "MODIFIED"
         position.phase = "protected"
+        position.projection_version += 1
+        position.reconcile_status = "pending"
         position.updated_at = utcnow()
-        self._log(db, position.symbol, "warn", f"All stops \u2192 breakeven: {position.entry_price:.2f}")
+        self._log(
+            db,
+            position.symbol,
+            "warn",
+            f"All stops \u2192 breakeven: {position.entry_price:.2f}",
+        )
+        self._sync_projection(db, position)
         db.commit()
         view = self.get_position(db, position.symbol)
         await self._broadcast_position_bundle(db, view)
@@ -424,8 +1341,19 @@ class CockpitService:
     async def flatten(self, db: Session, symbol: str) -> PositionView:
         position = self._require_position(db, symbol)
         self._ensure_position_is_open(position)
+        setup = self.get_setup(db, position.symbol)
+        blocking_reasons = self._pre_intent_blocking_reasons(
+            db,
+            symbol=position.symbol,
+            setup=setup,
+            allow_active_intent=(position.phase == "entry_pending"),
+        )
+        if blocking_reasons:
+            raise ValueError("; ".join(blocking_reasons))
         if position.phase == "entry_pending":
-            root_order = db.scalar(select(OrderEntity).where(OrderEntity.order_id == position.root_order_id))
+            root_order = db.scalar(
+                select(OrderEntity).where(OrderEntity.order_id == position.root_order_id)
+            )
             if root_order and root_order.broker_order_id:
                 self.broker.cancel_order(root_order.broker_order_id)
             if root_order:
@@ -435,21 +1363,28 @@ class CockpitService:
                 tranche["status"] = "canceled"
                 canceled_tranches.append(tranche)
             position.tranches = canceled_tranches
-            for order in db.scalars(select(OrderEntity).where(OrderEntity.symbol == position.symbol)):
+            for order in db.scalars(
+                select(OrderEntity).where(OrderEntity.symbol == position.symbol)
+            ):
                 if order.status in {"ACTIVE", "MODIFIED", "PENDING"}:
                     if order.broker_order_id:
                         self.broker.cancel_order(order.broker_order_id)
                     order.status = "CANCELED"
             position.phase = "closed"
             position.closed_at = utcnow()
+            position.projection_version += 1
+            position.reconcile_status = "synchronized"
+            position.last_reconciled_at = utcnow()
             position.updated_at = utcnow()
             self._log(db, position.symbol, "close", "Pending entry canceled before fill.")
+            self._sync_projection(db, position)
             db.commit()
             view = self.get_position(db, position.symbol)
             await self._broadcast_position_bundle(db, view)
             return view
         updated_tranches = []
         broker_result = self.broker.close_position(position.symbol)
+        is_filled = str(broker_result.status or "").upper() == "FILLED"
         for order in db.scalars(select(OrderEntity).where(OrderEntity.symbol == position.symbol)):
             if order.status in {"ACTIVE", "MODIFIED"}:
                 if order.broker_order_id:
@@ -457,6 +1392,19 @@ class CockpitService:
                 order.status = "CANCELED"
         for tranche in deepcopy(position.tranches):
             if tranche["status"] == "active":
+                intent_id = self._new_id("intent")
+                self._upsert_intent(
+                    db,
+                    intent_id=intent_id,
+                    symbol=position.symbol,
+                    action="flatten",
+                    side=self._exit_side(self._position_side(position)),
+                    qty=tranche["qty"],
+                    price=position.live_price,
+                    status="filled" if is_filled else "broker_accepted",
+                    broker_order_id=broker_result.broker_order_id,
+                    payload={"tranche": tranche["id"], "action": "flatten"},
+                )
                 db.add(
                     OrderEntity(
                         order_id=self._next_order_id(db),
@@ -466,55 +1414,315 @@ class CockpitService:
                         qty=tranche["qty"],
                         orig_qty=tranche["qty"],
                         price=position.live_price,
-                        status="FILLED",
+                        status="FILLED" if is_filled else "ACTIVE",
+                        intent_id=intent_id,
                         tranche_label=tranche["id"],
                         covered_tranches=[],
                         parent_id=position.root_order_id,
                         created_at=utcnow(),
-                        filled_at=utcnow(),
-                        fill_price=position.live_price,
+                        filled_at=utcnow() if is_filled else None,
+                        fill_price=position.live_price if is_filled else None,
+                        filled_qty=tranche["qty"] if is_filled else 0,
                     )
                 )
-                tranche["status"] = "sold"
+                self._record_event(
+                    db,
+                    "OrderIntentCreated",
+                    symbol=position.symbol,
+                    intent_id=intent_id,
+                    payload={"action": "flatten", "tranche": tranche["id"]},
+                )
+                self._sync_broker_order_snapshot(
+                    db,
+                    broker_order_id=broker_result.broker_order_id,
+                    symbol=position.symbol,
+                    intent_id=intent_id,
+                    payload=broker_result.payload,
+                    fallback_status=broker_result.status,
+                )
                 tranche["target"] = position.live_price
+                tranche["exitOrderType"] = "MKT"
+                if is_filled:
+                    tranche["status"] = "sold"
+                    tranche["exitPrice"] = position.live_price
+                    tranche["exitFilledAt"] = utcnow().isoformat()
+                    tranche["filledQty"] = tranche["qty"]
+                    tranche["remainingQty"] = 0
+                    self._record_fill(
+                        db,
+                        fill_id=self._new_id("fill"),
+                        broker_order_id=broker_result.broker_order_id,
+                        symbol=position.symbol,
+                        intent_id=intent_id,
+                        qty=tranche["qty"],
+                        price=position.live_price,
+                        occurred_at=utcnow(),
+                        payload=broker_result.payload,
+                    )
+                else:
+                    tranche["status"] = "pending_exit"
+                    tranche["filledQty"] = 0
+                    tranche["remainingQty"] = tranche["qty"]
             updated_tranches.append(tranche)
         position.tranches = updated_tranches
-        position.phase = "closed"
-        position.closed_at = utcnow()
+        position.phase = "closed" if is_filled else "closing"
+        position.closed_at = utcnow() if is_filled else None
+        position.projection_version += 1
+        position.reconcile_status = "synchronized" if is_filled else "pending"
+        position.last_reconciled_at = utcnow() if is_filled else position.last_reconciled_at
         position.updated_at = utcnow()
-        self._log(db, position.symbol, "close", "\u2B1B POSITION FLATTENED \u2014 all tranches closed @ market")
+        self._log(
+            db,
+            position.symbol,
+            "close",
+            "\u2b1b POSITION FLATTENED \u2014 all tranches closed @ market",
+        )
+        self._sync_projection(db, position)
         db.commit()
         view = self.get_position(db, position.symbol)
         await self._broadcast_position_bundle(db, view)
         return view
 
-    def get_positions(self, db: Session) -> list[PositionView]:
-        positions = db.scalars(select(PositionEntity).order_by(PositionEntity.created_at.desc())).all()
-        return [self._position_view(db, position) for position in positions]
+    def _projection_for_symbol(self, db: Session, symbol: str) -> PositionProjectionEntity | None:
+        pending = next(
+            (
+                instance
+                for instance in db.new
+                if isinstance(instance, PositionProjectionEntity)
+                and instance.symbol == symbol.upper()
+            ),
+            None,
+        )
+        if pending is not None:
+            return pending
+        return db.scalar(
+            select(PositionProjectionEntity).where(
+                PositionProjectionEntity.symbol == symbol.upper()
+            )
+        )
 
-    def get_position(self, db: Session, symbol: str) -> PositionView:
-        return self._position_view(db, self._require_position(db, symbol))
-
-    def get_orders(self, db: Session, symbol: str) -> list[OrderView]:
-        position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == symbol.upper()))
+    def _orders_for_position(
+        self,
+        db: Session,
+        symbol: str,
+        *,
+        position: PositionEntity | None = None,
+        reconcile: bool = True,
+    ) -> list[OrderView]:
+        if position is None:
+            position = db.scalar(
+                select(PositionEntity).where(PositionEntity.symbol == symbol.upper())
+            )
+        position_side = self._position_side(position) if position is not None else "buy"
+        if position is not None and reconcile and self._reconcile_position(db, position):
+            db.commit()
         if position is not None and position.root_order_id:
             rows = db.scalars(
                 select(OrderEntity)
                 .where(
                     OrderEntity.symbol == symbol.upper(),
-                    (OrderEntity.order_id == position.root_order_id) | (OrderEntity.parent_id == position.root_order_id),
+                    (OrderEntity.order_id == position.root_order_id)
+                    | (OrderEntity.parent_id == position.root_order_id),
                 )
                 .order_by(OrderEntity.created_at.asc())
             ).all()
         else:
             rows = db.scalars(
-                select(OrderEntity).where(OrderEntity.symbol == symbol.upper()).order_by(OrderEntity.created_at.asc())
+                select(OrderEntity)
+                .where(OrderEntity.symbol == symbol.upper())
+                .order_by(OrderEntity.created_at.asc())
             ).all()
-        return [self._order_view(row) for row in rows]
+        return [
+            self._order_view(
+                db,
+                row,
+                position_side=position_side,
+            )
+            for row in rows
+        ]
+
+    def _projection_payload(self, db: Session, position: PositionEntity) -> dict:
+        orders = self._orders_for_position(db, position.symbol, position=position, reconcile=False)
+        committed_stop_labels = {
+            order.tranche
+            for order in orders
+            if order.type == "STOP" and order.tranche.startswith("S")
+        }
+        position_side = self._position_side(position)
+        mark_state = (
+            position.setup_snapshot.get("markState", "frozen")
+            if position.setup_snapshot
+            else "frozen"
+        )
+        mark_label = position.setup_snapshot.get("markLabel") if position.setup_snapshot else None
+        intent = (
+            db.scalar(
+                select(OrderIntentEntity).where(
+                    OrderIntentEntity.intent_id == position.last_intent_id
+                )
+            )
+            if position.last_intent_id
+            else None
+        )
+        root_order = (
+            db.scalar(select(OrderEntity).where(OrderEntity.order_id == position.root_order_id))
+            if position.root_order_id
+            else None
+        )
+        view = PositionView(
+            symbol=position.symbol,
+            phase=position.phase,
+            side=position_side,
+            livePrice=position.live_price,
+            markState="live" if mark_state == "live" else "frozen",
+            markLabel=(str(mark_label) if mark_label else self._mark_label(str(mark_state))),
+            setup=position.setup_snapshot,
+            tranches=[Tranche.model_validate(item) for item in position.tranches],
+            orders=orders,
+            trancheModes=[TrancheMode.model_validate(item) for item in position.tranche_modes],
+            stopModes=[StopMode.model_validate(item) for item in position.stop_modes],
+            rootOrderId=position.root_order_id,
+            stopMode=len(committed_stop_labels),
+            trancheCount=position.tranche_count,
+            intentId=position.last_intent_id,
+            intentStatus=intent.status if intent is not None else None,
+            brokerOrderId=(root_order.broker_order_id if root_order is not None else None),
+            brokerStatus=root_order.status if root_order is not None else None,
+            reconcileStatus=position.reconcile_status,
+            blockingReasons=list(intent.blocking_reasons) if intent is not None else [],
+            projectionVersion=position.projection_version,
+            lastReconciledAt=self._coerce_utc(position.last_reconciled_at),
+            fills=self._position_fills(db, position.symbol),
+        )
+        return view.model_dump(mode="json")
+
+    def _position_view_from_state(self, db: Session, row: PositionEntity) -> PositionView:
+        return PositionView.model_validate(self._projection_payload(db, row))
+
+    def get_positions(self, db: Session) -> list[PositionView]:
+        self._reconcile_all_positions(db)
+        projections = db.scalars(
+            select(PositionProjectionEntity).order_by(PositionProjectionEntity.updated_at.desc())
+        ).all()
+        views = [
+            PositionView.model_validate(projection.payload)
+            for projection in projections
+            if isinstance(projection.payload, dict) and projection.payload
+        ]
+        projected_symbols = {view.symbol for view in views}
+        positions = db.scalars(
+            select(PositionEntity).order_by(PositionEntity.created_at.desc())
+        ).all()
+        for position in positions:
+            if position.symbol in projected_symbols:
+                continue
+            views.append(self._position_view_from_state(db, position))
+        return views
+
+    def get_position(self, db: Session, symbol: str) -> PositionView:
+        position = self._require_position(db, symbol)
+        if self._reconcile_position(db, position):
+            db.commit()
+        projection = self._projection_for_symbol(db, position.symbol)
+        if projection is not None and isinstance(projection.payload, dict) and projection.payload:
+            return PositionView.model_validate(projection.payload)
+        return self._position_view_from_state(db, position)
+
+    def get_orders(self, db: Session, symbol: str) -> list[OrderView]:
+        return self._orders_for_position(db, symbol, reconcile=True)
+
+    def get_recent_orders(self, db: Session, limit: int = 50) -> list[OrderView]:
+        broker_orders_by_symbol = self._recent_broker_orders_by_symbol(limit=max(limit, 100))
+        self._reconcile_all_positions(db, broker_orders_by_symbol)
+        try:
+            broker_payloads = self.broker.list_recent_orders(limit=limit)
+        except ValueError:
+            broker_payloads = []
+        broker_orders = {
+            order["id"]: order
+            for order in broker_payloads
+            if isinstance(order, dict) and order.get("id")
+        }
+        rows = db.scalars(
+            select(OrderEntity).order_by(OrderEntity.created_at.desc()).limit(limit * 3)
+        ).all()
+        position_side_by_symbol = {
+            position.symbol: self._position_side(position)
+            for position in db.scalars(select(PositionEntity)).all()
+        }
+        merged: list[OrderView] = []
+        seen_broker_ids: set[str] = set()
+        for row in rows:
+            broker_payload = broker_orders.get(row.broker_order_id or "")
+            if broker_payload is not None:
+                seen_broker_ids.add(str(broker_payload.get("id")))
+            merged.append(
+                self._order_view(
+                    db,
+                    row,
+                    broker_payload,
+                    position_side=position_side_by_symbol.get(row.symbol, "buy"),
+                )
+            )
+        for broker_order_id, broker_payload in broker_orders.items():
+            if broker_order_id in seen_broker_ids:
+                continue
+            merged.append(self._broker_order_view(broker_payload))
+        merged.sort(
+            key=lambda item: (
+                item.updatedAt
+                or item.filledAt
+                or item.createdAt
+                or datetime.min.replace(tzinfo=UTC)
+            ),
+            reverse=True,
+        )
+        return merged[:limit]
+
+    def cancel_recent_order(self, db: Session, broker_order_id: str) -> OrderView:
+        broker_order = self.broker.get_order(broker_order_id)
+        if broker_order is None:
+            raise ValueError("Broker order was not found.")
+        if not self._broker_order_cancelable(broker_order):
+            raise ValueError("Broker order is no longer cancelable.")
+        self.broker.cancel_order(broker_order_id)
+        refreshed = self.broker.get_order(broker_order_id) or {
+            **broker_order,
+            "status": "canceled",
+        }
+        local_orders = db.scalars(
+            select(OrderEntity).where(OrderEntity.broker_order_id == broker_order_id)
+        ).all()
+        for local in local_orders:
+            local.status = str(refreshed.get("status", "canceled")).upper()
+        self._reconcile_canceled_root_orders(db, local_orders)
+        if local_orders:
+            self._log(
+                db,
+                local_orders[0].symbol,
+                "warn",
+                f"Canceled broker order {broker_order_id} for {local_orders[0].symbol}.",
+            )
+        db.commit()
+        local = local_orders[0] if local_orders else None
+        position_side = "buy"
+        if local is not None:
+            position = db.scalar(
+                select(PositionEntity).where(PositionEntity.symbol == local.symbol)
+            )
+            if position is not None:
+                position_side = self._position_side(position)
+        return (
+            self._order_view(db, local, refreshed, position_side=position_side)
+            if local is not None
+            else self._broker_order_view(refreshed)
+        )
 
     def get_logs(self, db: Session) -> list[LogEntry]:
         self.ensure_seed_data(db)
-        rows = db.scalars(select(TradeLogEntity).order_by(TradeLogEntity.created_at.desc()).limit(200)).all()
+        rows = db.scalars(
+            select(TradeLogEntity).order_by(TradeLogEntity.created_at.desc()).limit(200)
+        ).all()
         return [LogEntry.model_validate(row, from_attributes=True) for row in rows]
 
     def clear_logs(self, db: Session) -> int:
@@ -531,22 +1739,360 @@ class CockpitService:
         position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == symbol.upper()))
         if position is None:
             return
-        position.live_price = round(max(0.01, position.live_price + uniform(-0.35, 0.35)), 2)
+        self._refresh_live_mark(position)
         position.updated_at = utcnow()
+        self._reconcile_position(db, position)
         db.commit()
         base = position.entry_price
+        snapshot = dict(position.setup_snapshot or {})
         await self.ws_manager.broadcast(
             "cockpit",
             self._event(
                 "price_update",
                 symbol=position.symbol,
-                bid=round(position.live_price - 0.03, 2),
-                ask=round(position.live_price + 0.03, 2),
+                bid=snapshot.get("bid", position.live_price),
+                ask=snapshot.get("ask", position.live_price),
                 last=position.live_price,
                 delta=round(position.live_price - base, 2),
-                delta_pct=round(((position.live_price - base) / base) * 100, 2) if base else 0.0,
+                delta_pct=(round(((position.live_price - base) / base) * 100, 2) if base else 0.0),
+                markState=snapshot.get("markState", "frozen"),
+                markLabel=snapshot.get("markLabel"),
             ),
         )
+        view = self._position_view(db, position)
+        await self._broadcast_position_bundle(db, view)
+
+    def _refresh_live_mark(self, position: PositionEntity) -> None:
+        snapshot = dict(position.setup_snapshot or {})
+        entry_order = snapshot.get("entryOrder")
+        next_state = "frozen"
+        next_label = "Mark frozen at last valid price."
+
+        try:
+            market = self.market_data.get_setup_data(position.symbol)
+        except ValueError:
+            market = None
+
+        if (
+            market is not None
+            and market.quote_state == "live_quote"
+            and market.session_state == "regular_open"
+            and market.last > 0
+        ):
+            position.live_price = round(market.last, 2)
+            snapshot.update(
+                {
+                    "bid": market.bid,
+                    "ask": market.ask,
+                    "last": round(market.last, 2),
+                    "quoteTimestamp": (
+                        market.quote_timestamp.isoformat() if market.quote_timestamp else None
+                    ),
+                    "sessionState": market.session_state,
+                    "quoteState": market.quote_state,
+                }
+            )
+            next_state = "live"
+            next_label = None
+        elif market is not None:
+            next_label = (
+                "Mark frozen outside regular session."
+                if market.session_state != "regular_open"
+                else "Mark frozen because the latest quote is stale or unavailable."
+            )
+
+        snapshot["markState"] = next_state
+        snapshot["markLabel"] = next_label
+        if isinstance(entry_order, dict):
+            snapshot["entryOrder"] = entry_order
+        position.setup_snapshot = snapshot
+
+    def _reconcile_all_positions(
+        self,
+        db: Session,
+        broker_orders_by_symbol: dict[str, dict[str, dict]] | None = None,
+    ) -> None:
+        changed = False
+        processed_orders = 0
+        processed_fills = 0
+        run = self._start_reconcile_run(db, "poll")
+        for position in db.scalars(select(PositionEntity)).all():
+            symbol_orders = None
+            if broker_orders_by_symbol is not None:
+                symbol_orders = broker_orders_by_symbol.get(position.symbol.upper(), {})
+            processed_orders += len(symbol_orders or {})
+            changed = self._reconcile_position(db, position, symbol_orders) or changed
+            processed_fills += len(self._position_fills(db, position.symbol))
+        self._finish_reconcile_run(
+            run,
+            processed_orders=processed_orders,
+            processed_fills=processed_fills,
+        )
+        if changed:
+            db.commit()
+
+    def _reconcile_position(
+        self,
+        db: Session,
+        position: PositionEntity,
+        broker_orders: dict[str, dict] | None = None,
+    ) -> bool:
+        changed = False
+        symbol_orders = (
+            broker_orders
+            if broker_orders is not None
+            else self._broker_orders_for_symbol(position.symbol)
+        )
+        for broker_order_id, payload in symbol_orders.items():
+            local_order = db.scalar(
+                select(OrderEntity).where(OrderEntity.broker_order_id == broker_order_id)
+            )
+            self._sync_broker_order_snapshot(
+                db,
+                broker_order_id=broker_order_id,
+                symbol=position.symbol,
+                intent_id=local_order.intent_id if local_order is not None else None,
+                payload=payload,
+                fallback_status=str(payload.get("status") or "UNKNOWN").upper(),
+            )
+        root_order = db.scalar(
+            select(OrderEntity).where(OrderEntity.order_id == position.root_order_id)
+        )
+        if position.phase == "entry_pending" and root_order is not None:
+            root_payload = symbol_orders.get(root_order.broker_order_id or "")
+            if root_payload is not None and str(root_payload.get("status", "")).lower() == "filled":
+                self._mark_entry_filled_if_ready(db, position)
+                root_order.fill_price = (
+                    self._broker_fill_price(root_payload, root_order.fill_price)
+                    or position.entry_price
+                )
+                root_order.filled_at = (
+                    self._broker_timestamp(root_payload, "filled_at")
+                    or root_order.filled_at
+                    or utcnow()
+                )
+                root_order.filled_qty = root_order.orig_qty
+                position.reconcile_status = "synchronized"
+                position.last_reconciled_at = utcnow()
+                position.projection_version += 1
+                self._record_fill(
+                    db,
+                    fill_id=self._new_id("fill"),
+                    broker_order_id=root_order.broker_order_id,
+                    symbol=position.symbol,
+                    intent_id=root_order.intent_id,
+                    qty=root_order.orig_qty,
+                    price=root_order.fill_price or position.entry_price,
+                    occurred_at=root_order.filled_at or utcnow(),
+                    payload=root_payload,
+                )
+                self._record_event(
+                    db,
+                    "OrderFilled",
+                    symbol=position.symbol,
+                    intent_id=root_order.intent_id,
+                    broker_order_id=root_order.broker_order_id,
+                    payload={"status": "FILLED"},
+                )
+                changed = True
+        exit_orders = db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == position.symbol,
+                OrderEntity.type.in_(["STOP", "TRAIL", "LMT", "MKT"]),
+                OrderEntity.status.in_(["ACTIVE", "MODIFIED", "NEW", "ACCEPTED"]),
+            )
+        ).all()
+        for order in exit_orders:
+            fill_details = self._resolve_exit_fill(
+                position, order, symbol_orders.get(order.broker_order_id or "")
+            )
+            if fill_details is None:
+                continue
+            changed = self._apply_exit_fill(db, position, order, fill_details) or changed
+        if changed:
+            position.last_reconciled_at = utcnow()
+            position.reconcile_status = "synchronized"
+            position.projection_version += 1
+            self._sync_projection(db, position)
+        return changed
+
+    def _recent_broker_orders_by_symbol(self, limit: int = 100) -> dict[str, dict[str, dict]]:
+        try:
+            recent = self.broker.list_recent_orders(limit=limit)
+        except ValueError:
+            return {}
+        grouped: dict[str, dict[str, dict]] = {}
+        for order in recent:
+            if not isinstance(order, dict):
+                continue
+            symbol = str(order.get("symbol") or "").upper()
+            broker_order_id = str(order.get("id") or "")
+            if not symbol or not broker_order_id:
+                continue
+            grouped.setdefault(symbol, {})[broker_order_id] = order
+        return grouped
+
+    def _broker_orders_for_symbol(self, symbol: str) -> dict[str, dict]:
+        return dict(self._recent_broker_orders_by_symbol(limit=100).get(symbol.upper(), {}))
+
+    def _resolve_exit_fill(
+        self,
+        position: PositionEntity,
+        order: OrderEntity,
+        broker_payload: dict | None,
+    ) -> dict[str, object] | None:
+        if broker_payload is not None:
+            status = str(broker_payload.get("status") or "").lower()
+            if status == "canceled":
+                order.status = "CANCELED"
+                return None
+            if status not in {"filled", "partially_filled"}:
+                return None
+            return {
+                "status": status.upper(),
+                "fill_price": self._broker_fill_price(broker_payload, order.fill_price)
+                or order.price,
+                "filled_at": self._broker_timestamp(broker_payload, "filled_at") or utcnow(),
+                "filled_qty": max(0, self._broker_filled_qty(broker_payload) or order.orig_qty),
+                "payload": broker_payload,
+            }
+        if order.status not in {"ACTIVE", "MODIFIED"}:
+            return None
+        if position.phase == "entry_pending":
+            return None
+        if self.settings.broker_execution_provider != "paper":
+            return None
+        position_side = self._position_side(position)
+        if position_side == "buy" and position.live_price > order.price:
+            return None
+        if position_side == "sell" and position.live_price < order.price:
+            return None
+        return {
+            "status": "FILLED",
+            "fill_price": order.price,
+            "filled_at": utcnow(),
+            "filled_qty": order.orig_qty,
+            "payload": None,
+        }
+
+    def _apply_exit_fill(
+        self,
+        db: Session,
+        position: PositionEntity,
+        order: OrderEntity,
+        fill_details: dict[str, object],
+    ) -> bool:
+        active_ids = {
+            tranche["id"]
+            for tranche in position.tranches
+            if tranche["status"] in {"active", "pending_exit", "partially_filled"}
+        }
+        covered = [
+            tranche_id
+            for tranche_id in (
+                order.covered_tranches
+                or ([order.tranche_label] if order.tranche_label.startswith("T") else [])
+            )
+            if tranche_id in active_ids
+        ]
+        if not covered:
+            order.status = str(fill_details["status"])
+            order.fill_price = float(fill_details["fill_price"])
+            order.filled_at = fill_details["filled_at"]  # type: ignore[assignment]
+            order.filled_qty = int(fill_details.get("filled_qty") or order.orig_qty)
+            return True
+        tranches = deepcopy(position.tranches)
+        filled_at = fill_details["filled_at"]
+        fill_price = float(fill_details["fill_price"])
+        filled_qty = int(fill_details.get("filled_qty") or order.orig_qty)
+        order_fill_id = self._new_id("fill")
+        for tranche in tranches:
+            if tranche["id"] not in covered or tranche["status"] not in {
+                "active",
+                "pending_exit",
+                "partially_filled",
+            }:
+                continue
+            partial_fill = filled_qty < order.orig_qty
+            tranche["status"] = "partially_filled" if partial_fill else "sold"
+            tranche["target"] = fill_price
+            tranche["exitPrice"] = fill_price
+            tranche["exitFilledAt"] = (
+                filled_at.isoformat() if isinstance(filled_at, datetime) else str(filled_at)
+            )
+            tranche["exitOrderType"] = order.type
+            tranche["filledQty"] = filled_qty
+            tranche["remainingQty"] = max(0, order.orig_qty - filled_qty)
+            if partial_fill:
+                tranche["qty"] = max(0, tranche["qty"] - filled_qty)
+        order.status = str(fill_details["status"])
+        order.fill_price = fill_price
+        order.filled_at = filled_at if isinstance(filled_at, datetime) else utcnow()
+        order.filled_qty = filled_qty
+        position.tranches = tranches
+        position.phase = self._phase_from_tranches(position, tranches)
+        position.updated_at = utcnow()
+        if position.phase == "closed":
+            position.closed_at = position.closed_at or utcnow()
+        else:
+            position.closed_at = None
+        self._record_fill(
+            db,
+            fill_id=order_fill_id,
+            broker_order_id=order.broker_order_id,
+            symbol=position.symbol,
+            intent_id=order.intent_id,
+            qty=filled_qty,
+            price=fill_price,
+            occurred_at=order.filled_at or utcnow(),
+            payload=(fill_details.get("payload") if isinstance(fill_details, dict) else None),
+        )
+        self._record_event(
+            db,
+            (
+                "OrderPartiallyFilled"
+                if str(fill_details["status"]).upper() == "PARTIALLY_FILLED"
+                else "OrderFilled"
+            ),
+            symbol=position.symbol,
+            intent_id=order.intent_id,
+            broker_order_id=order.broker_order_id,
+            fill_id=order_fill_id,
+            payload={
+                "order_type": order.type,
+                "filled_qty": filled_qty,
+                "fill_price": fill_price,
+            },
+        )
+        verb = "Stop hit" if order.type == "STOP" else "Exit filled"
+        self._log(
+            db,
+            position.symbol,
+            "warn" if order.type == "STOP" else "exec",
+            f"{verb}: {' · '.join(covered)} @ {fill_price:.2f}",
+        )
+        db.flush()
+        return True
+
+    def _phase_from_tranches(self, position: PositionEntity, tranches: list[dict]) -> str:
+        actionable = [
+            tranche
+            for tranche in tranches
+            if tranche["status"] in {"active", "pending_exit", "partially_filled"}
+        ]
+        if not actionable:
+            return "closed"
+        if any(tranche["status"] == "pending_exit" for tranche in tranches):
+            return "closing"
+        runner_active = any(tranche.get("mode") == "runner" for tranche in actionable)
+        sold_count = sum(1 for tranche in tranches if tranche["status"] in {"sold", "closed"})
+        if runner_active and len(actionable) == 1:
+            return "runner_only"
+        if sold_count >= 2:
+            return "P2_done"
+        if sold_count >= 1:
+            return "P1_done"
+        return "protected"
 
     def _build_setup_response(
         self,
@@ -555,17 +2101,40 @@ class CockpitService:
         buying_power: float,
         risk_pct: float,
         equity_source: str,
+        cash: float | None = None,
+        *,
+        reconcile_status: str = "synchronized",
+        last_reconciled_at: datetime | None = None,
+        additional_blocking_reasons: list[str] | None = None,
     ) -> SetupResponse:
         entry = round((market.bid + market.ask) / 2, 2)
         lod_stop = round(market.lod, 2)
         atr_stop = round(max(0.01, entry - market.atr14), 2)
+        hod_stop = round(market.hod, 2)
+        short_atr_stop = round(entry + market.atr14, 2)
         lod_is_valid = lod_stop < entry
         atr_is_valid = 0 < atr_stop < entry
+        hod_is_valid = hod_stop > entry
+        short_atr_is_valid = short_atr_stop > entry
         stop_reference_default = "lod" if lod_is_valid else "manual"
+        short_stop_reference_default = "lod" if hod_is_valid else "manual"
         final_stop = lod_stop if lod_is_valid else 0.0
-        manual_stop_warning = None if lod_is_valid else "Low of day is above the current entry price. Enter a manual stop for this setup."
+        manual_stop_warning = (
+            None
+            if lod_is_valid
+            else "Low of day is above the current entry price. Enter a manual stop for this setup."
+        )
         per_share_risk = round(entry - final_stop, 2) if lod_is_valid else 0.0
         shares = self._calculate_shares(equity, buying_power, entry, risk_pct, per_share_risk)
+        sizing_warning = self._sizing_warning(buying_power, entry, shares)
+        buying_power_note = self._buying_power_note(equity, buying_power, cash, equity_source)
+        quote_age_ms = self._quote_age_ms(market.quote_timestamp)
+        blocking_reasons = self._setup_execution_blocking_reasons(market, quote_age_ms)
+        if additional_blocking_reasons:
+            blocking_reasons.extend(additional_blocking_reasons)
+        blocking_reasons = self._distinct_reasons(blocking_reasons)
+        is_executable = not blocking_reasons
+        data_quality = self._data_quality(market, quote_age_ms, is_executable)
         return SetupResponse(
             symbol=market.symbol,
             provider=market.provider,
@@ -580,11 +2149,24 @@ class CockpitService:
             sessionState=market.session_state,
             quoteState=market.quote_state,
             entryBasis=market.entry_basis,
+            dataQuality=data_quality,
+            quoteAgeMs=quote_age_ms,
+            reconcileStatus=(
+                "stale" if not is_executable and reconcile_status != "pending" else reconcile_status
+            ),
+            lastReconciledAt=self._coerce_utc(last_reconciled_at),
+            isExecutable=is_executable,
+            executionBlockingReasons=blocking_reasons,
             stopReferenceDefault=stop_reference_default,
+            shortStopReferenceDefault=short_stop_reference_default,
             lodIsValid=lod_is_valid,
             atrIsValid=atr_is_valid,
+            hodIsValid=hod_is_valid,
+            shortAtrIsValid=short_atr_is_valid,
             lodStop=lod_stop,
             atrStop=atr_stop,
+            hodStop=hod_stop,
+            shortAtrStop=short_atr_stop,
             manualStopWarning=manual_stop_warning,
             bid=market.bid,
             ask=market.ask,
@@ -610,30 +2192,142 @@ class CockpitService:
             riskPct=risk_pct,
             accountEquity=equity,
             accountBuyingPower=buying_power,
+            accountCash=cash,
             equitySource=equity_source,
+            sizingWarning=sizing_warning,
+            buyingPowerNote=buying_power_note,
             atrExtension=round((entry - market.sma50) / market.atr14, 2),
             extFrom10Ma=round(((entry - market.sma10) / market.sma10) * 100, 2),
         )
 
-    def _calculate_shares(self, equity: float, buying_power: float, entry: float, risk_pct: float, per_share_risk: float) -> int:
+    def _quote_age_ms(self, quote_timestamp: datetime | None) -> int | None:
+        if quote_timestamp is None:
+            return None
+        return max(0, int((utcnow() - quote_timestamp).total_seconds() * 1000))
+
+    def _setup_execution_blocking_reasons(
+        self, market: SetupMarketData, quote_age_ms: int | None
+    ) -> list[str]:
+        reasons: list[str] = []
+        if not self.settings.trading_enabled:
+            reasons.append("Trading is disabled by runtime configuration.")
+        if market.symbol.upper() in self.settings.disabled_symbols:
+            reasons.append(f"{market.symbol.upper()} is currently disabled for trading.")
+        if quote_age_ms is None:
+            reasons.append("Quote timestamp is unavailable.")
+        elif quote_age_ms > self.settings.max_quote_age_seconds * 1000:
+            reasons.append("Quote is stale and cannot be used for execution.")
+        if self.settings.app_env not in {"development", "test"} and (
+            market.fallback_reason or not market.quote_is_real or market.technicals_are_fallback
+        ):
+            reasons.append("Fallback-backed market data is visible but blocked from execution.")
+        if (
+            self.settings.broker_mode in {"alpaca_paper", "alpaca_live"}
+            and not self.settings.has_alpaca_credentials
+        ):
+            reasons.append("Broker credentials are missing for the configured execution mode.")
+        return reasons
+
+    def _data_quality(
+        self, market: SetupMarketData, quote_age_ms: int | None, is_executable: bool
+    ) -> str:
+        if not is_executable:
+            return "blocked"
+        if quote_age_ms is not None and quote_age_ms > self.settings.max_quote_age_seconds * 1000:
+            return "stale"
+        if market.fallback_reason or not market.quote_is_real or market.technicals_are_fallback:
+            return "fallback"
+        return "live"
+
+    def _calculate_shares(
+        self,
+        equity: float,
+        buying_power: float,
+        entry: float,
+        risk_pct: float,
+        per_share_risk: float,
+    ) -> int:
         if per_share_risk <= 0 or entry <= 0:
             return 0
         risk_budget = floor((equity * (risk_pct / 100)) / per_share_risk)
         max_notional = equity * (self.settings.max_position_notional_pct / 100)
-        effective_notional_cap = min(buying_power, max_notional) if buying_power > 0 else max_notional
-        buying_power_cap = floor(effective_notional_cap / entry) if effective_notional_cap > 0 else 0
-        capped = min(risk_budget, buying_power_cap) if buying_power_cap > 0 else risk_budget
+        effective_notional_cap = (
+            min(buying_power, max_notional) if buying_power > 0 else max_notional
+        )
+        buying_power_cap = (
+            floor(effective_notional_cap / entry) if effective_notional_cap > 0 else 0
+        )
+        capped = min(risk_budget, buying_power_cap)
         return max(0, capped)
 
-    def _split_shares(self, shares: int, count: int) -> list[int]:
+    def _sizing_warning(self, buying_power: float, entry: float, shares: int) -> str | None:
+        if entry > 0 and buying_power > 0 and buying_power < entry:
+            return "Insufficient buying power to fund even one share at the current entry price."
+        if buying_power <= 0:
+            return "Broker buying power is unavailable or zero."
+        if shares <= 0:
+            return "Calculated shares is zero for this setup."
+        return None
+
+    def _buying_power_note(
+        self,
+        equity: float,
+        buying_power: float,
+        cash: float | None,
+        equity_source: str,
+    ) -> str | None:
+        if equity_source != "alpaca_account":
+            return None
+        if buying_power <= 0:
+            return "Live broker buying power is unavailable or fully reserved by current Alpaca paper orders or positions."
+        if cash is not None and buying_power <= cash:
+            return "Live broker buying power is currently limited by open or pending Alpaca paper orders and positions."
+        if equity > 0 and buying_power < equity * 0.25:
+            return "Live broker buying power is currently much lower than equity because Alpaca is reserving capital for open or pending paper orders."
+        return None
+
+    def _split_shares(
+        self,
+        shares: int,
+        count: int,
+        tranche_modes: list[TrancheMode] | None = None,
+    ) -> list[int]:
         if count <= 1:
             return [shares]
-        if count == 2:
-            first = shares // 2
-            return [first, shares - first]
-        first = floor(shares * 0.33)
-        second = floor(shares * 0.33)
-        return [first, second, shares - first - second]
+        if shares <= 0:
+            return [0 for _ in range(count)]
+        if not tranche_modes:
+            tranche_modes = []
+        allocations = self._normalize_allocation_pcts(tranche_modes, count)
+        raw_shares = [shares * (allocation / 100.0) for allocation in allocations]
+        assigned = [floor(value) for value in raw_shares]
+        remainder = shares - sum(assigned)
+        remainders = sorted(
+            ((raw_shares[index] - assigned[index], index) for index in range(count)),
+            key=lambda item: (-item[0], item[1]),
+        )
+        for _, index in remainders[:remainder]:
+            assigned[index] += 1
+        return assigned
+
+    def _normalize_allocation_pcts(
+        self, tranche_modes: list[TrancheMode], count: int
+    ) -> list[float]:
+        active = tranche_modes[:count]
+        if count == 1:
+            return [100.0]
+        default = 100.0 / count
+        provided = [
+            mode.allocationPct if mode.allocationPct is not None else default for mode in active
+        ]
+        total = sum(provided)
+        if total <= 0:
+            return [round(default, 2) for _ in range(count - 1)] + [
+                round(100.0 - round(default, 2) * (count - 1), 2)
+            ]
+        normalized = [round((value / total) * 100.0, 2) for value in provided]
+        normalized[-1] = round(100.0 - sum(normalized[:-1]), 2)
+        return normalized
 
     def _stop_groups(self, tranches: list[dict], stop_mode: int) -> list[list[dict]]:
         active = [tranche for tranche in tranches if tranche["status"] == "active"]
@@ -652,17 +2346,32 @@ class CockpitService:
         base = floor(100 / stop_mode)
         return float(100 - base * index) if index == stop_mode - 1 else float(base)
 
-    def _resolve_target_price(self, entry: float, per_share_risk: float, mode: TrancheMode) -> float:
+    def _resolve_target_price(
+        self, entry: float, per_share_risk: float, mode: TrancheMode, side: str
+    ) -> float:
         if mode.target == "Manual" and mode.manualPrice is not None:
             return round(mode.manualPrice, 2)
         multiplier = {"1R": 1, "2R": 2, "3R": 3}[mode.target]
-        return round(entry + per_share_risk * multiplier, 2)
+        direction = 1 if side == "buy" else -1
+        return round(entry + direction * per_share_risk * multiplier, 2)
 
-    def _trail_stop(self, live_price: float, trail: float, trail_unit: str) -> float:
-        return round(live_price - trail, 2) if trail_unit == "$" else round(live_price * (1 - trail / 100), 2)
+    def _trail_stop(self, live_price: float, trail: float, trail_unit: str, side: str) -> float:
+        if side == "buy":
+            return (
+                round(live_price - trail, 2)
+                if trail_unit == "$"
+                else round(live_price * (1 - trail / 100), 2)
+            )
+        return (
+            round(live_price + trail, 2)
+            if trail_unit == "$"
+            else round(live_price * (1 + trail / 100), 2)
+        )
 
     def _reduce_stop_orders(self, db: Session, symbol: str, tranche_id: str, qty_sold: int) -> None:
-        for order in db.scalars(select(OrderEntity).where(OrderEntity.symbol == symbol, OrderEntity.type == "STOP")):
+        for order in db.scalars(
+            select(OrderEntity).where(OrderEntity.symbol == symbol, OrderEntity.type == "STOP")
+        ):
             if order.status == "CANCELED" or tranche_id not in order.covered_tranches:
                 continue
             order.qty = max(0, order.qty - qty_sold)
@@ -673,21 +2382,88 @@ class CockpitService:
         account = self.get_account(db)
         if entry * shares > account.equity * (self.settings.max_position_notional_pct / 100):
             raise ValueError("Position exceeds max notional cap")
-        if account.daily_realized_pnl < -(account.equity * (self.settings.daily_loss_limit_pct / 100)):
+        if account.daily_realized_pnl < -(
+            account.equity * (self.settings.daily_loss_limit_pct / 100)
+        ):
             raise ValueError("Daily loss limit reached")
         open_positions = [row for row in self.get_positions(db) if row.phase != "closed"]
         if len(open_positions) >= self.settings.max_open_positions:
             raise ValueError("Max open positions reached")
         self._cancel_stale_active_orders(db, symbol)
-        active = db.scalars(select(OrderEntity).where(OrderEntity.symbol == symbol, OrderEntity.status.in_(["ACTIVE", "MODIFIED"]))).all()
+        active = db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == symbol,
+                OrderEntity.status.in_(["ACTIVE", "MODIFIED"]),
+            )
+        ).all()
         if active:
             raise ValueError("Duplicate active orders exist for this symbol")
 
-    def _validate_stop(self, entry: float, stop_price: float) -> None:
-        if stop_price >= entry:
-            raise ValueError("Stop price must be below entry")
-        if stop_price <= entry * 0.5:
-            raise ValueError("Stop price too far below entry")
+    def _build_broker_entry_order(
+        self,
+        symbol: str,
+        shares: int,
+        entry: float,
+        order: EntryOrderDraft,
+        session_state: str,
+        enforce_alpaca_offhours: bool,
+    ) -> BrokerEntryOrder:
+        return BrokerEntryOrder(
+            symbol=symbol,
+            qty=shares,
+            side=order.side,
+            order_type="limit",
+            time_in_force="gtc",
+            limit_price=round(entry, 2),
+        )
+
+    def _entry_should_start_filled(
+        self,
+        order: BrokerEntryOrder,
+        broker_status: str,
+        session_state: str,
+        enforce_alpaca_offhours: bool,
+    ) -> bool:
+        if broker_status.upper() == "FILLED":
+            return True
+        if enforce_alpaca_offhours and session_state != "regular_open":
+            return False
+        return False
+
+    def _local_entry_order_type(self, order: EntryOrderDraft) -> str:
+        return "LMT"
+
+    def _per_share_risk(self, entry: float, stop_price: float, side: str) -> float:
+        return round(entry - stop_price, 2) if side == "buy" else round(stop_price - entry, 2)
+
+    def _stop_price_from_pct(self, entry: float, stop_range: float, pct: float, side: str) -> float:
+        direction = -1 if side == "buy" else 1
+        return round(entry + direction * stop_range * pct / 100.0, 2)
+
+    def _position_side(self, position: PositionEntity) -> str:
+        entry_order = position.setup_snapshot.get("entryOrder") if position.setup_snapshot else None
+        side = entry_order.get("side") if isinstance(entry_order, dict) else None
+        return "sell" if side == "sell" else "buy"
+
+    def _exit_side(self, side: str) -> str:
+        return "sell" if side == "buy" else "buy"
+
+    def _mark_label(self, state: str, reason: str | None = None) -> str | None:
+        if state == "live":
+            return None
+        return reason or "Mark frozen at last valid price."
+
+    def _validate_stop(self, entry: float, stop_price: float, side: str) -> None:
+        if side == "buy":
+            if stop_price >= entry:
+                raise ValueError("Stop price must be below entry")
+            if stop_price <= entry * 0.5:
+                raise ValueError("Stop price too far below entry")
+            return
+        if stop_price <= entry:
+            raise ValueError("Stop price must be above entry for short entries")
+        if stop_price >= entry * 1.5:
+            raise ValueError("Stop price too far above entry")
 
     def _validate_stop_mode(self, stop_mode: int, stop_modes: list[StopMode]) -> None:
         if stop_mode not in {1, 2, 3}:
@@ -703,11 +2479,19 @@ class CockpitService:
 
     def _reject_duplicate_active_stops(self, db: Session, symbol: str) -> None:
         self._cancel_stale_active_orders(db, symbol)
-        active = db.scalars(select(OrderEntity).where(OrderEntity.symbol == symbol, OrderEntity.type == "STOP", OrderEntity.status.in_(["ACTIVE", "MODIFIED"]))).all()
+        active = db.scalars(
+            select(OrderEntity).where(
+                OrderEntity.symbol == symbol,
+                OrderEntity.type == "STOP",
+                OrderEntity.status.in_(["ACTIVE", "MODIFIED"]),
+            )
+        ).all()
         if active:
             raise ValueError("Active stop orders already exist for this symbol")
 
-    def _reject_duplicate_active_order(self, db: Session, symbol: str, tranche_id: str, order_type: str) -> None:
+    def _reject_duplicate_active_order(
+        self, db: Session, symbol: str, tranche_id: str, order_type: str
+    ) -> None:
         self._cancel_stale_active_orders(db, symbol)
         active = db.scalars(
             select(OrderEntity).where(
@@ -716,13 +2500,18 @@ class CockpitService:
                 OrderEntity.status.in_(["ACTIVE", "MODIFIED"]),
             )
         ).all()
-        if any(tranche_id in (order.covered_tranches or []) or order.tranche_label == tranche_id for order in active):
+        if any(
+            tranche_id in (order.covered_tranches or []) or order.tranche_label == tranche_id
+            for order in active
+        ):
             raise ValueError(f"Active {order_type} order already exists for {tranche_id}")
 
     def _cancel_stale_active_orders(self, db: Session, symbol: str) -> None:
         position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == symbol))
-        if position is not None and position.phase != "closed" and any(
-            tranche["status"] == "active" for tranche in position.tranches
+        if (
+            position is not None
+            and position.phase != "closed"
+            and any(tranche["status"] == "active" for tranche in position.tranches)
         ):
             return
         stale_orders = db.scalars(
@@ -752,10 +2541,37 @@ class CockpitService:
         if active_orders:
             db.flush()
 
+    def _reconcile_canceled_root_orders(self, db: Session, local_orders: list[OrderEntity]) -> None:
+        for local in local_orders:
+            if local.parent_id is not None:
+                continue
+            position = db.scalar(
+                select(PositionEntity).where(PositionEntity.symbol == local.symbol)
+            )
+            if position is None or position.root_order_id != local.order_id:
+                continue
+            if position.phase != "entry_pending":
+                continue
+            position.phase = "closed"
+            position.closed_at = utcnow()
+            position.updated_at = utcnow()
+            position.tranches = [
+                {**tranche, "status": "canceled"} for tranche in deepcopy(position.tranches)
+            ]
+            siblings = db.scalars(
+                select(OrderEntity).where(OrderEntity.symbol == local.symbol)
+            ).all()
+            for sibling in siblings:
+                if sibling.status in {"ACTIVE", "MODIFIED", "PENDING", "ACCEPTED"}:
+                    sibling.status = "CANCELED"
+            db.flush()
+
     def _mark_entry_filled_if_ready(self, db: Session, position: PositionEntity) -> None:
         if position.phase != "entry_pending":
             return
-        root_order = db.scalar(select(OrderEntity).where(OrderEntity.order_id == position.root_order_id))
+        root_order = db.scalar(
+            select(OrderEntity).where(OrderEntity.order_id == position.root_order_id)
+        )
         if root_order is None:
             return
         position.phase = "trade_entered"
@@ -774,7 +2590,10 @@ class CockpitService:
     def _ensure_position_is_open(self, position: PositionEntity) -> None:
         if position.phase == "closed":
             raise ValueError(f"Position {position.symbol} is already closed")
-        if not any(tranche["status"] == "active" for tranche in position.tranches):
+        if not any(
+            tranche["status"] in {"active", "pending_exit", "partially_filled"}
+            for tranche in position.tranches
+        ):
             raise ValueError(f"No active tranches remain for {position.symbol}")
 
     def _ensure_position_filled(self, position: PositionEntity, message: str) -> None:
@@ -783,9 +2602,14 @@ class CockpitService:
 
     def _ensure_profit_actionable(self, position: PositionEntity) -> None:
         self._ensure_position_is_open(position)
-        self._ensure_position_filled(position, "Position management is unavailable until the entry order is filled.")
+        self._ensure_position_filled(
+            position,
+            "Position management is unavailable until the entry order is filled.",
+        )
         if position.phase not in {"protected", "P1_done", "P2_done", "runner_only"}:
-            raise ValueError("Profit execution requires a protected or active profit-managed position")
+            raise ValueError(
+                "Profit execution requires a protected or active profit-managed position"
+            )
 
     def _effective_account_mode(self, requested_mode: str) -> str:
         if requested_mode == "alpaca_live" and self._live_disabled_reason(requested_mode):
@@ -808,11 +2632,32 @@ class CockpitService:
         await self.ws_manager.broadcast(
             "cockpit",
             self._event(
+                "position_projection_update",
+                symbol=view.symbol,
+                phase=view.phase,
+                projectionVersion=view.projectionVersion,
+                reconcileStatus=view.reconcileStatus,
+                position=view.model_dump(mode="json"),
+            ),
+        )
+        await self.ws_manager.broadcast(
+            "cockpit",
+            self._event(
                 "position_update",
                 symbol=view.symbol,
                 phase=view.phase,
                 pnl=self._pnl(view) if pnl is None else pnl,
                 position=view.model_dump(mode="json"),
+            ),
+        )
+        await self.ws_manager.broadcast(
+            "cockpit",
+            self._event(
+                "intent_update",
+                symbol=view.symbol,
+                intentId=view.intentId,
+                intentStatus=view.intentStatus,
+                blockingReasons=view.blockingReasons,
             ),
         )
         await self.ws_manager.broadcast(
@@ -824,11 +2669,39 @@ class CockpitService:
                 orders=[order.model_dump(mode="json") for order in view.orders],
             ),
         )
+        if view.fills:
+            await self.ws_manager.broadcast(
+                "cockpit",
+                self._event(
+                    "fill_update",
+                    symbol=view.symbol,
+                    fills=[fill.model_dump(mode="json") for fill in view.fills],
+                ),
+            )
         if latest_log is not None:
             await self.ws_manager.broadcast(
                 "cockpit",
-                self._event("log_update", symbol=view.symbol, log=latest_log.model_dump(mode="json")),
+                self._event(
+                    "log_update",
+                    symbol=view.symbol,
+                    log=latest_log.model_dump(mode="json"),
+                ),
             )
+
+    async def broadcast_position_projection(self, db: Session, view: PositionView) -> None:
+        await self._broadcast_position_bundle(db, view)
+
+    async def broadcast_account_update(self, db: Session) -> None:
+        account = self.get_account(db)
+        await self.ws_manager.broadcast(
+            "cockpit",
+            self._event(
+                "account_update",
+                account=account.model_dump(mode="json"),
+                effectiveMode=account.effective_mode,
+                reconcileStatus=account.reconcile_status,
+            ),
+        )
 
     def _latest_log_entry(self, db: Session, symbol: str | None = None) -> LogEntry | None:
         stmt = select(TradeLogEntity)
@@ -846,6 +2719,110 @@ class CockpitService:
             "timestamp": utcnow().isoformat(),
             **payload,
         }
+
+    def _lookup_intent_id(self, db: Session, broker_order_id: str) -> str | None:
+        order = db.scalar(select(OrderEntity).where(OrderEntity.broker_order_id == broker_order_id))
+        if order is not None:
+            return order.intent_id
+        snapshot = db.scalar(
+            select(BrokerOrderEntity).where(BrokerOrderEntity.broker_order_id == broker_order_id)
+        )
+        return snapshot.intent_id if snapshot is not None else None
+
+    def _normalize_fallback_webhook_payload(self, payload: dict) -> list[BrokerWebhookEvent]:
+        raw_events = payload.get("events") if isinstance(payload.get("events"), list) else [payload]
+        normalized: list[BrokerWebhookEvent] = []
+        for raw_event in raw_events:
+            if not isinstance(raw_event, dict):
+                continue
+            order_payload = None
+            for key in ("order", "data", "payload"):
+                candidate = raw_event.get(key)
+                if isinstance(candidate, dict) and candidate.get("id") and candidate.get("symbol"):
+                    order_payload = candidate
+                    break
+            if order_payload is None and raw_event.get("id") and raw_event.get("symbol"):
+                order_payload = raw_event
+            account_payload = None
+            for key in ("account", "account_snapshot"):
+                candidate = raw_event.get(key)
+                if isinstance(candidate, dict):
+                    account_payload = candidate
+                    break
+            if (
+                account_payload is None
+                and raw_event.get("equity") is not None
+                and raw_event.get("buying_power") is not None
+            ):
+                account_payload = raw_event
+            event_type = str(
+                raw_event.get("type")
+                or raw_event.get("event")
+                or raw_event.get("event_type")
+                or "broker_webhook"
+            ).lower()
+            occurred_at = self._broker_timestamp(raw_event, "timestamp")
+            if order_payload is not None:
+                broker_order_id = str(order_payload.get("id") or "").strip() or None
+                symbol = str(order_payload.get("symbol") or "").upper() or None
+                event_id = self._stable_external_event_id(
+                    "order", event_type, order_payload, occurred_at
+                )
+                fill_id = None
+                status = str(order_payload.get("status") or "").lower()
+                if status in {"filled", "partially_filled"}:
+                    fill_id = self._stable_external_event_id(
+                        "fill",
+                        status,
+                        {
+                            "broker_order_id": broker_order_id,
+                            "filled_qty": order_payload.get("filled_qty"),
+                            "filled_at": order_payload.get("filled_at"),
+                        },
+                        occurred_at,
+                    )
+                normalized.append(
+                    BrokerWebhookEvent(
+                        event_id=event_id,
+                        event_type=event_type,
+                        kind="order",
+                        broker_order_id=broker_order_id,
+                        symbol=symbol,
+                        payload=order_payload,
+                        fill_id=fill_id,
+                        occurred_at=occurred_at,
+                    )
+                )
+            if account_payload is not None:
+                normalized.append(
+                    BrokerWebhookEvent(
+                        event_id=self._stable_external_event_id(
+                            "account", event_type, account_payload, occurred_at
+                        ),
+                        event_type=event_type,
+                        kind="account",
+                        payload=account_payload,
+                        occurred_at=occurred_at,
+                        account_payload=account_payload,
+                    )
+                )
+        return normalized
+
+    def _stable_external_event_id(
+        self, kind: str, event_type: str, payload: dict, occurred_at: datetime | None
+    ) -> str:
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(
+            f"{kind}|{event_type}|{occurred_at.isoformat() if occurred_at else ''}|{canonical}".encode()
+        ).hexdigest()[:24]
+        return f"external-{kind}-{digest}"
+
+    @staticmethod
+    def _safe_float(value: object) -> float | None:
+        try:
+            return None if value is None else float(value)
+        except (TypeError, ValueError):
+            return None
 
     def _next_order_id(self, db: Session) -> str:
         persisted_max = 0
@@ -866,48 +2843,209 @@ class CockpitService:
         next_seq = max(persisted_max, pending_max) + 1
         return f"ORD-{next_seq:04d}"
 
-    def _order_view(self, row: OrderEntity) -> OrderView:
+    def _order_view(
+        self,
+        db: Session,
+        row: OrderEntity,
+        broker_payload: dict | None = None,
+        position_side: str = "buy",
+    ) -> OrderView:
+        intent = (
+            db.scalar(select(OrderIntentEntity).where(OrderIntentEntity.intent_id == row.intent_id))
+            if row.intent_id
+            else None
+        )
+        fills = self._order_fills(db, row.broker_order_id)
+        filled_qty = (
+            self._broker_filled_qty(broker_payload)
+            if broker_payload
+            else (row.filled_qty if row.filled_qty else (row.orig_qty if row.filled_at else 0))
+        )
+        remaining_qty = self._broker_remaining_qty(
+            broker_payload, row.qty, row.orig_qty, filled_qty
+        )
+        side = self._broker_side(broker_payload) or self._local_order_side(row, position_side)
+        status = (
+            str(broker_payload.get("status", row.status)).upper() if broker_payload else row.status
+        )
+        price = self._broker_price(broker_payload, row.price) if broker_payload else row.price
         return OrderView(
             id=row.order_id,
+            symbol=row.symbol,
+            side=side,
             type=row.type,
             qty=row.qty,
             origQty=row.orig_qty,
-            price=row.price,
-            status=row.status,
+            filledQty=filled_qty,
+            remainingQty=remaining_qty,
+            price=price,
+            status=status,
             tranche=row.tranche_label,
             coveredTranches=list(row.covered_tranches or []),
             parentId=row.parent_id,
             brokerOrderId=row.broker_order_id,
+            cancelable=(
+                self._broker_order_cancelable(broker_payload)
+                if broker_payload
+                else row.status in {"ACTIVE", "MODIFIED", "PENDING"}
+            ),
             createdAt=row.created_at,
+            updatedAt=(
+                self._broker_timestamp(broker_payload, "updated_at")
+                if broker_payload
+                else row.filled_at or row.created_at
+            ),
             filledAt=row.filled_at,
-            fillPrice=row.fill_price,
+            fillPrice=(
+                self._broker_fill_price(broker_payload, row.fill_price)
+                if broker_payload
+                else row.fill_price
+            ),
+            intentId=row.intent_id,
+            intentStatus=intent.status if intent is not None else None,
+            brokerStatus=(
+                str(broker_payload.get("status") or status).upper()
+                if broker_payload
+                else row.status
+            ),
+            reconcileStatus=(
+                "synchronized" if fills or row.status in {"FILLED", "CANCELED"} else "pending"
+            ),
+            fills=fills,
+        )
+
+    def _broker_order_view(self, broker_payload: dict) -> OrderView:
+        order_id = str(
+            broker_payload.get("client_order_id") or broker_payload.get("id") or "BROKER"
+        )
+        qty = self._broker_qty(broker_payload)
+        filled_qty = self._broker_filled_qty(broker_payload)
+        remaining_qty = max(0, qty - filled_qty)
+        return OrderView(
+            id=order_id,
+            symbol=str(broker_payload.get("symbol") or ""),
+            side=self._broker_side(broker_payload),
+            type=str(broker_payload.get("type") or "").upper(),
+            qty=qty,
+            origQty=qty,
+            filledQty=filled_qty,
+            remainingQty=remaining_qty,
+            price=self._broker_price(broker_payload, 0.0),
+            status=str(broker_payload.get("status") or "").upper(),
+            tranche="BROKER",
+            coveredTranches=[],
+            parentId=None,
+            brokerOrderId=str(broker_payload.get("id") or ""),
+            cancelable=self._broker_order_cancelable(broker_payload),
+            createdAt=self._broker_timestamp(broker_payload, "created_at"),
+            updatedAt=self._broker_timestamp(broker_payload, "updated_at"),
+            filledAt=self._broker_timestamp(broker_payload, "filled_at"),
+            fillPrice=self._broker_fill_price(broker_payload, None),
+            brokerStatus=str(broker_payload.get("status") or "").upper(),
+            reconcileStatus="external_only",
+            fills=[],
         )
 
     def _position_view(self, db: Session, row: PositionEntity) -> PositionView:
-        orders = self.get_orders(db, row.symbol)
-        committed_stop_labels = {
-            order.tranche
-            for order in orders
-            if order.type == "STOP" and order.tranche.startswith("S")
-        }
-        return PositionView(
-            symbol=row.symbol,
-            phase=row.phase,
-            livePrice=row.live_price,
-            setup=row.setup_snapshot,
-            tranches=[Tranche.model_validate(item) for item in row.tranches],
-            orders=orders,
-            trancheModes=[TrancheMode.model_validate(item) for item in row.tranche_modes],
-            stopModes=[StopMode.model_validate(item) for item in row.stop_modes],
-            rootOrderId=row.root_order_id,
-            stopMode=len(committed_stop_labels),
-            trancheCount=row.tranche_count,
-        )
+        projection = self._projection_for_symbol(db, row.symbol)
+        if projection is not None and isinstance(projection.payload, dict) and projection.payload:
+            return PositionView.model_validate(projection.payload)
+        return self._position_view_from_state(db, row)
 
     def _log(self, db: Session, symbol: str | None, tag: str, message: str) -> None:
         db.add(TradeLogEntity(symbol=symbol, tag=tag, message=message, created_at=utcnow()))
 
     def _pnl(self, position: PositionView) -> float:
         entry = float(position.setup.get("entry", 0.0))
-        active_shares = sum(tranche.qty for tranche in position.tranches if tranche.status == "active")
-        return round((position.livePrice - entry) * active_shares, 2)
+        active_shares = sum(
+            tranche.qty for tranche in position.tranches if tranche.status == "active"
+        )
+        direction = 1 if position.side == "buy" else -1
+        return round((position.livePrice - entry) * active_shares * direction, 2)
+
+    def _broker_timestamp(self, payload: dict | None, key: str) -> datetime | None:
+        if not payload:
+            return None
+        raw = payload.get(key)
+        if not raw:
+            return None
+        try:
+            parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+    def _broker_qty(self, payload: dict | None) -> int:
+        if not payload:
+            return 0
+        try:
+            return int(float(payload.get("qty") or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def _broker_filled_qty(self, payload: dict | None) -> int:
+        if not payload:
+            return 0
+        try:
+            return int(float(payload.get("filled_qty") or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def _broker_remaining_qty(
+        self, payload: dict | None, qty: int, orig_qty: int, filled_qty: int
+    ) -> int:
+        if payload:
+            try:
+                return max(0, int(float(payload.get("qty") or qty)) - filled_qty)
+            except (TypeError, ValueError):
+                return max(0, qty - filled_qty)
+        return 0 if filled_qty >= orig_qty else qty
+
+    def _broker_price(self, payload: dict | None, fallback: float) -> float:
+        if not payload:
+            return fallback
+        for key in ("limit_price", "stop_price", "trail_price", "notional"):
+            value = payload.get(key)
+            if value not in (None, ""):
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    continue
+        return fallback
+
+    def _broker_fill_price(self, payload: dict | None, fallback: float | None) -> float | None:
+        if not payload:
+            return fallback
+        for key in ("filled_avg_price", "limit_price", "stop_price"):
+            value = payload.get(key)
+            if value not in (None, ""):
+                try:
+                    return float(value)
+                except (TypeError, ValueError):
+                    continue
+        return fallback
+
+    def _broker_side(self, payload: dict | None) -> str | None:
+        if not payload:
+            return None
+        side = payload.get("side")
+        return str(side).upper() if side else None
+
+    def _local_order_side(self, row: OrderEntity, position_side: str) -> str:
+        if row.parent_id is None:
+            return position_side.upper()
+        return self._exit_side(position_side).upper()
+
+    def _broker_order_cancelable(self, payload: dict | None) -> bool:
+        if not payload:
+            return False
+        status = str(payload.get("status") or "").lower()
+        return status in {
+            "new",
+            "accepted",
+            "pending_new",
+            "partially_filled",
+            "accepted_for_bidding",
+            "stopped",
+            "calculated",
+        }

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -24,7 +24,7 @@ from app.adapters.market_data import SetupMarketData  # noqa: E402
 from app.db.base import Base  # noqa: E402
 from app.db.session import SessionLocal, engine  # noqa: E402
 from app.main import app, service  # noqa: E402
-from app.models.entities import OrderEntity, PositionEntity, TradeLogEntity  # noqa: E402
+from app.models.entities import AccountSettingsEntity, OrderEntity, PositionEntity, TradeLogEntity  # noqa: E402
 from app.services.auth import get_auth_store  # noqa: E402
 from app.core.config import Settings, _normalize_database_url  # noqa: E402
 from app.api import deps_auth  # noqa: E402
@@ -83,8 +83,13 @@ def test_setup_endpoint_returns_contract() -> None:
     assert isinstance(data["quoteIsReal"], bool)
     assert isinstance(data["technicalsAreFallback"], bool)
     assert data["entryBasis"] == "bid_ask_midpoint"
-    assert data["entry"] > data["finalStop"]
-    assert data["shares"] > 0
+    assert data["stopReferenceDefault"] in {"lod", "atr", "manual"}
+    assert isinstance(data["lodIsValid"], bool)
+    assert isinstance(data["atrIsValid"], bool)
+    assert "equitySource" in data
+    if data["stopReferenceDefault"] != "manual":
+        assert data["entry"] > data["finalStop"]
+        assert data["shares"] >= 0
 
 
 def test_postgres_urls_normalize_to_psycopg_driver() -> None:
@@ -137,6 +142,104 @@ def test_setup_fails_loudly_when_real_quote_is_unavailable() -> None:
     finally:
         service.settings.allow_controller_mock = original_allow_mock
         service.market_data.get_setup_data = original_get_setup_data
+
+
+def test_build_setup_defaults_to_manual_when_real_lod_is_invalid() -> None:
+    market = SetupMarketData(
+        symbol="AAPL",
+        provider="alpaca_market",
+        provider_state="real_quote_range_atr_fallback_technicals",
+        quote_provider="alpaca",
+        technicals_provider="mock",
+        quote_is_real=True,
+        technicals_are_fallback=True,
+        fallback_reason="partial_technicals_fallback_only",
+        quote_timestamp=None,
+        session_state="after_hours",
+        quote_state="cached_quote",
+        entry_basis="bid_ask_midpoint",
+        bid=101.00,
+        ask=101.20,
+        last=101.10,
+        lod=101.50,
+        hod=103.00,
+        prev_close=100.00,
+        atr14=2.25,
+        sma10=100.0,
+        sma50=95.0,
+        sma200=90.0,
+        sma200_prev=89.5,
+        rvol=1.2,
+        days_to_cover=2.0,
+    )
+    setup = service._build_setup_response(market, 50000.0, 200000.0, 1.0, "alpaca_account")
+    assert setup.stopReferenceDefault == "manual"
+    assert setup.lodIsValid is False
+    assert setup.manualStopWarning
+    assert setup.shares == 0
+    assert setup.finalStop == 0.0
+
+
+def test_build_setup_uses_real_lod_when_valid() -> None:
+    market = SetupMarketData(
+        symbol="AAPL",
+        provider="alpaca_market",
+        provider_state="real_quote_range_atr_fallback_technicals",
+        quote_provider="alpaca",
+        technicals_provider="mock",
+        quote_is_real=True,
+        technicals_are_fallback=True,
+        fallback_reason="partial_technicals_fallback_only",
+        quote_timestamp=None,
+        session_state="regular_open",
+        quote_state="live_quote",
+        entry_basis="bid_ask_midpoint",
+        bid=101.00,
+        ask=101.20,
+        last=101.10,
+        lod=98.00,
+        hod=103.00,
+        prev_close=100.00,
+        atr14=2.25,
+        sma10=100.0,
+        sma50=95.0,
+        sma200=90.0,
+        sma200_prev=89.5,
+        rvol=1.2,
+        days_to_cover=2.0,
+    )
+    setup = service._build_setup_response(market, 50000.0, 200000.0, 1.0, "alpaca_account")
+    assert setup.stopReferenceDefault == "lod"
+    assert setup.lodIsValid is True
+    assert setup.finalStop == 98.0
+    assert setup.atrStop == round(setup.entry - market.atr14, 2)
+    assert setup.shares > 0
+
+
+def test_get_account_uses_broker_equity_for_alpaca_paper_mode() -> None:
+    original_broker = service.broker
+    original_mode = service.settings.broker_mode
+
+    class StubBroker:
+        def get_account_summary(self) -> dict[str, float]:
+            return {"equity": 76543.21, "buying_power": 123456.78, "cash": 10000.0}
+
+    service.broker = StubBroker()
+    service.settings.broker_mode = "alpaca_paper"
+    try:
+        with SessionLocal() as db:
+            service.ensure_seed_data(db)
+            settings_row = db.scalar(select(AccountSettingsEntity))
+            assert settings_row is not None
+            settings_row.mode = "alpaca_paper"
+            db.commit()
+            account = service.get_account(db)
+        assert account.equity == 76543.21
+        assert account.buying_power == 123456.78
+        assert account.equity_source == "alpaca_account"
+    finally:
+        service.broker = original_broker
+        service.settings.broker_mode = original_mode
 
 
 def test_login_creates_session_and_me_resolves_user() -> None:
@@ -485,6 +588,7 @@ def test_setup_uses_cached_quote_metadata_when_alpaca_quote_is_off_hours() -> No
             quote_timestamp=fallback.quote_timestamp,
             session_state="closed",
             quote_state="cached_quote",
+            entry_basis=fallback.entry_basis,
             bid=fallback.bid,
             ask=fallback.ask,
             last=fallback.last,

--- a/backend/app/tests/test_api.py
+++ b/backend/app/tests/test_api.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+# ruff: noqa: E402
+
 import os
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -24,10 +27,23 @@ from app.adapters.market_data import SetupMarketData  # noqa: E402
 from app.db.base import Base  # noqa: E402
 from app.db.session import SessionLocal, engine  # noqa: E402
 from app.main import app, service  # noqa: E402
-from app.models.entities import AccountSettingsEntity, OrderEntity, PositionEntity, TradeLogEntity  # noqa: E402
-from app.services.auth import get_auth_store  # noqa: E402
-from app.core.config import Settings, _normalize_database_url  # noqa: E402
+from app.models.entities import (
+    AccountSettingsEntity,
+    AccountSnapshotEntity,
+    BrokerFillEntity,
+    BrokerOrderEntity,
+    EventLogEntity,
+    OrderEntity,
+    OrderIntentEntity,
+    PositionEntity,
+    PositionProjectionEntity,
+    ReconcileRunEntity,
+    TradeLogEntity,
+)  # noqa: E402
+from app.schemas.cockpit import TrancheMode  # noqa: E402
 from app.api import deps_auth  # noqa: E402
+from app.core.config import Settings, _normalize_database_url  # noqa: E402
+from app.services.auth import get_auth_store  # noqa: E402
 
 Base.metadata.drop_all(bind=engine)
 Base.metadata.create_all(bind=engine)
@@ -35,9 +51,9 @@ client = TestClient(app)
 auth_store = get_auth_store(Settings.from_env())
 auth_store.bootstrap_users(
     admin_username="admin",
-    admin_password="admin123!",
+    admin_password="change-me-admin",
     trader_username="trader",
-    trader_password="trader123!",
+    trader_password="change-me-trader",
     seed_enabled=True,
 )
 
@@ -45,6 +61,13 @@ auth_store.bootstrap_users(
 @pytest.fixture(autouse=True)
 def reset_db() -> None:
     with SessionLocal() as db:
+        db.query(ReconcileRunEntity).delete()
+        db.query(AccountSnapshotEntity).delete()
+        db.query(PositionProjectionEntity).delete()
+        db.query(BrokerFillEntity).delete()
+        db.query(BrokerOrderEntity).delete()
+        db.query(OrderIntentEntity).delete()
+        db.query(EventLogEntity).delete()
         db.query(OrderEntity).delete()
         db.query(PositionEntity).delete()
         db.query(TradeLogEntity).delete()
@@ -52,9 +75,9 @@ def reset_db() -> None:
     auth_store.reset_for_tests()
     auth_store.bootstrap_users(
         admin_username="admin",
-        admin_password="admin123!",
+        admin_password="change-me-admin",
         trader_username="trader",
-        trader_password="trader123!",
+        trader_password="change-me-trader",
         seed_enabled=True,
     )
     yield
@@ -62,9 +85,30 @@ def reset_db() -> None:
 
 def tranche_modes() -> list[dict]:
     return [
-        {"mode": "limit", "trail": 2, "trailUnit": "$", "target": "1R", "manualPrice": None},
-        {"mode": "limit", "trail": 2, "trailUnit": "$", "target": "2R", "manualPrice": None},
-        {"mode": "runner", "trail": 2, "trailUnit": "$", "target": "3R", "manualPrice": None},
+        {
+            "mode": "limit",
+            "allocationPct": 33.33,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "1R",
+            "manualPrice": None,
+        },
+        {
+            "mode": "limit",
+            "allocationPct": 33.33,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "2R",
+            "manualPrice": None,
+        },
+        {
+            "mode": "runner",
+            "allocationPct": 33.34,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "3R",
+            "manualPrice": None,
+        },
     ]
 
 
@@ -80,6 +124,8 @@ def test_setup_endpoint_returns_contract() -> None:
     assert data["executionProvider"] == "paper"
     assert data["sessionState"]
     assert data["quoteState"]
+    assert data["reconcileStatus"] in {"synchronized", "pending", "stale"}
+    assert "lastReconciledAt" in data
     assert isinstance(data["quoteIsReal"], bool)
     assert isinstance(data["technicalsAreFallback"], bool)
     assert data["entryBasis"] == "bid_ask_midpoint"
@@ -104,7 +150,25 @@ def test_postgres_urls_normalize_to_psycopg_driver() -> None:
     assert _normalize_database_url("sqlite:///./data/test.db") == "sqlite:///./data/test.db"
 
 
-def test_local_personal_paper_ready_requires_real_alpaca_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_broker_mode_aliases_normalize_to_legacy_runtime_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BROKER_MODE", "sim_paper")
+    assert Settings.from_env().broker_mode == "paper"
+    assert Settings.from_env().normalized_broker_mode == "sim_paper"
+
+    monkeypatch.setenv("BROKER_MODE", "broker_paper")
+    assert Settings.from_env().broker_mode == "alpaca_paper"
+    assert Settings.from_env().normalized_broker_mode == "broker_paper"
+
+    monkeypatch.setenv("BROKER_MODE", "live")
+    assert Settings.from_env().broker_mode == "alpaca_live"
+    assert Settings.from_env().normalized_broker_mode == "live"
+
+
+def test_local_personal_paper_ready_requires_real_alpaca_creds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("BROKER_MODE", "alpaca_paper")
     monkeypatch.setenv("ALLOW_LIVE_TRADING", "false")
     monkeypatch.setenv("ALPACA_API_KEY_ID", "paper-key")
@@ -115,7 +179,9 @@ def test_local_personal_paper_ready_requires_real_alpaca_creds(monkeypatch: pyte
     assert Settings.from_env().local_personal_paper_ready is False
 
 
-def test_alpaca_market_order_fails_loudly_without_mock_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_alpaca_market_order_fails_loudly_without_mock_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("BROKER_MODE", "alpaca_paper")
     monkeypatch.setenv("ALLOW_CONTROLLER_MOCK", "false")
     monkeypatch.delenv("ALPACA_API_KEY_ID", raising=False)
@@ -172,7 +238,7 @@ def test_build_setup_defaults_to_manual_when_real_lod_is_invalid() -> None:
         rvol=1.2,
         days_to_cover=2.0,
     )
-    setup = service._build_setup_response(market, 50000.0, 200000.0, 1.0, "alpaca_account")
+    setup = service._build_setup_response(market, 50000.0, 200000.0, 1.0, "alpaca_account", 15000.0)
     assert setup.stopReferenceDefault == "manual"
     assert setup.lodIsValid is False
     assert setup.manualStopWarning
@@ -208,12 +274,79 @@ def test_build_setup_uses_real_lod_when_valid() -> None:
         rvol=1.2,
         days_to_cover=2.0,
     )
-    setup = service._build_setup_response(market, 50000.0, 200000.0, 1.0, "alpaca_account")
+    setup = service._build_setup_response(market, 50000.0, 200000.0, 1.0, "alpaca_account", 15000.0)
     assert setup.stopReferenceDefault == "lod"
     assert setup.lodIsValid is True
     assert setup.finalStop == 98.0
     assert setup.atrStop == round(setup.entry - market.atr14, 2)
     assert setup.shares > 0
+
+
+def test_refresh_live_mark_freezes_stale_quote_without_mutation() -> None:
+    original_get_setup_data = service.market_data.get_setup_data
+    with SessionLocal() as db:
+        setup = service.get_setup(db, "AAPL")
+        position = PositionEntity(
+            symbol="AAPL",
+            phase="trade_entered",
+            entry_price=setup.entry,
+            live_price=setup.last,
+            shares=10,
+            stop_ref="lod",
+            stop_price=setup.finalStop,
+            tranche_count=3,
+            tranche_modes=tranche_modes(),
+            stop_modes=[{"mode": "stop", "pct": None} for _ in range(3)],
+            tranches=[],
+            setup_snapshot={
+                **setup.model_dump(mode="json"),
+                "entryOrder": {"side": "buy"},
+            },
+            root_order_id="ORD-FROZEN-1",
+        )
+        db.add(position)
+        db.commit()
+        db.refresh(position)
+        original_live_price = position.live_price
+
+        def stale_market(_symbol: str):
+            return SetupMarketData(
+                symbol="AAPL",
+                provider="alpaca_market",
+                provider_state="cached_quote",
+                quote_provider="alpaca",
+                technicals_provider="alpaca",
+                quote_is_real=True,
+                technicals_are_fallback=False,
+                fallback_reason=None,
+                quote_timestamp=None,
+                session_state="after_hours",
+                quote_state="cached_quote",
+                entry_basis="bid_ask_midpoint",
+                bid=setup.bid,
+                ask=setup.ask,
+                last=setup.last + 5,
+                lod=setup.lod,
+                hod=setup.hod,
+                prev_close=setup.prev_close,
+                atr14=setup.atr14,
+                sma10=setup.sma10,
+                sma50=setup.sma50,
+                sma200=setup.sma200,
+                sma200_prev=setup.sma200_prev,
+                rvol=setup.rvol,
+                days_to_cover=setup.days_to_cover,
+            )
+
+        service.market_data.get_setup_data = stale_market
+        try:
+            service._refresh_live_mark(position)
+        finally:
+            service.market_data.get_setup_data = original_get_setup_data
+
+        assert position.live_price == original_live_price
+        assert position.setup_snapshot["markState"] == "frozen"
+        assert "frozen" in str(position.setup_snapshot["markLabel"]).lower()
 
 
 def test_get_account_uses_broker_equity_for_alpaca_paper_mode() -> None:
@@ -236,14 +369,50 @@ def test_get_account_uses_broker_equity_for_alpaca_paper_mode() -> None:
             account = service.get_account(db)
         assert account.equity == 76543.21
         assert account.buying_power == 123456.78
+        assert account.cash == 10000.0
         assert account.equity_source == "alpaca_account"
     finally:
         service.broker = original_broker
         service.settings.broker_mode = original_mode
 
 
+def test_split_shares_uses_allocation_percentages() -> None:
+    allocations = [
+        {
+            "mode": "limit",
+            "allocationPct": 50.0,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "1R",
+            "manualPrice": None,
+        },
+        {
+            "mode": "limit",
+            "allocationPct": 30.0,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "2R",
+            "manualPrice": None,
+        },
+        {
+            "mode": "runner",
+            "allocationPct": 20.0,
+            "trail": 2,
+            "trailUnit": "$",
+            "target": "3R",
+            "manualPrice": None,
+        },
+    ]
+    result = service._split_shares(
+        101, 3, [TrancheMode.model_validate(item) for item in allocations]
+    )
+    assert result == [51, 30, 20]
+
+
 def test_login_creates_session_and_me_resolves_user() -> None:
-    login = client.post("/api/auth/login", json={"username": "admin", "password": "admin123!"})
+    login = client.post(
+        "/api/auth/login", json={"username": "admin", "password": "change-me-admin"}
+    )
     assert login.status_code == 200
     payload = login.json()
     assert payload["username"] == "admin"
@@ -270,7 +439,9 @@ def test_staging_cookie_settings_can_support_hosted_preview() -> None:
     routes_auth_module.settings.auth_cookie_samesite = "none"
     routes_auth_module.settings.auth_cookie_secure = True
     try:
-        login = client.post("/api/auth/login", json={"username": "admin", "password": "admin123!"})
+        login = client.post(
+            "/api/auth/login", json={"username": "admin", "password": "change-me-admin"}
+        )
         assert login.status_code == 200
         cookie_header = login.headers.get("set-cookie", "").lower()
         assert "samesite=none" in cookie_header
@@ -288,7 +459,9 @@ def test_sensitive_routes_require_session_when_auth_is_enabled() -> None:
         unauthenticated = client.get("/api/account")
         assert unauthenticated.status_code == 401
 
-        login = client.post("/api/auth/login", json={"username": "admin", "password": "admin123!"})
+        login = client.post(
+            "/api/auth/login", json={"username": "admin", "password": "change-me-admin"}
+        )
         assert login.status_code == 200
 
         authenticated = client.get("/api/account")
@@ -351,15 +524,250 @@ def test_trade_lifecycle() -> None:
     assert stops.status_code == 200
     assert stops.json()["phase"] == "protected"
 
-    profit = client.post("/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()})
+    profit = client.post(
+        "/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()}
+    )
     assert profit.status_code == 200
     profit_state = profit.json()
     assert profit_state["phase"] in {"P2_done", "runner_only", "closed"}
     assert len(profit_state["orders"]) >= 4
     assert all(
-        order["id"] == profit_state["rootOrderId"] or order.get("parentId") == profit_state["rootOrderId"]
+        order["id"] == profit_state["rootOrderId"]
+        or order.get("parentId") == profit_state["rootOrderId"]
         for order in profit_state["orders"]
     )
+
+
+def test_broker_webhook_reconciles_pending_exit_order() -> None:
+    with SessionLocal() as db:
+        position = PositionEntity(
+            symbol="AAPL",
+            phase="protected",
+            entry_price=100.0,
+            live_price=104.0,
+            shares=10,
+            stop_ref="lod",
+            stop_price=98.0,
+            tranche_count=1,
+            tranche_modes=tranche_modes()[:1],
+            stop_modes=[{"mode": "stop", "pct": 100.0}],
+            tranches=[
+                {
+                    "id": "T1",
+                    "qty": 10,
+                    "stop": 98.0,
+                    "status": "pending_exit",
+                    "filledQty": 0,
+                    "remainingQty": 10,
+                    "mode": "limit",
+                    "trail": 2,
+                    "trailUnit": "$",
+                    "label": "Tranche 1",
+                }
+            ],
+            setup_snapshot={
+                "symbol": "AAPL",
+                "entry": 100.0,
+                "finalStop": 98.0,
+                "last": 104.0,
+            },
+            root_order_id="ORD-ROOT-1",
+            last_intent_id="intent-root-1",
+            projection_version=1,
+            reconcile_status="pending",
+        )
+        db.add(position)
+        db.add(
+            OrderEntity(
+                order_id="ORD-ROOT-1",
+                broker_order_id="broker-root-1",
+                symbol="AAPL",
+                type="LMT",
+                qty=10,
+                orig_qty=10,
+                price=100.0,
+                status="FILLED",
+                tranche_label="ROOT",
+                covered_tranches=[],
+                created_at=service._broker_timestamp(
+                    {"created_at": "2026-03-28T09:20:00Z"}, "created_at"
+                ),
+                filled_at=service._broker_timestamp(
+                    {"filled_at": "2026-03-28T09:20:01Z"}, "filled_at"
+                ),
+                fill_price=100.0,
+                filled_qty=10,
+            )
+        )
+        db.add(
+            OrderEntity(
+                order_id="ORD-EXIT-1",
+                broker_order_id="broker-exit-1",
+                symbol="AAPL",
+                type="LMT",
+                qty=10,
+                orig_qty=10,
+                price=105.0,
+                status="ACTIVE",
+                intent_id="intent-exit-1",
+                tranche_label="T1",
+                covered_tranches=["T1"],
+                parent_id="ORD-ROOT-1",
+                created_at=service._broker_timestamp(
+                    {"created_at": "2026-03-28T09:25:00Z"}, "created_at"
+                ),
+                filled_qty=0,
+            )
+        )
+        db.commit()
+
+    webhook = client.post(
+        "/api/broker/webhook",
+        json={
+            "type": "trade_update",
+            "order": {
+                "id": "broker-exit-1",
+                "symbol": "AAPL",
+                "status": "filled",
+                "qty": "10",
+                "filled_qty": "10",
+                "filled_avg_price": "105.00",
+                "filled_at": "2026-03-28T09:30:00Z",
+                "side": "sell",
+                "type": "limit",
+            },
+        },
+    )
+    assert webhook.status_code == 200
+    body = webhook.json()
+    assert body["processedOrders"] == 1
+    assert body["symbols"] == ["AAPL"]
+
+    replay = client.post(
+        "/api/broker/webhook",
+        json={
+            "type": "trade_update",
+            "order": {
+                "id": "broker-exit-1",
+                "symbol": "AAPL",
+                "status": "filled",
+                "qty": "10",
+                "filled_qty": "10",
+                "filled_avg_price": "105.00",
+                "filled_at": "2026-03-28T09:30:00Z",
+                "side": "sell",
+                "type": "limit",
+            },
+        },
+    )
+    assert replay.status_code == 200
+    assert replay.json()["processedOrders"] == 0
+
+    position = client.get("/api/positions/AAPL")
+    assert position.status_code == 200
+    position_body = position.json()
+    assert position_body["phase"] == "closed"
+    assert position_body["reconcileStatus"] == "synchronized"
+    assert position_body["tranches"][0]["status"] == "sold"
+    with SessionLocal() as db:
+        fills = db.scalars(select(BrokerFillEntity)).all()
+    assert len(fills) == 1
+
+
+def test_get_position_prefers_projection_payload() -> None:
+    with SessionLocal() as db:
+        position = PositionEntity(
+            symbol="MSFT",
+            phase="protected",
+            entry_price=100.0,
+            live_price=102.0,
+            shares=5,
+            stop_ref="lod",
+            stop_price=98.0,
+            tranche_count=1,
+            tranche_modes=tranche_modes()[:1],
+            stop_modes=[{"mode": "stop", "pct": 100.0}],
+            tranches=[
+                {
+                    "id": "T1",
+                    "qty": 5,
+                    "stop": 98.0,
+                    "status": "active",
+                    "filledQty": 0,
+                    "remainingQty": 5,
+                    "mode": "limit",
+                    "trail": 2,
+                    "trailUnit": "$",
+                    "label": "Tranche 1",
+                }
+            ],
+            setup_snapshot={
+                "symbol": "MSFT",
+                "entry": 100.0,
+                "finalStop": 98.0,
+                "last": 102.0,
+                "entryOrder": {"side": "buy"},
+            },
+            root_order_id="ORD-MSFT-1",
+            last_intent_id="intent-msft-1",
+            projection_version=3,
+            reconcile_status="synchronized",
+        )
+        db.add(position)
+        db.flush()
+        service._sync_projection(db, position)
+        db.flush()
+        position.phase = "closing"
+        position.reconcile_status = "pending"
+        db.flush()
+        projected = service.get_position(db, "MSFT")
+
+    assert projected.phase == "protected"
+    assert projected.reconcileStatus == "synchronized"
+
+
+def test_preview_trade_uses_live_midpoint_for_sell_side() -> None:
+    setup = client.get("/api/setup/AAPL").json()
+    preview = client.post(
+        "/api/trade/preview",
+        json={
+            "symbol": "AAPL",
+            "entry": 0,
+            "stopRef": "lod",
+            "stopPrice": setup["hodStop"],
+            "riskPct": setup["riskPct"],
+            "order": {"side": "sell"},
+        },
+    )
+    assert preview.status_code == 200
+    payload = preview.json()
+    assert payload["entry"] == setup["entry"]
+    assert payload["finalStop"] == setup["hodStop"]
+    assert payload["shares"] >= 0
+
+
+def test_enter_trade_preserves_sell_side() -> None:
+    client.put(
+        "/api/account/settings",
+        json={"equity": 1000000, "risk_pct": 0.2, "mode": "paper"},
+    )
+    setup = client.get("/api/setup/AAPL").json()
+    enter = client.post(
+        "/api/trade/enter",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "lod",
+            "stopPrice": setup["hodStop"],
+            "trancheCount": 3,
+            "trancheModes": tranche_modes(),
+            "order": {"side": "sell"},
+        },
+    )
+    assert enter.status_code == 200
+    position = enter.json()
+    assert position["side"] == "sell"
+    assert position["setup"]["entryOrder"]["side"] == "sell"
 
 
 def test_three_stop_mode_defaults_to_33_33_34_when_pct_is_blank() -> None:
@@ -408,7 +816,10 @@ def test_three_stop_mode_defaults_to_33_33_34_when_pct_is_blank() -> None:
 
 
 def test_account_update() -> None:
-    update = client.put("/api/account/settings", json={"equity": 30000, "risk_pct": 1.5, "mode": "paper"})
+    update = client.put(
+        "/api/account/settings",
+        json={"equity": 30000, "risk_pct": 1.5, "mode": "paper"},
+    )
     assert update.status_code == 200
     data = update.json()
     assert data["equity"] == 30000
@@ -418,7 +829,10 @@ def test_account_update() -> None:
 
 
 def test_live_mode_is_gated_by_default() -> None:
-    update = client.put("/api/account/settings", json={"equity": 30000, "risk_pct": 1.5, "mode": "alpaca_live"})
+    update = client.put(
+        "/api/account/settings",
+        json={"equity": 30000, "risk_pct": 1.5, "mode": "alpaca_live"},
+    )
     assert update.status_code == 400
     assert "Live trading is disabled" in update.text
 
@@ -468,11 +882,15 @@ def test_runner_cannot_be_reexecuted_once_active() -> None:
             ],
         },
     )
-    first_profit = client.post("/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()})
+    first_profit = client.post(
+        "/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()}
+    )
     assert first_profit.status_code == 200
-    second_profit = client.post("/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()})
+    second_profit = client.post(
+        "/api/trade/profit", json={"symbol": "AAPL", "trancheModes": tranche_modes()}
+    )
     assert second_profit.status_code == 400
-    assert "Active TRAIL order already exists" in second_profit.text
+    assert "Another trade intent is already pending for this symbol." in second_profit.text
 
 
 def test_enter_trade_recovers_stale_active_orders_for_closed_symbol() -> None:
@@ -542,7 +960,11 @@ def test_off_hours_queue_for_open_creates_pending_entry() -> None:
     def fake_setup(_db, _symbol: str):
         setup = original_get_setup(_db, "AAPL")
         return setup.model_copy(
-            update={"sessionState": "closed", "quoteState": "cached_quote", "executionProvider": "alpaca_paper"}
+            update={
+                "sessionState": "closed",
+                "quoteState": "cached_quote",
+                "executionProvider": "alpaca_paper",
+            }
         )
 
     service.get_setup = fake_setup
@@ -569,6 +991,76 @@ def test_off_hours_queue_for_open_creates_pending_entry() -> None:
         assert flatten.json()["phase"] == "closed"
     finally:
         service.get_setup = original_get_setup
+
+
+def test_stop_fill_reconciles_realized_loss_for_only_hit_tranche() -> None:
+    client.put(
+        "/api/account/settings",
+        json={"equity": 1000000, "risk_pct": 0.2, "mode": "paper"},
+    )
+    setup = client.get("/api/setup/AAPL").json()
+    enter = client.post(
+        "/api/trade/enter",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "lod",
+            "stopPrice": setup["finalStop"],
+            "trancheCount": 3,
+            "trancheModes": tranche_modes(),
+        },
+    )
+    assert enter.status_code == 200
+
+    stops = client.post(
+        "/api/trade/stops",
+        json={
+            "symbol": "AAPL",
+            "stopMode": 3,
+            "stopModes": [
+                {"mode": "stop", "pct": 33.0},
+                {"mode": "stop", "pct": 66.0},
+                {"mode": "stop", "pct": 100.0},
+            ],
+        },
+    )
+    assert stops.status_code == 200
+    protected = stops.json()
+    s1 = next(
+        order
+        for order in protected["orders"]
+        if order["type"] == "STOP" and order["tranche"] == "S1"
+    )
+    s2 = next(
+        order
+        for order in protected["orders"]
+        if order["type"] == "STOP" and order["tranche"] == "S2"
+    )
+    assert s1["price"] > s2["price"]
+
+    with SessionLocal() as db:
+        position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == "AAPL"))
+        assert position is not None
+        position.live_price = round((s1["price"] + s2["price"]) / 2, 2)
+        db.commit()
+
+    reconciled = client.get("/api/positions/AAPL")
+    assert reconciled.status_code == 200
+    payload = reconciled.json()
+    sold = [tranche for tranche in payload["tranches"] if tranche["status"] == "sold"]
+    active = [tranche for tranche in payload["tranches"] if tranche["status"] == "active"]
+    assert len(sold) == 1
+    assert len(active) == 2
+    assert sold[0]["exitOrderType"] == "STOP"
+    assert sold[0]["exitPrice"] == s1["price"]
+    assert sold[0]["exitFilledAt"] is not None
+    filled_stop_orders = [
+        order
+        for order in payload["orders"]
+        if order["type"] == "STOP" and order["status"] == "FILLED"
+    ]
+    assert len(filled_stop_orders) == 1
+    assert filled_stop_orders[0]["tranche"] == "S1"
 
 
 def test_setup_uses_cached_quote_metadata_when_alpaca_quote_is_off_hours() -> None:
@@ -614,3 +1106,426 @@ def test_setup_uses_cached_quote_metadata_when_alpaca_quote_is_off_hours() -> No
         assert data["quoteState"] == "cached_quote"
     finally:
         service.market_data.get_setup_data = original_market_data
+
+
+def test_recent_orders_merge_broker_state_and_cancel() -> None:
+    with SessionLocal() as db:
+        db.add(
+            OrderEntity(
+                order_id="ORD-9001",
+                broker_order_id="broker-1",
+                symbol="AAPL",
+                type="LMT",
+                qty=10,
+                orig_qty=10,
+                price=101.25,
+                status="PENDING",
+                tranche_label="AAPL",
+                covered_tranches=[],
+                parent_id=None,
+            )
+        )
+        db.commit()
+
+    canceled: list[str] = []
+    original_list_recent_orders = service.broker.list_recent_orders
+    original_get_order = service.broker.get_order
+    original_cancel_order = service.broker.cancel_order
+
+    def fake_list_recent_orders(limit: int = 50):
+        return [
+            {
+                "id": "broker-1",
+                "client_order_id": "client-1",
+                "symbol": "AAPL",
+                "side": "buy",
+                "type": "limit",
+                "qty": "10",
+                "filled_qty": "0",
+                "limit_price": "101.25",
+                "status": "accepted",
+                "created_at": "2026-03-22T10:00:00Z",
+                "updated_at": "2026-03-22T10:00:05Z",
+            },
+            {
+                "id": "broker-2",
+                "client_order_id": "client-2",
+                "symbol": "MSFT",
+                "side": "sell",
+                "type": "market",
+                "qty": "5",
+                "filled_qty": "5",
+                "filled_avg_price": "380.10",
+                "status": "filled",
+                "created_at": "2026-03-22T09:59:00Z",
+                "updated_at": "2026-03-22T09:59:10Z",
+                "filled_at": "2026-03-22T09:59:10Z",
+            },
+        ][:limit]
+
+    def fake_get_order(broker_order_id: str):
+        if broker_order_id == "broker-1" and "broker-1" not in canceled:
+            return {
+                "id": "broker-1",
+                "client_order_id": "client-1",
+                "symbol": "AAPL",
+                "side": "buy",
+                "type": "limit",
+                "qty": "10",
+                "filled_qty": "0",
+                "limit_price": "101.25",
+                "status": "accepted",
+                "created_at": "2026-03-22T10:00:00Z",
+                "updated_at": "2026-03-22T10:00:05Z",
+            }
+        if broker_order_id == "broker-1":
+            return {
+                "id": "broker-1",
+                "client_order_id": "client-1",
+                "symbol": "AAPL",
+                "side": "buy",
+                "type": "limit",
+                "qty": "10",
+                "filled_qty": "0",
+                "limit_price": "101.25",
+                "status": "canceled",
+                "created_at": "2026-03-22T10:00:00Z",
+                "updated_at": "2026-03-22T10:01:00Z",
+            }
+        return None
+
+    def fake_cancel_order(broker_order_id: str):
+        canceled.append(broker_order_id)
+
+    service.broker.list_recent_orders = fake_list_recent_orders
+    service.broker.get_order = fake_get_order
+    service.broker.cancel_order = fake_cancel_order
+    try:
+        response = client.get("/api/orders")
+        assert response.status_code == 200
+        orders = response.json()
+        assert orders[0]["brokerOrderId"] == "broker-1"
+        assert orders[0]["cancelable"] is True
+        assert orders[0]["symbol"] == "AAPL"
+        assert any(order["brokerOrderId"] == "broker-2" for order in orders)
+
+        cancel_response = client.delete("/api/orders/broker-1")
+        assert cancel_response.status_code == 200
+        canceled_view = cancel_response.json()
+        assert canceled_view["status"] == "CANCELED"
+        assert canceled == ["broker-1"]
+
+        with SessionLocal() as db:
+            local = db.scalar(select(OrderEntity).where(OrderEntity.order_id == "ORD-9001"))
+            assert local is not None
+            assert local.status == "CANCELED"
+    finally:
+        service.broker.list_recent_orders = original_list_recent_orders
+        service.broker.get_order = original_get_order
+        service.broker.cancel_order = original_cancel_order
+
+
+def test_cancel_recent_root_order_closes_pending_position() -> None:
+    with SessionLocal() as db:
+        db.add(
+            PositionEntity(
+                symbol="AMD",
+                phase="entry_pending",
+                entry_price=201.22,
+                live_price=201.22,
+                shares=10,
+                stop_ref="lod",
+                stop_price=198.33,
+                tranche_count=3,
+                tranche_modes=tranche_modes(),
+                stop_modes=[{"mode": "stop", "pct": None} for _ in range(3)],
+                tranches=[
+                    {
+                        "id": "T1",
+                        "qty": 3,
+                        "stop": 198.33,
+                        "label": "T1",
+                        "status": "active",
+                        "mode": "limit",
+                        "trail": 2.0,
+                        "trailUnit": "$",
+                        "runnerStop": None,
+                    },
+                    {
+                        "id": "T2",
+                        "qty": 3,
+                        "stop": 198.33,
+                        "label": "T2",
+                        "status": "active",
+                        "mode": "limit",
+                        "trail": 2.0,
+                        "trailUnit": "$",
+                        "runnerStop": None,
+                    },
+                    {
+                        "id": "T3",
+                        "qty": 4,
+                        "stop": 198.33,
+                        "label": "T3",
+                        "status": "active",
+                        "mode": "limit",
+                        "trail": 2.0,
+                        "trailUnit": "$",
+                        "runnerStop": None,
+                    },
+                ],
+                setup_snapshot=service.get_setup(db, "AAPL").model_dump(mode="json"),
+                root_order_id="ORD-9010",
+            )
+        )
+        db.add(
+            OrderEntity(
+                order_id="ORD-9010",
+                broker_order_id="broker-root",
+                symbol="AMD",
+                type="MKT",
+                qty=10,
+                orig_qty=10,
+                price=201.22,
+                status="PENDING",
+                tranche_label="AMD",
+                covered_tranches=[],
+                parent_id=None,
+            )
+        )
+        db.commit()
+
+    original_get_order = service.broker.get_order
+    original_cancel_order = service.broker.cancel_order
+
+    def fake_get_order(broker_order_id: str):
+        if broker_order_id == "broker-root":
+            return {
+                "id": "broker-root",
+                "client_order_id": "client-root",
+                "symbol": "AMD",
+                "side": "buy",
+                "type": "market",
+                "qty": "10",
+                "filled_qty": "0",
+                "status": "accepted",
+                "created_at": "2026-03-22T10:00:00Z",
+                "updated_at": "2026-03-22T10:00:05Z",
+            }
+        return None
+
+    canceled: list[str] = []
+
+    def fake_cancel_order(broker_order_id: str):
+        canceled.append(broker_order_id)
+
+    service.broker.get_order = fake_get_order
+    service.broker.cancel_order = fake_cancel_order
+    try:
+        response = client.delete("/api/orders/broker-root")
+        assert response.status_code == 200
+        assert canceled == ["broker-root"]
+        with SessionLocal() as db:
+            position = db.scalar(select(PositionEntity).where(PositionEntity.symbol == "AMD"))
+            assert position is not None
+            assert position.phase == "closed"
+            assert all(tranche["status"] == "canceled" for tranche in position.tranches)
+    finally:
+        service.broker.get_order = original_get_order
+        service.broker.cancel_order = original_cancel_order
+
+
+def test_projection_rebuild_restores_served_position_state() -> None:
+    with SessionLocal() as db:
+        setup = service.get_setup(db, "AAPL")
+        position = PositionEntity(
+            symbol="AAPL",
+            phase="trade_entered",
+            entry_price=setup.entry,
+            live_price=setup.last,
+            shares=24,
+            stop_ref="lod",
+            stop_price=setup.finalStop,
+            tranche_count=3,
+            tranche_modes=tranche_modes(),
+            stop_modes=[{"mode": "stop", "pct": None} for _ in range(3)],
+            tranches=[
+                {
+                    "id": "T1",
+                    "qty": 8,
+                    "stop": setup.finalStop,
+                    "label": "T1",
+                    "status": "active",
+                    "mode": "limit",
+                    "trail": 2.0,
+                    "trailUnit": "$",
+                    "runnerStop": None,
+                },
+                {
+                    "id": "T2",
+                    "qty": 8,
+                    "stop": setup.finalStop,
+                    "label": "T2",
+                    "status": "active",
+                    "mode": "limit",
+                    "trail": 2.0,
+                    "trailUnit": "$",
+                    "runnerStop": None,
+                },
+                {
+                    "id": "T3",
+                    "qty": 8,
+                    "stop": setup.finalStop,
+                    "label": "T3",
+                    "status": "active",
+                    "mode": "runner",
+                    "trail": 2.0,
+                    "trailUnit": "$",
+                    "runnerStop": None,
+                },
+            ],
+            setup_snapshot={
+                **setup.model_dump(mode="json"),
+                "entryOrder": {"side": "buy"},
+            },
+            root_order_id="ORD-REBUILD-1",
+            projection_version=4,
+            reconcile_status="synchronized",
+            last_reconciled_at=datetime.now(UTC),
+        )
+        db.add(position)
+        service._sync_projection(db, position)
+        db.commit()
+
+        expected = service.get_position(db, "AAPL").model_dump(mode="json")
+        projection = db.scalar(
+            select(PositionProjectionEntity).where(PositionProjectionEntity.symbol == "AAPL")
+        )
+        assert projection is not None
+        db.delete(projection)
+        db.commit()
+
+        rebuilt = service.rebuild_position_projections(db, symbols=["AAPL"])
+        db.commit()
+
+        assert rebuilt == ["AAPL"]
+        actual = service.get_position(db, "AAPL").model_dump(mode="json")
+
+    assert actual == expected
+
+
+def test_stale_reconciliation_blocks_entry_in_broker_paper_mode() -> None:
+    original_mode = service.settings.broker_mode
+    original_key = service.settings.alpaca_api_key_id
+    original_secret = service.settings.alpaca_api_secret_key
+    original_max_age = service.settings.max_reconcile_age_seconds
+    original_market_data = service.market_data.get_setup_data
+    try:
+        service.settings.broker_mode = "alpaca_paper"
+        service.settings.alpaca_api_key_id = "paper-key"
+        service.settings.alpaca_api_secret_key = "paper-secret"
+        service.settings.max_reconcile_age_seconds = 5
+        service.market_data.get_setup_data = lambda _symbol: SetupMarketData(
+            symbol="AAPL",
+            provider="alpaca_market",
+            provider_state="live_quote",
+            quote_provider="alpaca",
+            technicals_provider="alpaca",
+            quote_is_real=True,
+            technicals_are_fallback=False,
+            fallback_reason=None,
+            quote_timestamp=datetime.now(UTC),
+            session_state="regular_open",
+            quote_state="live_quote",
+            entry_basis="bid_ask_midpoint",
+            bid=101.0,
+            ask=101.2,
+            last=101.1,
+            lod=99.5,
+            hod=102.8,
+            prev_close=100.0,
+            atr14=1.6,
+            sma10=100.5,
+            sma50=98.2,
+            sma200=92.4,
+            sma200_prev=92.1,
+            rvol=1.4,
+            days_to_cover=2.0,
+        )
+
+        with SessionLocal() as db:
+            db.add(
+                ReconcileRunEntity(
+                    run_id="rec-stale-1",
+                    trigger="poll",
+                    broker="alpaca_paper",
+                    status="COMPLETED",
+                    processed_orders=0,
+                    processed_fills=0,
+                    created_at=datetime.now(UTC) - timedelta(minutes=2),
+                    completed_at=datetime.now(UTC) - timedelta(minutes=2),
+                )
+            )
+            db.commit()
+
+        setup = client.get("/api/setup/AAPL")
+        assert setup.status_code == 200
+        assert setup.json()["reconcileStatus"] == "stale"
+        assert "Reconciliation is stale" in " ".join(setup.json()["executionBlockingReasons"])
+
+        enter = client.post(
+            "/api/trade/enter",
+            json={
+                "symbol": "AAPL",
+                "entry": 101.1,
+                "stopRef": "lod",
+                "stopPrice": 99.5,
+                "trancheCount": 3,
+                "trancheModes": tranche_modes(),
+                "order": {"side": "buy"},
+            },
+        )
+        assert enter.status_code == 400
+        assert "Reconciliation is stale and execution is blocked." in enter.text
+    finally:
+        service.settings.broker_mode = original_mode
+        service.settings.alpaca_api_key_id = original_key
+        service.settings.alpaca_api_secret_key = original_secret
+        service.settings.max_reconcile_age_seconds = original_max_age
+        service.market_data.get_setup_data = original_market_data
+
+
+def test_duplicate_active_intent_blocks_trade_entry() -> None:
+    setup = client.get("/api/setup/AAPL").json()
+    with SessionLocal() as db:
+        db.add(
+            OrderIntentEntity(
+                intent_id="intent-pending-1",
+                symbol="AAPL",
+                action="enter",
+                side="buy",
+                qty=10,
+                price=101.1,
+                status="broker_accepted",
+                blocking_reasons=[],
+                broker_order_id="broker-pending-1",
+                payload={},
+            )
+        )
+        db.commit()
+
+    response = client.post(
+        "/api/trade/enter",
+        json={
+            "symbol": "AAPL",
+            "entry": setup["entry"],
+            "stopRef": "lod",
+            "stopPrice": setup["finalStop"],
+            "trancheCount": 3,
+            "trancheModes": tranche_modes(),
+            "order": {"side": "buy"},
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Another trade intent is already pending for this symbol." in response.text

--- a/backend/app/ws/manager.py
+++ b/backend/app/ws/manager.py
@@ -12,7 +12,9 @@ from redis.asyncio import Redis
 
 
 class WebSocketManager:
-    def __init__(self, redis_url: str | None = None, channel_prefix: str = "traders-cockpit") -> None:
+    def __init__(
+        self, redis_url: str | None = None, channel_prefix: str = "traders-cockpit"
+    ) -> None:
         self.connections: dict[str, set[WebSocket]] = defaultdict(set)
         self._lock = asyncio.Lock()
         self._redis_url = redis_url
@@ -32,7 +34,9 @@ class WebSocketManager:
             return
         self._redis = client
         self._shutdown.clear()
-        self._subscriber_task = asyncio.create_task(self._subscriber_loop(), name="redis-ws-fanout")
+        self._subscriber_task = asyncio.create_task(
+            self._subscriber_loop(), name="redis-ws-fanout"
+        )
 
     async def stop(self) -> None:
         self._shutdown.set()
@@ -81,7 +85,9 @@ class WebSocketManager:
         await pubsub.subscribe(*channels)
         try:
             while not self._shutdown.is_set():
-                message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True, timeout=1.0
+                )
                 if not message:
                     continue
                 payload = self._decode_message(message.get("data"))

--- a/docs/architecture/architecture-diagram.html
+++ b/docs/architecture/architecture-diagram.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  background: #0f172a;
+  font-family: 'Segoe UI', sans-serif;
+  color: #e2e8f0;
+  padding: 28px 20px;
+}
+h1 { text-align: center; font-size: 17px; color: #f1f5f9; margin-bottom: 4px; }
+.sub { text-align: center; font-size: 11px; color: #64748b; margin-bottom: 24px; }
+
+/* layout */
+.diagram { display: flex; align-items: flex-start; justify-content: center; gap: 0; }
+.col { display: flex; flex-direction: column; align-items: center; }
+
+/* sections */
+.section {
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+}
+.section-title {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+  text-align: center;
+}
+.fe  { border: 1px dashed #3b82f666; background: #1e3a5f1a; }
+.be  { border: 1px dashed #22c55e66; background: #1a3a2a1a; }
+.inf { border: 1px dashed #ef444466; background: #3b1f1f1a; }
+.ext { border: 1px dashed #a855f766; background: #2d1f3b1a; }
+.fe  .section-title { color: #3b82f6; }
+.be  .section-title { color: #22c55e; }
+.inf .section-title { color: #ef4444; }
+.ext .section-title { color: #a855f7; }
+
+/* boxes */
+.box {
+  border-radius: 7px;
+  padding: 8px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-align: center;
+  line-height: 1.4;
+  width: 100%;
+}
+.box span { font-size: 10px; font-weight: 400; display: block; margin-top: 2px; }
+.fe  .box { background: #1e3a5f; border: 1.5px solid #3b82f6; color: #93c5fd; }
+.be  .box { background: #1a3a2a; border: 1.5px solid #22c55e; color: #86efac; }
+.inf .box { background: #3b1f1f; border: 1.5px solid #ef4444; color: #fca5a5; }
+.ext .box { background: #2d1f3b; border: 1.5px solid #a855f7; color: #d8b4fe; }
+.ws-box    { background: #2d2010; border: 1.5px solid #f59e0b; color: #fcd34d; }
+
+/* arrows vertical */
+.av { display: flex; flex-direction: column; align-items: center; padding: 5px 0; }
+.av .lbl { font-size: 9px; color: #64748b; }
+.av .line { width: 1.5px; height: 18px; background: #334155; }
+.av .head { color: #475569; font-size: 11px; line-height: 1; }
+
+/* arrows horizontal */
+.ah { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 0 10px; gap: 3px; min-width: 80px; }
+.ah .lbl  { font-size: 9px; color: #64748b; text-align: center; white-space: nowrap; }
+.ah .line { height: 1.5px; background: #334155; width: 60px; }
+.ah .head { color: #475569; font-size: 13px; line-height: 1; }
+.ah .ws-lbl { font-size: 9px; color: #f59e0b; text-align: center; white-space: nowrap; }
+
+/* right col */
+.right-col { display: flex; flex-direction: column; gap: 14px; }
+
+/* lifecycle */
+.lifecycle { display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 4px; margin-top: 20px; }
+.lc-box { background: #1a3a2a; border: 1px solid #22c55e66; border-radius: 5px; padding: 4px 10px; font-size: 10px; color: #86efac; }
+.lc-arr { color: #22c55e88; font-size: 14px; }
+
+/* legend */
+.legend { display: flex; gap: 16px; justify-content: center; margin-top: 18px; flex-wrap: wrap; }
+.li { display: flex; align-items: center; gap: 5px; font-size: 10px; color: #94a3b8; }
+.ld { width: 10px; height: 10px; border-radius: 2px; }
+
+/* user box */
+.user { background: #1e293b; border: 1.5px solid #f59e0b; border-radius: 7px; padding: 6px 24px; font-size: 12px; font-weight: 600; color: #fcd34d; text-align: center; margin-bottom: 0; }
+</style>
+</head>
+<body>
+
+<h1>Traders Cockpit — Architecture</h1>
+<p class="sub">High-level component flow</p>
+
+<!-- USER -->
+<div class="col" style="margin-bottom:0">
+  <div class="user">👤 User Browser</div>
+  <div class="av"><div class="lbl">HTTP / WebSocket</div><div class="line"></div><div class="head">▼</div></div>
+</div>
+
+<!-- MAIN DIAGRAM ROW -->
+<div class="diagram">
+
+  <!-- FRONTEND -->
+  <div class="section fe" style="width:185px;">
+    <div class="section-title">Frontend · Next.js (3010)</div>
+    <div class="box">LoginPanel<span>Auth state · 401 guard</span></div>
+    <div class="av"><div class="lbl">on auth success</div><div class="line"></div><div class="head">▼</div></div>
+    <div class="box">Cockpit.tsx<span>Orchestrator · WS reconnect · Error banner</span></div>
+    <div class="av"><div class="lbl">props</div><div class="line"></div><div class="head">▼</div></div>
+    <div class="box">UI Panels<span>Setup · Entry · Stops · Profit · Log</span></div>
+    <div class="av"><div class="lbl">REST calls</div><div class="line"></div><div class="head">▼</div></div>
+    <div class="box">lib/api.ts<span>ApiError · login/logout · trade actions</span></div>
+  </div>
+
+  <!-- H arrows FE ↔ BE -->
+  <div class="ah" style="padding-top: 80px;">
+    <div class="lbl">REST ⇅</div>
+    <div style="display:flex; align-items:center; gap:4px;">
+      <div class="head" style="color:#475569">◀</div>
+      <div class="line"></div>
+      <div class="head" style="color:#475569">▶</div>
+    </div>
+    <div style="height:16px"></div>
+    <div class="ws-lbl">WS events ◀</div>
+    <div style="display:flex; align-items:center; gap:4px;">
+      <div class="head" style="color:#f59e0b88">◀</div>
+      <div class="line" style="background:#f59e0b44"></div>
+    </div>
+    <div class="ws-lbl" style="margin-top:4px">price_update</div>
+    <div class="ws-lbl">position_update</div>
+    <div class="ws-lbl">order_update</div>
+    <div class="ws-lbl">log_update</div>
+  </div>
+
+  <!-- BACKEND -->
+  <div class="section be" style="width:200px;">
+    <div class="section-title">Backend · FastAPI (8010)</div>
+    <div class="box">main.py<span>CORS · WS auth guard · /health</span></div>
+    <div class="av"><div class="lbl">routes</div><div class="line"></div><div class="head">▼</div></div>
+    <div class="box">API Routes<span>auth · account · market · positions · trade</span></div>
+    <div class="av"><div class="lbl">delegates logic</div><div class="line"></div><div class="head">▼</div></div>
+    <div class="box">CockpitService<span>Risk sizing · Trade lifecycle · Orders · Safety checks</span></div>
+    <div style="display:flex; gap:6px; margin-top:6px; width:100%">
+      <div style="flex:1">
+        <div class="av"><div class="lbl">quotes</div><div class="line"></div><div class="head">▼</div></div>
+        <div class="box" style="font-size:10px;">MarketData Adapter<span>Alpaca/Polygon · Fallback</span></div>
+      </div>
+      <div style="flex:1">
+        <div class="av"><div class="lbl">orders</div><div class="line"></div><div class="head">▼</div></div>
+        <div class="box" style="font-size:10px;">Broker Adapter<span>Paper sim · Alpaca · _fallback_or_raise</span></div>
+      </div>
+    </div>
+    <div class="av"><div class="lbl">pub/sub fanout</div><div class="line"></div><div class="head">▼</div></div>
+    <div class="box ws-box">WebSocketManager<span>Redis pub/sub · Local broadcast fallback</span></div>
+  </div>
+
+  <!-- H arrows BE → Infra/External -->
+  <div class="col" style="gap:30px; padding-top:70px; padding-left:4px; padding-right:4px;">
+    <div class="ah">
+      <div class="lbl">SQL →</div>
+      <div style="display:flex; align-items:center; gap:3px;">
+        <div class="line" style="width:40px"></div>
+        <div class="head">▶</div>
+      </div>
+    </div>
+    <div class="ah">
+      <div class="lbl">pub/sub →</div>
+      <div style="display:flex; align-items:center; gap:3px;">
+        <div class="line" style="width:40px"></div>
+        <div class="head">▶</div>
+      </div>
+    </div>
+    <div class="ah">
+      <div class="lbl">HTTP →</div>
+      <div style="display:flex; align-items:center; gap:3px;">
+        <div class="line" style="width:40px"></div>
+        <div class="head">▶</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- RIGHT: Infra + External -->
+  <div class="right-col">
+    <div class="section inf" style="width:165px;">
+      <div class="section-title">Infrastructure</div>
+      <div class="box">PostgreSQL · 55432<span>Account · Position · Order · TradeLog</span></div>
+      <div class="av"><div class="lbl">Alembic migrations</div><div class="line"></div><div class="head">▼</div></div>
+      <div class="box">Redis · 56379<span>WS event pub/sub · Multi-instance fanout</span></div>
+    </div>
+
+    <div class="section ext" style="width:165px;">
+      <div class="section-title">External APIs</div>
+      <div class="box">Alpaca<span>Paper (default) · Live (guarded by token)</span></div>
+      <div class="av"><div class="lbl">quotes · roadmap</div><div class="line"></div><div class="head">▼</div></div>
+      <div class="box">Polygon<span>Technicals · RVOL · Days-to-cover</span></div>
+    </div>
+  </div>
+
+</div>
+
+<!-- TRADE LIFECYCLE -->
+<div style="text-align:center; margin-top:22px; margin-bottom:8px;">
+  <div style="font-size:10px; font-weight:700; letter-spacing:1px; color:#22c55e; text-transform:uppercase; margin-bottom:8px;">Trade Lifecycle</div>
+  <div class="lifecycle">
+    <div class="lc-box">idle</div><div class="lc-arr">→</div>
+    <div class="lc-box">setup_loaded</div><div class="lc-arr">→</div>
+    <div class="lc-box">trade_entered</div><div class="lc-arr">→</div>
+    <div class="lc-box">protected</div><div class="lc-arr">→</div>
+    <div class="lc-box">P1 / P2 done</div><div class="lc-arr">→</div>
+    <div class="lc-box">runner_only</div><div class="lc-arr">→</div>
+    <div class="lc-box">closed</div>
+  </div>
+</div>
+
+<!-- LEGEND -->
+<div class="legend">
+  <div class="li"><div class="ld" style="background:#3b82f6"></div> Frontend</div>
+  <div class="li"><div class="ld" style="background:#22c55e"></div> Backend</div>
+  <div class="li"><div class="ld" style="background:#ef4444"></div> Infrastructure</div>
+  <div class="li"><div class="ld" style="background:#a855f7"></div> External APIs</div>
+  <div class="li"><div class="ld" style="background:#f59e0b"></div> WebSocket events</div>
+  <div class="li"><div class="ld" style="background:#475569"></div> REST / SQL</div>
+</div>
+
+</body>
+</html>

--- a/docs/architecture/diagram.jsx
+++ b/docs/architecture/diagram.jsx
@@ -1,0 +1,211 @@
+
+import { useState } from "react";
+
+const COLORS = {
+  frontend: { bg: "#1e3a5f", border: "#3b82f6", text: "#93c5fd", label: "#dbeafe" },
+  backend: { bg: "#1a3a2a", border: "#22c55e", text: "#86efac", label: "#dcfce7" },
+  infra: { bg: "#3b1f1f", border: "#ef4444", text: "#fca5a5", label: "#fee2e2" },
+  external: { bg: "#2d1f3b", border: "#a855f7", text: "#d8b4fe", label: "#f3e8ff" },
+  arrow: "#94a3b8",
+};
+
+function Box({ title, items, color, width = 180 }) {
+  return (
+    <div style={{
+      background: color.bg,
+      border: `1.5px solid ${color.border}`,
+      borderRadius: 8,
+      padding: "10px 14px",
+      width,
+      minHeight: 40,
+    }}>
+      <div style={{ color: color.label, fontWeight: 700, fontSize: 12, marginBottom: 6, letterSpacing: 0.5 }}>{title}</div>
+      {items.map((item, i) => (
+        <div key={i} style={{
+          color: color.text,
+          fontSize: 11,
+          padding: "2px 0",
+          borderTop: i === 0 ? `1px solid ${color.border}33` : "none",
+          paddingTop: i === 0 ? 4 : 2,
+        }}>• {item}</div>
+      ))}
+    </div>
+  );
+}
+
+function Label({ text, color }) {
+  return (
+    <div style={{
+      color,
+      fontSize: 10,
+      fontWeight: 600,
+      textAlign: "center",
+      letterSpacing: 0.5,
+      marginBottom: 2,
+    }}>{text}</div>
+  );
+}
+
+function Arrow({ label, direction = "down", color = COLORS.arrow }) {
+  const isHoriz = direction === "right" || direction === "left";
+  return (
+    <div style={{
+      display: "flex",
+      flexDirection: isHoriz ? "row" : "column",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 2,
+      padding: isHoriz ? "0 6px" : "4px 0",
+    }}>
+      <div style={{
+        color,
+        fontSize: 9,
+        textAlign: "center",
+        whiteSpace: "nowrap",
+        opacity: 0.85,
+      }}>{label}</div>
+      <div style={{
+        color,
+        fontSize: isHoriz ? 16 : 14,
+        lineHeight: 1,
+      }}>
+        {direction === "down" ? "↓" : direction === "up" ? "↑" : direction === "right" ? "→" : "←"}
+      </div>
+    </div>
+  );
+}
+
+function BiArrow({ label, color = COLORS.arrow }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", padding: "4px 0" }}>
+      <div style={{ color, fontSize: 9, opacity: 0.85, whiteSpace: "nowrap" }}>{label}</div>
+      <div style={{ color, fontSize: 14 }}>⇅</div>
+    </div>
+  );
+}
+
+function Section({ title, color, children, style = {} }) {
+  return (
+    <div style={{
+      border: `1px dashed ${color.border}55`,
+      borderRadius: 10,
+      padding: "10px 16px 14px",
+      background: `${color.bg}55`,
+      ...style
+    }}>
+      <div style={{
+        color: color.border,
+        fontSize: 11,
+        fontWeight: 700,
+        marginBottom: 10,
+        letterSpacing: 1,
+        textTransform: "uppercase",
+      }}>{title}</div>
+      {children}
+    </div>
+  );
+}
+
+export default function ArchDiagram() {
+  return (
+    <div style={{
+      background: "#0f172a",
+      minHeight: "100vh",
+      padding: "28px 24px",
+      fontFamily: "'Inter', 'Segoe UI', sans-serif",
+      color: "#e2e8f0",
+    }}>
+      <div style={{ textAlign: "center", marginBottom: 28 }}>
+        <div style={{ fontSize: 20, fontWeight: 700, color: "#f1f5f9", letterSpacing: 0.5 }}>Traders Cockpit — Architecture</div>
+        <div style={{ fontSize: 11, color: "#64748b", marginTop: 4 }}>Component relationships &amp; data flow</div>
+      </div>
+
+      {/* Main layout: 3 columns */}
+      <div style={{ display: "flex", gap: 24, justifyContent: "center", alignItems: "flex-start" }}>
+
+        {/* ── FRONTEND ── */}
+        <Section title="Frontend  ·  Next.js / React  (port 3010)" color={COLORS.frontend} style={{ width: 220 }}>
+          <Box title="Auth Layer" color={COLORS.frontend} width={190} items={["LoginPanel", "authUser / authRequired state", "submitLogin / logout", "401 → show login"]} />
+          <Arrow label="on auth success" direction="down" color={COLORS.frontend.border} />
+          <Box title="Cockpit.tsx  (orchestrator)" color={COLORS.frontend} width={190} items={["Global state manager", "hydrate() — full re-sync", "loadSetup / selectPosition", "WS reconnect + backoff", "runtimeError banner"]} />
+          <Arrow label="props" direction="down" color={COLORS.frontend.border} />
+          <Box title="UI Panels" color={COLORS.frontend} width={190} items={["CockpitHeader (ticker, price, logout)", "SetupPanel (quote, R-levels, positions)", "EntryPanel (entry, stop, preview, enter)", "StopProtectionPanel (stops, BE, flatten)", "ProfitTakingPanel (tranches, targets)", "ActivityLog (trade log, clear)"]} />
+          <Arrow label="REST calls" direction="down" color={COLORS.frontend.border} />
+          <Box title="lib/api.ts" color={COLORS.frontend} width={190} items={["ApiError (status-aware)", "getAccount / updateAccount", "getSetup / previewTrade", "enterTrade / applyStops", "executeProfit / moveToBe / flatten", "login / logout / me"]} />
+        </Section>
+
+        {/* ── CENTER ARROWS ── */}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", paddingTop: 60, gap: 0 }}>
+          <BiArrow label="REST HTTP" color="#94a3b8" />
+          <div style={{ height: 16 }} />
+          <Arrow label="WS events" direction="right" color="#f59e0b" />
+          <div style={{ fontSize: 9, color: "#f59e0b", opacity: 0.8, textAlign: "center", marginTop: 2, whiteSpace: "nowrap" }}>price_update</div>
+          <div style={{ fontSize: 9, color: "#f59e0b", opacity: 0.8, textAlign: "center", whiteSpace: "nowrap" }}>position_update</div>
+          <div style={{ fontSize: 9, color: "#f59e0b", opacity: 0.8, textAlign: "center", whiteSpace: "nowrap" }}>order_update</div>
+          <div style={{ fontSize: 9, color: "#f59e0b", opacity: 0.8, textAlign: "center", whiteSpace: "nowrap" }}>log_update</div>
+        </div>
+
+        {/* ── BACKEND ── */}
+        <Section title="Backend  ·  FastAPI / Python  (port 8010)" color={COLORS.backend} style={{ width: 230 }}>
+          <Box title="main.py  (entry point)" color={COLORS.backend} width={200} items={["CORS middleware", "Lifespan: start WS manager, seed DB", "GET /health", "WS /ws/cockpit  ← session auth guard"]} />
+          <Arrow label="routes" direction="down" color={COLORS.backend.border} />
+          <Box title="API Routes" color={COLORS.backend} width={200} items={["routes_auth  — login / logout / me", "routes_account  — equity, risk%, mode", "routes_market  — setup data", "routes_positions  — positions, orders, logs", "routes_trade  — enter, stops, profit, flatten"]} />
+          <Arrow label="delegates all logic" direction="down" color={COLORS.backend.border} />
+          <Box title="CockpitService  (business logic)" color={COLORS.backend} width={200} items={["Risk sizing (equity × risk% ÷ per-share-risk)", "Trade lifecycle state machine", "Tranche split & stop grouping", "Order hierarchy (root MKT → STOP/LMT/TRAIL)", "Safety checks (notional, loss limit, dupes)", "Broadcasts WS events after every mutation"]} />
+          <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+            <div>
+              <Arrow label="quotes" direction="down" color={COLORS.backend.border} />
+              <Box title="MarketDataAdapter" color={COLORS.backend} width={94} items={["AlpacaPolygon", "Fallback local"]} />
+            </div>
+            <div>
+              <Arrow label="orders" direction="down" color={COLORS.backend.border} />
+              <Box title="BrokerAdapter" color={COLORS.backend} width={94} items={["Paper (sim)", "Alpaca paper", "_fallback_or_raise"]} />
+            </div>
+          </div>
+          <Arrow label="pub/sub fanout" direction="down" color={COLORS.backend.border} />
+          <Box title="WebSocketManager" color={COLORS.backend} width={200} items={["Redis pub/sub (multi-instance)", "Direct broadcast (local fallback)", "connect / disconnect / broadcast"]} />
+        </Section>
+
+        {/* ── RIGHT: INFRA + EXTERNAL ── */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, paddingTop: 40 }}>
+
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <Arrow label="SQL (SQLAlchemy)" direction="left" color={COLORS.infra.border} />
+            <Section title="Infrastructure" color={COLORS.infra} style={{ width: 170 }}>
+              <Box title="PostgreSQL  (55432)" color={COLORS.infra} width={148} items={["AccountSettingsEntity", "PositionEntity (phase, tranches)", "OrderEntity (MKT/STOP/LMT/TRAIL)", "TradeLogEntity (audit log)"]} />
+              <Arrow label="Alembic migrations" direction="down" color={COLORS.infra.border} />
+              <Box title="Redis  (56379)" color={COLORS.infra} width={148} items={["WS event pub/sub channel", "Channel prefix scoping", "Multi-instance fanout"]} />
+            </Section>
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+            <Arrow label="HTTP (paper / live)" direction="left" color={COLORS.external.border} />
+            <Section title="External" color={COLORS.external} style={{ width: 170 }}>
+              <Box title="Alpaca API" color={COLORS.external} width={148} items={["Paper trading endpoint", "Live endpoint (disabled by default)", "ALLOW_LIVE_TRADING guard", "LIVE_CONFIRMATION_TOKEN required"]} />
+              <Arrow label="quotes (planned)" direction="down" color={COLORS.external.border} />
+              <Box title="Polygon" color={COLORS.external} width={148} items={["Technicals, RVOL", "Days-to-cover", "Roadmap: full integration"]} />
+            </Section>
+          </div>
+
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div style={{ display: "flex", gap: 20, justifyContent: "center", marginTop: 28 }}>
+        {[
+          { color: COLORS.frontend.border, label: "Frontend" },
+          { color: COLORS.backend.border, label: "Backend" },
+          { color: COLORS.infra.border, label: "Infrastructure" },
+          { color: COLORS.external.border, label: "External APIs" },
+          { color: "#f59e0b", label: "WebSocket events" },
+          { color: "#94a3b8", label: "REST / SQL" },
+        ].map(({ color, label }) => (
+          <div key={label} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <div style={{ width: 10, height: 10, borderRadius: 2, background: color }} />
+            <span style={{ fontSize: 10, color: "#94a3b8" }}>{label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/issues/2026-03-28-broker-event-normalization.md
+++ b/docs/issues/2026-03-28-broker-event-normalization.md
@@ -1,0 +1,25 @@
+# Broker Event Normalization
+
+> Status: In Progress
+> Branch: `codex/feature-hedge-hardening-foundation`
+> Opened: 2026-03-28
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+Broker webhook payloads need a stable internal event contract so replay, dedupe, and downstream reconciliation can be deterministic. Raw broker payloads are too provider-shaped to be used directly as the service boundary.
+
+## Scope
+
+- normalize Alpaca webhook payloads into one internal event shape
+- keep stable `event_id`, `fill_id`, `broker_order_id`, `symbol`, `event_type`, `occurred_at`, and `kind`
+- dedupe external events before applying any local side effects
+- preserve additive API behavior for the existing webhook route
+
+## Acceptance Criteria
+
+- [ ] duplicate webhook deliveries do not create duplicate fills
+- [ ] duplicate webhook deliveries do not create duplicate event-log rows
+- [ ] duplicate webhook deliveries do not produce extra position transitions
+- [ ] malformed webhook payloads fail with a clear 400 response

--- a/docs/issues/2026-03-28-broker-event-normalization.md
+++ b/docs/issues/2026-03-28-broker-event-normalization.md
@@ -1,10 +1,12 @@
 # Broker Event Normalization
 
-> Status: In Progress
-> Branch: `codex/feature-hedge-hardening-foundation`
+> Status: In Review
+> Branch: `codex/feature-broker-truth-paper-promotion`
 > Opened: 2026-03-28
 > Closed: -
 > Closing Commit: -
+> Review PR: [#32](https://github.com/Melvinroy/traders-cockpit/pull/32)
+> Latest Commit: `afb12ef`
 
 ## Problem
 
@@ -19,7 +21,7 @@ Broker webhook payloads need a stable internal event contract so replay, dedupe,
 
 ## Acceptance Criteria
 
-- [ ] duplicate webhook deliveries do not create duplicate fills
-- [ ] duplicate webhook deliveries do not create duplicate event-log rows
-- [ ] duplicate webhook deliveries do not produce extra position transitions
-- [ ] malformed webhook payloads fail with a clear 400 response
+- [x] duplicate webhook deliveries do not create duplicate fills
+- [x] duplicate webhook deliveries do not create duplicate event-log rows
+- [x] duplicate webhook deliveries do not produce extra position transitions
+- [x] malformed webhook payloads fail with a clear 400 response

--- a/docs/issues/2026-03-28-hedge-hardening-foundation.md
+++ b/docs/issues/2026-03-28-hedge-hardening-foundation.md
@@ -1,10 +1,12 @@
 # Hedge Hardening Foundation
 
-> Status: In Progress
-> Branch: `codex/feature-hedge-hardening-foundation`
+> Status: In Review
+> Branch: `codex/feature-broker-truth-paper-promotion`
 > Opened: 2026-03-28
 > Closed: -
 > Closing Commit: -
+> Review PR: [#32](https://github.com/Melvinroy/traders-cockpit/pull/32)
+> Latest Commit: `afb12ef`
 
 ## Problem
 
@@ -27,10 +29,10 @@ The current cockpit still allows optimistic local state transitions that are not
 
 ## Acceptance criteria
 
-- [ ] append-only trading event tables exist and are populated by core trade flows
-- [ ] entry/profit/flatten flows stop assuming broker-paper orders are instantly filled
-- [ ] setup payload can explicitly block execution when market data is stale or fallback-backed
-- [ ] write routes require session plus CSRF checks when auth is enabled
+- [x] append-only trading event tables exist and are populated by core trade flows
+- [x] entry/profit/flatten flows stop assuming broker-paper orders are instantly filled
+- [x] setup payload can explicitly block execution when market data is stale or fallback-backed
+- [x] write routes require session plus CSRF checks when auth is enabled
 - [ ] frontend `npm run typecheck` passes from a clean checkout
 
 ## Risks / constraints

--- a/docs/issues/2026-03-28-hedge-hardening-foundation.md
+++ b/docs/issues/2026-03-28-hedge-hardening-foundation.md
@@ -1,0 +1,40 @@
+# Hedge Hardening Foundation
+
+> Status: In Progress
+> Branch: `codex/feature-hedge-hardening-foundation`
+> Opened: 2026-03-28
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The current cockpit still allows optimistic local state transitions that are not strictly tied to broker-confirmed fills and reconciled broker truth. That makes the stack usable for supervised simulation, but not for a safer solo-pro trading bar.
+
+## Business value
+
+- reduce false confidence in position, exit, and P&L state
+- add durable event and reconciliation foundations for later hardening
+- keep the current UI usable while the backend contract grows additively
+- improve clean-checkout validation so the repo is easier to trust and promote
+
+## Scope
+
+- add append-only event and intent foundations in Postgres
+- extend read models and API responses with reconciliation and blocking metadata
+- remove optimistic live-broker exit handling where possible
+- tighten auth/runtime guards and add CSRF protection for write actions
+- fix frontend clean-checkout typecheck behavior
+
+## Acceptance criteria
+
+- [ ] append-only trading event tables exist and are populated by core trade flows
+- [ ] entry/profit/flatten flows stop assuming broker-paper orders are instantly filled
+- [ ] setup payload can explicitly block execution when market data is stale or fallback-backed
+- [ ] write routes require session plus CSRF checks when auth is enabled
+- [ ] frontend `npm run typecheck` passes from a clean checkout
+
+## Risks / constraints
+
+- the worktree already contains in-flight changes, so edits must preserve existing behavior where possible
+- the current service layer is stateful and broad, so changes should be additive before deeper refactors
+- browser QC is out of scope for this implementation slice

--- a/docs/issues/2026-03-28-projection-first-position-reads.md
+++ b/docs/issues/2026-03-28-projection-first-position-reads.md
@@ -1,0 +1,23 @@
+# Projection-First Position Reads
+
+> Status: In Progress
+> Branch: `codex/feature-hedge-hardening-foundation`
+> Opened: 2026-03-28
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The cockpit still has legacy mutable rows that can drift away from the operator-facing read state. Position reads need to come from the projection payload first so the UI renders broker-truthful, reconciliation-aware state.
+
+## Scope
+
+- serve `get_position` and `get_positions` from `position_projections.payload` first
+- keep mutable state rows as build inputs and fallbacks only
+- add rebuild tooling so deleted projections can be reproduced safely
+
+## Acceptance Criteria
+
+- [ ] projection payload is the default served `PositionView`
+- [ ] changing a mutable row without syncing the projection does not change served state
+- [ ] deleting projection rows and rebuilding reproduces served position state for fixtures

--- a/docs/issues/2026-03-28-projection-first-position-reads.md
+++ b/docs/issues/2026-03-28-projection-first-position-reads.md
@@ -1,10 +1,12 @@
 # Projection-First Position Reads
 
-> Status: In Progress
-> Branch: `codex/feature-hedge-hardening-foundation`
+> Status: In Review
+> Branch: `codex/feature-broker-truth-paper-promotion`
 > Opened: 2026-03-28
 > Closed: -
 > Closing Commit: -
+> Review PR: [#32](https://github.com/Melvinroy/traders-cockpit/pull/32)
+> Latest Commit: `afb12ef`
 
 ## Problem
 
@@ -18,6 +20,6 @@ The cockpit still has legacy mutable rows that can drift away from the operator-
 
 ## Acceptance Criteria
 
-- [ ] projection payload is the default served `PositionView`
-- [ ] changing a mutable row without syncing the projection does not change served state
-- [ ] deleting projection rows and rebuilding reproduces served position state for fixtures
+- [x] projection payload is the default served `PositionView`
+- [x] changing a mutable row without syncing the projection does not change served state
+- [x] deleting projection rows and rebuilding reproduces served position state for fixtures

--- a/docs/issues/2026-03-28-projection-rebuild-tooling.md
+++ b/docs/issues/2026-03-28-projection-rebuild-tooling.md
@@ -1,0 +1,23 @@
+# Projection Rebuild Tooling
+
+> Status: In Progress
+> Branch: `codex/feature-hedge-hardening-foundation`
+> Opened: 2026-03-28
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+Projection rows are disposable read models. The repo needs a recovery-friendly way to rebuild them after drift, operator cleanup, or database restore work without exposing that control in the public UI.
+
+## Scope
+
+- add a backend rebuild path for `position_projections`
+- wrap it in a CLI-oriented recovery script for local and staging ops
+- prove rebuild parity in automated tests
+
+## Acceptance Criteria
+
+- [ ] projections can be deleted and rebuilt from backend state
+- [ ] the rebuild path is callable from a repo script
+- [ ] a regression test proves rebuild parity for a fixture position

--- a/docs/issues/2026-03-28-projection-rebuild-tooling.md
+++ b/docs/issues/2026-03-28-projection-rebuild-tooling.md
@@ -1,10 +1,12 @@
 # Projection Rebuild Tooling
 
-> Status: In Progress
-> Branch: `codex/feature-hedge-hardening-foundation`
+> Status: In Review
+> Branch: `codex/feature-broker-truth-paper-promotion`
 > Opened: 2026-03-28
 > Closed: -
 > Closing Commit: -
+> Review PR: [#32](https://github.com/Melvinroy/traders-cockpit/pull/32)
+> Latest Commit: `afb12ef`
 
 ## Problem
 
@@ -18,6 +20,6 @@ Projection rows are disposable read models. The repo needs a recovery-friendly w
 
 ## Acceptance Criteria
 
-- [ ] projections can be deleted and rebuilt from backend state
-- [ ] the rebuild path is callable from a repo script
-- [ ] a regression test proves rebuild parity for a fixture position
+- [x] projections can be deleted and rebuilt from backend state
+- [x] the rebuild path is callable from a repo script
+- [x] a regression test proves rebuild parity for a fixture position

--- a/docs/issues/2026-03-28-reconciler-heartbeat.md
+++ b/docs/issues/2026-03-28-reconciler-heartbeat.md
@@ -1,0 +1,25 @@
+# Reconciler Heartbeat
+
+> Status: In Progress
+> Branch: `codex/feature-hedge-hardening-foundation`
+> Opened: 2026-03-28
+> Closed: -
+> Closing Commit: -
+
+## Problem
+
+The stack can reconcile on demand and from webhook ingress, but it does not yet maintain a durable freshness heartbeat. Without periodic poll-driven reconciliation, `broker_paper` execution can look healthy while local state is actually stale.
+
+## Scope
+
+- add a background reconcile loop with fast and slow cadence modes
+- persist poll freshness in `reconcile_runs`
+- expose reconcile freshness through setup and account payloads
+- block trade-mutating actions when reconciliation is stale
+
+## Acceptance Criteria
+
+- [ ] open working orders use the fast heartbeat cadence
+- [ ] idle periods use the slow heartbeat cadence
+- [ ] setup and account payloads surface reconcile freshness
+- [ ] stale reconciliation blocks trade-mutating routes with a stable reason string

--- a/docs/issues/2026-03-28-reconciler-heartbeat.md
+++ b/docs/issues/2026-03-28-reconciler-heartbeat.md
@@ -1,10 +1,12 @@
 # Reconciler Heartbeat
 
-> Status: In Progress
-> Branch: `codex/feature-hedge-hardening-foundation`
+> Status: In Review
+> Branch: `codex/feature-broker-truth-paper-promotion`
 > Opened: 2026-03-28
 > Closed: -
 > Closing Commit: -
+> Review PR: [#32](https://github.com/Melvinroy/traders-cockpit/pull/32)
+> Latest Commit: `afb12ef`
 
 ## Problem
 
@@ -19,7 +21,7 @@ The stack can reconcile on demand and from webhook ingress, but it does not yet 
 
 ## Acceptance Criteria
 
-- [ ] open working orders use the fast heartbeat cadence
-- [ ] idle periods use the slow heartbeat cadence
-- [ ] setup and account payloads surface reconcile freshness
-- [ ] stale reconciliation blocks trade-mutating routes with a stable reason string
+- [x] open working orders use the fast heartbeat cadence
+- [x] idle periods use the slow heartbeat cadence
+- [x] setup and account payloads surface reconcile freshness
+- [x] stale reconciliation blocks trade-mutating routes with a stable reason string

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="120" height="120">
+  <defs>
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f1218;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#141820;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="cyanGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#00c8d4;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#4a9eff;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="1.5" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="120" height="120" rx="18" fill="url(#bgGrad)"/>
+  <rect width="120" height="120" rx="18" fill="none" stroke="#1e2a3a" stroke-width="1.5"/>
+
+  <!-- Gauge arc background -->
+  <path d="M 22 80 A 38 38 0 0 1 98 80" fill="none" stroke="#1c2230" stroke-width="6" stroke-linecap="round"/>
+
+  <!-- Gauge arc fill (cyan) -->
+  <path d="M 22 80 A 38 38 0 0 1 72 44" fill="none" stroke="url(#cyanGrad)" stroke-width="6" stroke-linecap="round" filter="url(#glow)" opacity="0.9"/>
+
+  <!-- Gauge ticks -->
+  <line x1="22" y1="80" x2="26" y2="75" stroke="#2a3a50" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="31" y1="55" x2="35" y2="58" stroke="#2a3a50" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="60" y1="42" x2="60" y2="47" stroke="#2a3a50" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="89" y1="55" x2="85" y2="58" stroke="#2a3a50" stroke-width="1.5" stroke-linecap="round"/>
+  <line x1="98" y1="80" x2="94" y2="75" stroke="#2a3a50" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- Gauge needle -->
+  <line x1="60" y1="80" x2="72" y2="44" stroke="#00d07a" stroke-width="2" stroke-linecap="round" filter="url(#glow)"/>
+  <!-- Needle pivot -->
+  <circle cx="60" cy="80" r="4" fill="#1c2230" stroke="#00d07a" stroke-width="1.5"/>
+  <circle cx="60" cy="80" r="1.5" fill="#00d07a"/>
+
+  <!-- Price chart line (bottom area) -->
+  <polyline points="16,100 26,96 36,98 46,92 56,94 66,88 76,90 82,85 92,87 104,80"
+    fill="none" stroke="#00c8d4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.5"/>
+
+  <!-- Bottom label -->
+  <text x="60" y="114" text-anchor="middle" font-family="'IBM Plex Mono', 'Courier New', monospace" font-size="7" font-weight="600" letter-spacing="3" fill="#3d5068" text-transform="uppercase">COCKPIT</text>
+</svg>

--- a/frontend/components/ActivityLog.tsx
+++ b/frontend/components/ActivityLog.tsx
@@ -2,6 +2,8 @@ import type { LogEntry } from "@/lib/types";
 import { formatLogTime } from "@/lib/cockpit-ui";
 
 export function ActivityLog({ logs, onClear, clearFlashing = false }: { logs: LogEntry[]; onClear: () => void; clearFlashing?: boolean }) {
+  const visibleLogs = logs.slice(0, 80);
+
   return (
     <div className="panel log-panel">
       <div className="panel-header">
@@ -9,8 +11,8 @@ export function ActivityLog({ logs, onClear, clearFlashing = false }: { logs: Lo
         <button type="button" className={`btn btn-ghost log-clear-btn ${clearFlashing ? "flash" : ""}`} onClick={onClear}>CLR</button>
       </div>
       <div className="log-body">
-        {logs.length ? (
-          logs.map((entry) => (
+        {visibleLogs.length ? (
+          visibleLogs.map((entry) => (
             <div className="log-entry" key={entry.id}>
               <div className="log-time">{formatLogTime(entry.created_at)}</div>
               <div className="log-msg">

--- a/frontend/components/Cockpit.tsx
+++ b/frontend/components/Cockpit.tsx
@@ -24,6 +24,50 @@ const DEFAULT_TRANCHE_MODES: TrancheMode[] = [
   { mode: "runner", trail: 2, trailUnit: "$", target: "3R", manualPrice: null }
 ];
 
+function effectiveStopPrice(setup: SetupResponse | null, stopRef: "lod" | "atr" | "manual", manualStop: number | null) {
+  if (!setup) return 0;
+  if (stopRef === "manual") return manualStop ?? 0;
+  return stopRef === "atr" ? setup.atrStop : setup.lodStop;
+}
+
+function deriveSetupForSelection(
+  setup: SetupResponse | null,
+  account: AccountView | null,
+  stopRef: "lod" | "atr" | "manual",
+  manualStop: number | null,
+  entryPrice: number
+) {
+  if (!setup) return null;
+  const equity = account?.equity ?? setup.accountEquity;
+  const buyingPower = account?.buying_power ?? setup.accountBuyingPower;
+  const riskPct = account?.risk_pct ?? setup.riskPct;
+  const stopPrice = stopRef === "manual" ? manualStop : stopRef === "atr" ? setup.atrStop : setup.lodStop;
+  const validStop = typeof stopPrice === "number" && Number.isFinite(stopPrice) && stopPrice > 0 && stopPrice < entryPrice;
+  const perShareRisk = validStop ? Number((entryPrice - stopPrice).toFixed(2)) : 0;
+  const dollarRisk = Number((equity * (riskPct / 100)).toFixed(2));
+  const maxNotionalCap = equity * ((account?.max_position_notional_pct ?? 100) / 100);
+  const effectiveNotionalCap = Math.min(buyingPower, maxNotionalCap);
+  const shares = validStop && entryPrice > 0
+    ? Math.max(0, Math.min(Math.floor(dollarRisk / perShareRisk), Math.floor(effectiveNotionalCap / entryPrice)))
+    : 0;
+
+  return {
+    ...setup,
+    entry: entryPrice,
+    stopReferenceDefault: stopRef,
+    finalStop: validStop ? stopPrice : 0,
+    perShareRisk,
+    dollarRisk,
+    shares,
+    riskPct,
+    accountEquity: equity,
+    accountBuyingPower: buyingPower,
+    r1: perShareRisk > 0 ? Number((entryPrice + perShareRisk).toFixed(2)) : entryPrice,
+    r2: perShareRisk > 0 ? Number((entryPrice + perShareRisk * 2).toFixed(2)) : entryPrice,
+    r3: perShareRisk > 0 ? Number((entryPrice + perShareRisk * 3).toFixed(2)) : entryPrice
+  };
+}
+
 export function Cockpit() {
   const [flashState, setFlashState] = useState<Record<string, number>>({});
   const [authUser, setAuthUser] = useState<AuthUser | null>(null);
@@ -37,7 +81,7 @@ export function Cockpit() {
   const [positions, setPositions] = useState<PositionView[]>([]);
   const [activeSymbol, setActiveSymbol] = useState("");
   const [entryPrice, setEntryPrice] = useState(0);
-  const [manualStop, setManualStop] = useState(0);
+  const [manualStop, setManualStop] = useState<number | null>(null);
   const [offHoursMode, setOffHoursMode] = useState<OffHoursMode>("queue_for_open");
   const [stopRef, setStopRef] = useState<"lod" | "atr" | "manual">("lod");
   const [stopMode, setStopMode] = useState(3);
@@ -55,10 +99,14 @@ export function Cockpit() {
     () => positions.find((position) => position.symbol === activeSymbol) ?? null,
     [positions, activeSymbol]
   );
+  const effectiveSetup = useMemo(
+    () => deriveSetupForSelection(setup, account, stopRef, manualStop, entryPrice || setup?.entry || 0),
+    [account, entryPrice, manualStop, setup, stopRef]
+  );
   const phase = activePosition?.phase ?? (setup ? "setup_loaded" : "idle");
-  const livePrice = activePosition?.livePrice ?? setup?.last ?? null;
-  const delta = livePrice !== null && setup ? livePrice - setup.entry : 0;
-  const deltaPct = livePrice !== null && setup ? ((livePrice - setup.entry) / setup.entry) * 100 : 0;
+  const livePrice = activePosition?.livePrice ?? effectiveSetup?.last ?? null;
+  const delta = livePrice !== null && effectiveSetup ? livePrice - effectiveSetup.entry : 0;
+  const deltaPct = livePrice !== null && effectiveSetup ? ((livePrice - effectiveSetup.entry) / effectiveSetup.entry) * 100 : 0;
 
   useEffect(() => {
     activeSymbolRef.current = activeSymbol;
@@ -105,7 +153,8 @@ export function Cockpit() {
       setTicker(position.symbol);
       setSetup(position.setup as SetupResponse);
       setEntryPrice(position.setup.entry);
-      setManualStop(position.setup.finalStop);
+      setStopRef((position.setup.stopReferenceDefault as "lod" | "atr" | "manual") ?? "lod");
+      setManualStop(position.setup.stopReferenceDefault === "manual" ? null : position.setup.finalStop);
       setOffHoursMode("queue_for_open");
       setStopMode(position.stopMode || 3);
       setStopModes(position.stopModes.length ? position.stopModes : DEFAULT_STOP_MODES);
@@ -265,7 +314,8 @@ export function Cockpit() {
     setupLoadedRef.current = true;
     setSetup(nextSetup);
     setEntryPrice(nextSetup.entry);
-    setManualStop(nextSetup.finalStop);
+    setStopRef(nextSetup.stopReferenceDefault);
+    setManualStop(nextSetup.stopReferenceDefault === "manual" ? null : nextSetup.finalStop);
     setActiveSymbol("");
     setStopMode(3);
     setStopModes(DEFAULT_STOP_MODES);
@@ -302,7 +352,8 @@ export function Cockpit() {
         const nextSetup = await api.getSetup(ticker);
         setSetup(nextSetup);
         setEntryPrice(nextSetup.entry);
-        setManualStop(nextSetup.finalStop);
+        setStopRef(nextSetup.stopReferenceDefault);
+        setManualStop(nextSetup.stopReferenceDefault === "manual" ? null : nextSetup.finalStop);
       }
       await hydrate({ autoSelectFirst: false });
       setRuntimeError(null);
@@ -314,12 +365,16 @@ export function Cockpit() {
 
   async function previewTrade() {
     if (!setup) return;
+    if (stopRef === "manual" && (!manualStop || manualStop <= 0)) {
+      setRuntimeError("Enter a valid manual stop price.");
+      return;
+    }
     try {
       await api.previewTrade({
         symbol: ticker,
         entry: entryPrice,
         stopRef,
-        stopPrice: stopRef === "manual" ? manualStop : setup.finalStop,
+        stopPrice: effectiveStopPrice(setup, stopRef, manualStop),
         riskPct: account?.risk_pct ?? setup.riskPct
       });
       await hydrate({ autoSelectFirst: false });
@@ -333,12 +388,16 @@ export function Cockpit() {
 
   async function enterTrade() {
     if (!setup) return;
+    if (stopRef === "manual" && (!manualStop || manualStop <= 0)) {
+      setRuntimeError("Enter a valid manual stop price.");
+      return;
+    }
     try {
       const position = await api.enterTrade({
         symbol: ticker,
         entry: entryPrice,
         stopRef,
-        stopPrice: stopRef === "manual" ? manualStop : setup.finalStop,
+        stopPrice: effectiveStopPrice(setup, stopRef, manualStop),
         trancheCount,
         trancheModes,
         offHoursMode: setup.sessionState === "regular_open" ? null : offHoursMode
@@ -481,7 +540,8 @@ export function Cockpit() {
           setActiveSymbol("");
           setTicker("");
           setEntryPrice(0);
-          setManualStop(0);
+          setManualStop(null);
+          setStopRef("lod");
           setOffHoursMode("queue_for_open");
           setStopMode(3);
           setStopModes(DEFAULT_STOP_MODES);
@@ -504,17 +564,17 @@ export function Cockpit() {
       <div className="workspace">
         <SetupPanel
           symbol={activeSymbol || ticker}
-          setup={setup}
+          setup={effectiveSetup}
           account={account}
           positions={positions}
           onSelectPosition={selectPosition}
           onRiskPctCommit={(value) => void commitRiskPct(value)}
         />
         <EntryPanel
-          setup={setup}
-          entryPrice={entryPrice || setup?.entry || 0}
+          setup={effectiveSetup}
+          entryPrice={entryPrice || effectiveSetup?.entry || 0}
           stopRef={stopRef}
-          manualStop={manualStop || setup?.finalStop || 0}
+          manualStop={manualStop}
           offHoursMode={offHoursMode}
           previewFlashing={Boolean(flashState.preview)}
           enterFlashing={Boolean(flashState.enter)}
@@ -526,7 +586,7 @@ export function Cockpit() {
           onEnterTrade={() => void enterTrade()}
         />
         <StopProtectionPanel
-          setup={setup}
+          setup={effectiveSetup}
           phase={activePosition?.phase ?? null}
           stopMode={stopMode}
           stopModes={stopModes}
@@ -544,7 +604,7 @@ export function Cockpit() {
           onFlatten={() => void flatten()}
         />
         <ProfitTakingPanel
-          setup={setup}
+          setup={effectiveSetup}
           activePosition={activePosition}
           trancheCount={trancheCount}
           trancheModes={trancheModes}

--- a/frontend/components/Cockpit.tsx
+++ b/frontend/components/Cockpit.tsx
@@ -24,6 +24,8 @@ const DEFAULT_TRANCHE_MODES: TrancheMode[] = [
   { mode: "runner", trail: 2, trailUnit: "$", target: "3R", manualPrice: null }
 ];
 
+const MAX_LOG_ENTRIES = 120;
+
 function effectiveStopPrice(setup: SetupResponse | null, stopRef: "lod" | "atr" | "manual", manualStop: number | null) {
   if (!setup) return 0;
   if (stopRef === "manual") return manualStop ?? 0;
@@ -217,6 +219,7 @@ export function Cockpit() {
     } catch (error) {
       if (error instanceof ApiError && error.status === 401) {
         setAuthUser(null);
+        setAuthRequired(true);
         return null;
       }
       throw error;
@@ -234,15 +237,15 @@ export function Cockpit() {
 
   useEffect(() => {
     void (async () => {
-      const hydrated = await hydrate({ autoSelectFirst: true });
-      if (hydrated) {
-        await loadSession();
+      const user = await loadSession();
+      if (user) {
+        await hydrate({ autoSelectFirst: true });
       }
     })();
   }, [hydrate, loadSession]);
 
   useEffect(() => {
-    if (authRequired) return;
+    if (authRequired || !authUser) return;
     const wsUrl = process.env.NEXT_PUBLIC_WS_URL ?? "ws://127.0.0.1:8010/ws/cockpit";
     let disposed = false;
     let reconnectDelay = 1000;
@@ -266,12 +269,37 @@ export function Cockpit() {
             current.map((position) =>
               position.symbol === payload.symbol
                 ? { ...position, livePrice: Number(payload.last ?? position.livePrice) }
+              : position
+            )
+          );
+        }
+        if (payload.type === "position_update" && payload.position && typeof payload.symbol === "string") {
+          const nextPosition = payload.position as PositionView;
+          setPositions((current) => {
+            const next = current.some((position) => position.symbol === nextPosition.symbol)
+              ? current.map((position) => (position.symbol === nextPosition.symbol ? nextPosition : position))
+              : [nextPosition, ...current];
+            return next;
+          });
+          if (activeSymbolRef.current === nextPosition.symbol) {
+            applyPositionState(nextPosition);
+          }
+        }
+        if (payload.type === "order_update" && Array.isArray(payload.orders) && typeof payload.symbol === "string") {
+          setPositions((current) =>
+            current.map((position) =>
+              position.symbol === payload.symbol
+                ? { ...position, orders: payload.orders as PositionView["orders"] }
                 : position
             )
           );
         }
-        if (payload.type === "position_update" || payload.type === "order_update" || payload.type === "log_update") {
-          void hydrate({ autoSelectFirst: Boolean(activeSymbolRef.current) });
+        if (payload.type === "log_update" && payload.log) {
+          const nextLog = payload.log as LogEntry;
+          setLogs((current) => {
+            const deduped = current.filter((entry) => entry.id !== nextLog.id);
+            return [nextLog, ...deduped].slice(0, MAX_LOG_ENTRIES);
+          });
         }
       };
       ws.onerror = () => {
@@ -282,7 +310,9 @@ export function Cockpit() {
           wsRef.current = null;
         }
         if (disposed) return;
-        setRuntimeError("Realtime connection lost. Reconnecting...");
+        if (ws.readyState !== WebSocket.OPEN) {
+          setRuntimeError("Realtime connection lost. Reconnecting...");
+        }
         reconnectTimerRef.current = window.setTimeout(() => {
           reconnectDelay = Math.min(reconnectDelay * 2, 5000);
           connect();
@@ -300,7 +330,7 @@ export function Cockpit() {
       wsRef.current?.close();
       wsRef.current = null;
     };
-  }, [authRequired, hydrate]);
+  }, [applyPositionState, authRequired, authUser, hydrate]);
 
   const loadSetup = useCallback(async () => {
     let nextSetup: SetupResponse;

--- a/frontend/components/EntryPanel.tsx
+++ b/frontend/components/EntryPanel.tsx
@@ -5,13 +5,13 @@ type Props = {
   setup: SetupResponse | null;
   entryPrice: number;
   stopRef: "lod" | "atr" | "manual";
-  manualStop: number;
+  manualStop: number | null;
   offHoursMode: OffHoursMode;
   previewFlashing?: boolean;
   enterFlashing?: boolean;
   onEntryChange: (value: number) => void;
   onStopRefChange: (value: "lod" | "atr" | "manual") => void;
-  onManualStopChange: (value: number) => void;
+  onManualStopChange: (value: number | null) => void;
   onOffHoursModeChange: (value: OffHoursMode) => void;
   onPreview: () => void;
   onEnterTrade: () => void;
@@ -33,7 +33,7 @@ export function EntryPanel(props: Props) {
     onPreview,
     onEnterTrade
   } = props;
-  const stopPrice = stopRef === "manual" ? manualStop : setup?.finalStop ?? 0;
+  const stopPrice = stopRef === "manual" ? manualStop : stopRef === "atr" ? setup?.atrStop ?? null : setup?.lodStop ?? null;
   const isOffHours = Boolean(setup && setup.sessionState !== "regular_open");
 
   return (
@@ -63,8 +63,8 @@ export function EntryPanel(props: Props) {
               <div className="entry-v-divider" />
               <div className="stop-ref-wrap">
                 <div className="entry-toggle-group">
-                  <button type="button" className={`tranche-count-btn ${stopRef === "lod" ? "active" : ""}`} onClick={() => onStopRefChange("lod")}>LoD</button>
-                  <button type="button" className={`tranche-count-btn ${stopRef === "atr" ? "active" : ""}`} onClick={() => onStopRefChange("atr")}>ATR</button>
+                  <button type="button" className={`tranche-count-btn ${stopRef === "lod" ? "active" : ""}`} onClick={() => onStopRefChange("lod")} disabled={!setup?.lodIsValid}>LoD</button>
+                  <button type="button" className={`tranche-count-btn ${stopRef === "atr" ? "active" : ""}`} onClick={() => onStopRefChange("atr")} disabled={!setup?.atrIsValid}>ATR</button>
                   <button type="button" className={`tranche-count-btn ${stopRef === "manual" ? "active" : ""}`} onClick={() => onStopRefChange("manual")}>Manual</button>
                 </div>
                 <div className="manual-stop-wrap">
@@ -72,15 +72,21 @@ export function EntryPanel(props: Props) {
                   <input
                     type="number"
                     inputMode="decimal"
-                    value={manualStop}
+                    value={manualStop ?? ""}
                     className="manual-stop-input"
-                    onChange={(event) => onManualStopChange(Number(event.target.value))}
+                    onChange={(event) => onManualStopChange(event.target.value === "" ? null : Number(event.target.value))}
                     disabled={stopRef !== "manual"}
                   />
                 </div>
                 <span className="hero-stop-price">{fp(stopPrice)}</span>
               </div>
             </div>
+            {setup.manualStopWarning ? <div className="offhours-copy">{setup.manualStopWarning}</div> : null}
+            {setup ? (
+              <div className="offhours-copy">
+                Active stop source: {stopRef === "lod" ? `LoD ${fp(setup.lodStop)}` : stopRef === "atr" ? `ATR ${fp(setup.atrStop)}` : manualStop !== null ? `Manual ${fp(manualStop)}` : "Manual required"}
+              </div>
+            ) : null}
             <div className="entry-actions-row">
               <button type="button" className={`btn btn-ghost ${previewFlashing ? "flash" : ""}`} onClick={onPreview}>PREVIEW</button>
               <button type="button" className={`btn btn-cyan ${enterFlashing ? "flash" : ""}`} onClick={onEnterTrade}>{"\u2197"} ENTER TRADE</button>

--- a/frontend/components/SetupPanel.tsx
+++ b/frontend/components/SetupPanel.tsx
@@ -24,7 +24,7 @@ export function SetupPanel({ symbol, setup, account, positions, onSelectPosition
     ? `${setup.quoteIsReal ? "Real quote" : "Quote unavailable"} via ${setup.quoteProvider} | execution ${setup.executionProvider}`
     : "";
   const providerSubnote = setup?.technicalsAreFallback
-    ? "Derived metrics are still fallback-backed locally."
+    ? "LoD and ATR are real via Alpaca. Remaining derived metrics are still fallback-backed locally."
     : "All displayed setup fields are provider-backed.";
   const quoteTimestamp = setup?.quoteTimestamp ? formatQuoteTimestamp(setup.quoteTimestamp) : "--";
 
@@ -62,8 +62,10 @@ export function SetupPanel({ symbol, setup, account, positions, onSelectPosition
               <div className="provider-subnote">
                 Session: {setup ? sessionStateLabel(setup.sessionState) : "--"} | Quote state: {setup?.quoteState ?? "--"}
               </div>
+              <div className="provider-subnote">Entry basis: {setup.entryBasis.replaceAll("_", " ")}</div>
               <div className="provider-subnote">Using latest available Alpaca quote from {quoteTimestamp}</div>
               <div className="provider-subnote">{providerSubnote}</div>
+              {setup?.manualStopWarning ? <div className="provider-subnote">{setup.manualStopWarning}</div> : null}
               {setup.fallbackReason ? <div className="provider-subnote">Fallback reason: {setup.fallbackReason}</div> : null}
             </div>
             <div className="kv-group">
@@ -80,12 +82,20 @@ export function SetupPanel({ symbol, setup, account, positions, onSelectPosition
                 <span className="kv-label">Final Stop</span>
                 <span className="kv-val red">{fp(setup.finalStop)}</span>
               </div>
+              <div className="kv-row">
+                <span className="kv-label">Stop Default</span>
+                <span className="kv-val">{setup.stopReferenceDefault.toUpperCase()}</span>
+              </div>
             </div>
             <div className="kv-group">
               <div className="kv-group-label">Risk Sizing</div>
               <div className="kv-row">
                 <span className="kv-label">Account Equity</span>
                 <span className="kv-val">{fp(account?.equity ?? setup.accountEquity)}</span>
+              </div>
+              <div className="kv-row">
+                <span className="kv-label">Buying Power</span>
+                <span className="kv-val">{fp(account?.buying_power ?? setup.accountBuyingPower)}</span>
               </div>
               <div className="kv-row">
                 <span className="kv-label">Risk %</span>
@@ -122,6 +132,7 @@ export function SetupPanel({ symbol, setup, account, positions, onSelectPosition
                 <span className="kv-label">Calc. Shares</span>
                 <span className="kv-val green">{setup.shares} sh</span>
               </div>
+              <div className="provider-subnote">Sizing uses {setup.equitySource === "alpaca_account" ? "real Alpaca account equity and buying power" : "local account settings"}.</div>
             </div>
             <div className="kv-group">
               <div className="kv-group-label">Reference</div>

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -51,7 +51,12 @@ export type SetupResponse = {
   sessionState: "regular_open" | "overnight" | "pre_market" | "after_hours" | "closed";
   quoteState: "live_quote" | "cached_quote" | "quote_unavailable";
   entryBasis: string;
-  stopReferenceDefault: string;
+  stopReferenceDefault: "lod" | "atr" | "manual";
+  lodIsValid: boolean;
+  atrIsValid: boolean;
+  lodStop: number;
+  atrStop: number;
+  manualStopWarning?: string | null;
   bid: number;
   ask: number;
   last: number;
@@ -75,6 +80,8 @@ export type SetupResponse = {
   perShareRisk: number;
   riskPct: number;
   accountEquity: number;
+  accountBuyingPower: number;
+  equitySource: string;
   atrExtension: number;
   extFrom10Ma: number;
 };
@@ -101,6 +108,7 @@ export type AccountView = {
   risk_pct: number;
   mode: string;
   effective_mode: string;
+  equity_source: string;
   daily_realized_pnl: number;
   allow_live_trading: boolean;
   max_position_notional_pct: number;

--- a/scripts/dev/check_broker_paper_drift.py
+++ b/scripts/dev/check_broker_paper_drift.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    backend_dir = repo_root / "backend"
+    sys.path.insert(0, str(backend_dir))
+
+    from app.db.session import SessionLocal
+    from app.main import service
+
+    with SessionLocal() as db:
+        positions = service.get_positions(db)
+        account = service.get_account(db)
+        local_orders = service.get_recent_orders(db, limit=200)
+        try:
+            broker_orders = service.broker.list_recent_orders(limit=200)
+        except ValueError:
+            broker_orders = []
+
+    broker_by_id = {
+        str(order.get("id") or ""): order
+        for order in broker_orders
+        if isinstance(order, dict) and order.get("id")
+    }
+    issues: list[str] = []
+
+    if account.reconcileStatus != "synchronized":
+        issues.append(f"Account reconciliation is {account.reconcileStatus}.")
+
+    unsynchronized_positions = [
+        f"{position.symbol}:{position.reconcileStatus}"
+        for position in positions
+        if position.reconcileStatus != "synchronized"
+    ]
+    if unsynchronized_positions:
+        issues.append(
+            "Unsynchronized positions detected: " + ", ".join(unsynchronized_positions)
+        )
+
+    for order in local_orders:
+        if not order.brokerOrderId:
+            continue
+        broker_order = broker_by_id.get(order.brokerOrderId)
+        if broker_order is None:
+            continue
+        broker_status = str(broker_order.get("status") or "").upper()
+        if broker_status and broker_status != order.status:
+            issues.append(
+                f"Order {order.id} status drift: local={order.status} broker={broker_status}"
+            )
+
+    summary = {
+        "pass": not issues,
+        "brokerMode": service.settings.normalized_broker_mode,
+        "accountReconcileStatus": account.reconcileStatus,
+        "positionCount": len(positions),
+        "orderCount": len(local_orders),
+        "brokerOrderCount": len(broker_by_id),
+        "issues": issues,
+    }
+    print(json.dumps(summary, indent=2))
+    raise SystemExit(0 if summary["pass"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/docker-local-paper-smoke.mjs
+++ b/scripts/dev/docker-local-paper-smoke.mjs
@@ -90,6 +90,15 @@ try {
   if (!setup.sessionState || !setup.quoteState) {
     throw new Error("Setup response is missing sessionState/quoteState metadata.");
   }
+  if (typeof setup.lod !== "number" || typeof setup.atr14 !== "number" || setup.atr14 <= 0) {
+    throw new Error("Setup response is missing real LoD/ATR values.");
+  }
+  if (!["lod", "manual"].includes(setup.stopReferenceDefault)) {
+    throw new Error(`Unexpected default stop reference ${setup.stopReferenceDefault}`);
+  }
+  if (typeof setup.accountEquity !== "number" || setup.accountEquity <= 0 || setup.equitySource !== "alpaca_account") {
+    throw new Error("Setup sizing is not using broker-backed equity.");
+  }
 
   const enter = await fetchJson("/api/trade/enter", {
     method: "POST",

--- a/scripts/dev/rebuild_position_projections.py
+++ b/scripts/dev/rebuild_position_projections.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Rebuild position projection payloads from the current backend state tables."
+    )
+    parser.add_argument(
+        "--symbol",
+        action="append",
+        default=[],
+        help="Optional symbol filter. Repeat to rebuild multiple symbols.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    backend_dir = repo_root / "backend"
+    sys.path.insert(0, str(backend_dir))
+
+    from app.db.session import SessionLocal
+    from app.main import service
+
+    args = parse_args()
+    symbols = [symbol.upper() for symbol in args.symbol if symbol.strip()] or None
+
+    with SessionLocal() as db:
+        rebuilt = service.rebuild_position_projections(db, symbols=symbols)
+        db.commit()
+
+    target = ", ".join(rebuilt) if rebuilt else "(none)"
+    print(f"Rebuilt position projections for: {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/run-hybrid-local-paper-smoke.ps1
+++ b/scripts/dev/run-hybrid-local-paper-smoke.ps1
@@ -1,0 +1,41 @@
+param(
+  [int]$FrontendPort = 3010,
+  [int]$BackendPort = 8010,
+  [int]$PostgresPort = 55432,
+  [int]$RedisPort = 56379,
+  [string]$EnvFile = ".env.personal-paper.local",
+  [switch]$StartStack
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "common.ps1")
+
+$repoRoot = Get-RepoRoot
+$envPath = if ([System.IO.Path]::IsPathRooted($EnvFile)) { $EnvFile } else { Join-Path $repoRoot $EnvFile }
+$profileEnv = Get-LocalProfileEnv -RepoRoot $repoRoot -EnvFile $envPath -PersonalPaper
+$qcAuthUsername = Get-ResolvedValue -EnvValues $profileEnv -Key "AUTH_ADMIN_USERNAME" -Default "admin"
+$qcAuthPassword = Get-ResolvedValue -EnvValues $profileEnv -Key "AUTH_ADMIN_PASSWORD" -Default "admin123!"
+
+if ($StartStack) {
+  & (Join-Path $PSScriptRoot "start-hybrid-local-personal-paper.ps1") `
+    -FrontendPort $FrontendPort `
+    -FrontendProdPort ($FrontendPort + 100) `
+    -BackendPort $BackendPort `
+    -PostgresPort $PostgresPort `
+    -RedisPort $RedisPort `
+    -EnvFile $envPath
+}
+
+$env:FRONTEND_URL = "http://127.0.0.1:$FrontendPort"
+$env:BACKEND_URL = "http://127.0.0.1:$BackendPort"
+$env:QC_AUTH_USERNAME = $qcAuthUsername
+$env:QC_AUTH_PASSWORD = $qcAuthPassword
+
+try {
+  node (Join-Path $PSScriptRoot "docker-local-paper-smoke.mjs")
+} finally {
+  Remove-Item Env:FRONTEND_URL -ErrorAction SilentlyContinue
+  Remove-Item Env:BACKEND_URL -ErrorAction SilentlyContinue
+  Remove-Item Env:QC_AUTH_USERNAME -ErrorAction SilentlyContinue
+  Remove-Item Env:QC_AUTH_PASSWORD -ErrorAction SilentlyContinue
+}

--- a/scripts/dev/start-hybrid-local-personal-paper.ps1
+++ b/scripts/dev/start-hybrid-local-personal-paper.ps1
@@ -1,0 +1,22 @@
+param(
+  [int]$FrontendPort = 3010,
+  [int]$FrontendProdPort = 3110,
+  [int]$BackendPort = 8010,
+  [int]$PostgresPort = 55432,
+  [int]$RedisPort = 56379,
+  [string]$EnvFile = ".env.personal-paper.local"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Starting hybrid local personal-paper mode"
+Write-Host "Frontend/backend run locally; Postgres/Redis run in Docker"
+
+& (Join-Path $PSScriptRoot "check-local-paper-readiness.ps1") -EnvFile $EnvFile
+& (Join-Path $PSScriptRoot "start-local-personal-paper.ps1") `
+  -FrontendPort $FrontendPort `
+  -FrontendProdPort $FrontendProdPort `
+  -BackendPort $BackendPort `
+  -PostgresPort $PostgresPort `
+  -RedisPort $RedisPort `
+  -EnvFile $EnvFile

--- a/scripts/dev/start-local.ps1
+++ b/scripts/dev/start-local.ps1
@@ -14,6 +14,7 @@ $ErrorActionPreference = "Stop"
 $repoRoot = Get-RepoRoot
 $backendDir = Join-Path $repoRoot "backend"
 $frontendDir = Join-Path $repoRoot "frontend"
+$frontendNextCacheDir = Join-Path $frontendDir ".next\\cache"
 $backendOut = Join-Path $repoRoot "backend.out.log"
 $backendErr = Join-Path $repoRoot "backend.err.log"
 $frontendOut = Join-Path $repoRoot "frontend.out.log"
@@ -116,6 +117,10 @@ Invoke-RestMethod `
   -ContentType "application/json" `
   -Body $accountBody `
   -WebSession $authSession | Out-Null
+
+if (Test-Path $frontendNextCacheDir) {
+  Remove-Item -Path $frontendNextCacheDir -Recurse -Force -ErrorAction SilentlyContinue
+}
 
 $frontendCmd = @(
   "set ""NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:$BackendPort""",

--- a/scripts/dev/stop-hybrid-local-personal-paper.ps1
+++ b/scripts/dev/stop-hybrid-local-personal-paper.ps1
@@ -1,0 +1,15 @@
+param(
+  [int]$FrontendPort = 3010,
+  [int]$BackendPort = 8010,
+  [int]$PostgresPort = 55432,
+  [int]$RedisPort = 56379
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Stopping hybrid local personal-paper mode"
+& (Join-Path $PSScriptRoot "stop-local.ps1") `
+  -FrontendPort $FrontendPort `
+  -BackendPort $BackendPort `
+  -PostgresPort $PostgresPort `
+  -RedisPort $RedisPort


### PR DESCRIPTION
## Summary
- add broker-truth hardening foundations for webhook/event ingestion and projection-backed position state
- add reconcile heartbeat freshness, shared pre-intent blockers, and broker-paper recovery tooling
- add issue docs and backend regression coverage for projection rebuild and stale reconciliation blocking

## Validation
- `python -m black --check app\\core\\config.py app\\schemas\\cockpit.py app\\services\\cockpit.py app\\main.py app\\tests\\test_api.py` (from `backend`)
- `python -m ruff check .` (from `backend`)
- `python -m pytest -q` (from `backend`)

## Notes
- frontend/browser QC was not rerun in this PR because this commit scopes to backend/docs/scripts only
- the worktree still contains unrelated unstaged local changes that were intentionally left out of this PR